### PR TITLE
Bz1044 rapid continuous failure

### DIFF
--- a/src/riak_repl_client_sup.erl
+++ b/src/riak_repl_client_sup.erl
@@ -26,5 +26,5 @@ stop(_S) -> ok.
 
 %% @private
 init([]) ->
-    {ok, {{one_for_one, 10, 10}, []}}.
+    {ok, {{one_for_one, 100, 10}, []}}.
 

--- a/src/riak_repl_listener_sup.erl
+++ b/src/riak_repl_listener_sup.erl
@@ -20,7 +20,7 @@ stop(_S) -> ok.
 %% @private
 init([]) ->
     {ok, 
-     {{simple_one_for_one, 10, 10}, 
+     {{simple_one_for_one, 100, 10}, 
       [{undefined,
         {riak_repl_listener, start_link, []},
-        temporary, brutal_kill, worker, [riak_repl_listener]}]}}.
+        transient, brutal_kill, worker, [riak_repl_listener]}]}}.


### PR DESCRIPTION
Reviewer: any

See the commit log for a variation of the reproducing recipe to test
the ability of the listener to keep the server's TCP port open despite
the punishment of Dan's listener closing func running for 5 minutes.
