### PR TITLE
Clear controller on new candidates

### DIFF
--- a/src/riak_repl_leader.erl
+++ b/src/riak_repl_leader.erl
@@ -112,6 +112,7 @@ handle_call({set_candidates, CandidatesIn, WorkersIn}, _From, State) ->
             UpdState2 = UpdState1#state{candidates=Candidates, 
                                         workers=Workers,
                                         leader_node=undefined},
+            riak_repl_controller:set_is_leader(false),
             {reply, ok, restart_helper(UpdState2)}
     end;
 handle_call(helper_pid, _From, State) ->


### PR DESCRIPTION
When the new repl leader gen_server gets a new list of candidates, it clears the leader name and restarts the gen_leader process.  The riak_repl_controller needs to be told so that it correctly sets up the client supervisor (otherwise you can have multiple client connections).
