### PR TITLE
Bz882 cluster info

### DIFF
--- a/ebin/riak_repl.app
+++ b/ebin/riak_repl.app
@@ -11,6 +11,7 @@
                   'gen_leader',
                   'riak_repl', 
                   'riak_repl_app', 
+                  'riak_repl_cinfo',
                   'riak_repl_client_sup',
                   'riak_repl_connector',
                   'riak_repl_connector_sup',

--- a/src/riak_repl_app.erl
+++ b/src/riak_repl_app.erl
@@ -14,6 +14,11 @@ start(_Type, _StartArgs) ->
     IncarnationId = erlang:phash2({make_ref(), now()}),
     application:set_env(riak_repl, incarnation, IncarnationId),
     ok = ensure_dirs(),
+
+    %% Register our cluster_info app callback modules, with catch if
+    %% the app is missing or packaging is broken.
+    catch cluster_info:register_app(riak_repl_cinfo),
+
     %% Spin up supervisor
     case riak_repl_sup:start_link() of
         {ok, Pid} ->

--- a/src/riak_repl_cinfo.erl
+++ b/src/riak_repl_cinfo.erl
@@ -1,0 +1,27 @@
+%% Riak EnterpriseDS
+%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+
+-module(riak_repl_cinfo).
+
+-export([cluster_info_init/0, cluster_info_generator_funs/0]).
+
+%% @spec () -> term()
+%% @doc Required callback function for cluster_info: initialization.
+%%
+%% This function doesn't have to do anything.
+
+cluster_info_init() ->
+    ok.
+
+%% @spec () -> list({string(), fun()})
+%% @doc Required callback function for cluster_info: return list of
+%%      {NameForReport, FunOfArity_1} tuples to generate ASCII/UTF-8
+%%      formatted reports.
+
+cluster_info_generator_funs() ->
+    [
+     {"Riak Repl status", fun status/1}
+    ].
+
+status(CPid) -> % CPid is the data collector's pid.
+    cluster_info:format(CPid, "~p\n", [riak_repl_console:status(quiet)]).

--- a/src/riak_repl_console.erl
+++ b/src/riak_repl_console.erl
@@ -46,12 +46,22 @@ del_site([SiteName]) ->
     ok = maybe_set_ring(Ring, NewRing).
 
 status([]) ->
+    status2(true);
+status(quiet) ->
+    status2(false).
+
+status2(Verbose) ->
     Config = get_config(),
     Stats1 = lists:sort(ets:tab2list(riak_repl_stats)),
     LeaderStats = leader_stats(),
     ClientStats = client_stats(),
     ServerStats = server_stats(),
-    format_counter_stats(Config++Stats1++LeaderStats++ClientStats++ServerStats).
+    All = Config++Stats1++LeaderStats++ClientStats++ServerStats,
+    if Verbose ->
+            format_counter_stats(All);
+       true ->
+            All
+    end.
 
 start_fullsync([]) ->
     [riak_repl_tcp_server:start_fullsync(Pid) || Pid <- server_pids()],


### PR DESCRIPTION
Reviewer: anyone

In the name of laziness and time before code cutoff, I only added the
same stats that "riak-repl status" spits out, using the same trick for
riak_repl_console.erl that I used for riak_kv_console.erl.
