### PR TITLE
Repl by capability

### DIFF
--- a/src/riak_repl_tcp_client.erl
+++ b/src/riak_repl_tcp_client.erl
@@ -109,17 +109,14 @@ disconnected(try_connect, State) ->
 connecting({connected, Socket}, State) ->
     gen_tcp:send(Socket, State#state.sitename),
     Props = riak_repl_fsm:common_init(Socket),
-    AckFreq = app_helper:get_env(riak_repl,client_ack_frequency,
-                                 ?REPL_DEFAULT_ACK_FREQUENCY),
+
     {_ConnPid, IPAddr, Port} = State#state.listener,
     NewState = State#state{
               listener = {connected, IPAddr, Port},
               socket=Socket, 
               client=proplists:get_value(client, Props),
               my_pi=proplists:get_value(my_pi, Props),
-              partitions=proplists:get_value(partitions, Props),
-              count=0, 
-              ack_freq=AckFreq},
+              partitions=proplists:get_value(partitions, Props)},
     send(Socket, {peerinfo, NewState#state.my_pi}),
     riak_repl_stats:client_connects(),
     {next_state, wait_peerinfo, NewState};
@@ -149,10 +146,21 @@ wait_peerinfo({peerinfo, TheirPeerInfo, Capability},
                            sitename=SiteName}) when is_list(Capability) ->
     case riak_repl_util:validate_peer_info(TheirPeerInfo, MyPeerInfo) of
         true ->
+             %% Set up for bounded queue if remote server supports it
+            case proplists:get_bool(bounded_queue, Capability) of
+                true ->
+                    AckFreq = app_helper:get_env(riak_repl,client_ack_frequency,
+                                                 ?REPL_DEFAULT_ACK_FREQUENCY),
+                    State1 = State#state{count=0, 
+                                         ack_freq=AckFreq};
+                false ->
+                    State1 = State
+            end,
+           
             {ok, WorkDir} = riak_repl_fsm:work_dir(Socket, SiteName),
             update_site_ips(riak_repl_ring:get_repl_config(
                               TheirPeerInfo#peer_info.ring), SiteName),
-            {next_state, merkle_exchange, State#state{work_dir = WorkDir}};
+            {next_state, merkle_exchange, State1#state{work_dir = WorkDir}};
         false ->
             error_logger:error_msg("Replication (client) - invalid peer_info ~p~n",
                                    [TheirPeerInfo]),
@@ -393,6 +401,9 @@ update_site_ips(TheirReplConfig, SiteName) ->
     riak_core_ring_manager:write_ringfile(),
     ok.    
 
+do_repl_put(Obj, State=#state{ack_freq = undefined}) -> % q_ack not supported
+    riak_repl_util:do_repl_put(Obj),
+    State;
 do_repl_put(Obj, State=#state{count=C, ack_freq=F}) when (C < (F-1)) ->
     riak_repl_util:do_repl_put(Obj),
     State#state{count=C+1};

--- a/src/riak_repl_tcp_server.erl
+++ b/src/riak_repl_tcp_server.erl
@@ -106,7 +106,13 @@ listener_for_node(Node) ->
                           L#repl_listener.nodename =:= Node],
     hd(NodeListeners).
 
-wait_peerinfo({peerinfo, TheirPeerInfo}, State=#state{my_pi=MyPeerInfo}) ->
+wait_peerinfo({peerinfo, TheirPeerInfo}, State) ->
+    %% Forward compatibility with post-0.14.0 - will allow protocol negotiation
+    %% rather than setting capabilities based on version
+    Capability = riak_repl_util:capability_from_vsn(TheirPeerInfo),
+    wait_peerinfo({peerinfo, TheirPeerInfo, Capability}, State);
+wait_peerinfo({peerinfo, TheirPeerInfo, Capability},
+              State=#state{my_pi=MyPeerInfo}) when is_list(Capability) ->
     case riak_repl_util:validate_peer_info(TheirPeerInfo, MyPeerInfo) of
         true ->
             case app_helper:get_env(riak_repl, fullsync_on_connect, true) of

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -29,9 +29,7 @@ validate_peer_info(T=#peer_info{}, M=#peer_info{}) ->
     TheirPartitions =:= OurPartitions.
 
 %% Build a default capability from the version information in #peerinfo{}
-capability_from_vsn(PeerInfo) ->
-    %% Replication version as a string of major.minor.micro[releasecandidateblah]
-    ReplVsnStr = PeerInfo#peer_info.repl_version,
+capability_from_vsn(#peer_info{repl_version = ReplVsnStr}) ->
     ReplVsn = parse_vsn(ReplVsnStr),
     case ReplVsn >= {0, 14, 0} of
         true ->

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -3,9 +3,9 @@
 -module(riak_repl_util).
 -author('Andy Gross <andy@basho.com>').
 -include("riak_repl.hrl").
--include_lin("riak_core/include/riak_core_vnode.hrl").
 -export([make_peer_info/0,
          validate_peer_info/2,
+         capability_from_vsn/1,
          get_partitions/1,
          do_repl_put/1,
          site_root_dir/1,
@@ -27,6 +27,18 @@ validate_peer_info(T=#peer_info{}, M=#peer_info{}) ->
     TheirPartitions = get_partitions(T#peer_info.ring),
     OurPartitions = get_partitions(M#peer_info.ring),
     TheirPartitions =:= OurPartitions.
+
+%% Build a default capability from the version information in #peerinfo{}
+capability_from_vsn(PeerInfo) ->
+    %% Replication version as a string of major.minor.micro[releasecandidateblah]
+    ReplVsnStr = PeerInfo#peer_info.repl_version,
+    ReplVsn = parse_vsn(ReplVsnStr),
+    case ReplVsn >= {0, 14, 0} of
+        true ->
+            [bounded_queue];
+        false ->
+            []
+    end.
 
 get_partitions(_Ring) ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
@@ -95,3 +107,14 @@ format_socketaddrs(Socket) ->
                                                 LocalPort,
                                                 inet_parse:ntoa(RemoteIP),
                                                 RemotePort])).
+
+%% Parse the version into major, minor, micro digits, ignoring any release
+%% candidate suffix
+parse_vsn(Str) ->
+    Toks = string:tokens(Str, "."),
+    Vsns = [begin
+                {I,_R} = string:to_integer(T),
+                I
+            end || T <- Toks],
+    list_to_tuple(Vsns).
+


### PR DESCRIPTION
Resubmitted https://github.com/basho/riak_repl/pull/9 against riak_repl-0.14 now github is feeling better.

Selectively enables q_ack behavior depending on versions and makes forward compatible change to pass a capability list with the peerinfo.
