### PR TITLE
BZ1074 Don't close the repl server socket if the election is still going

### DIFF
--- a/src/riak_repl_listener.erl
+++ b/src/riak_repl_listener.erl
@@ -23,8 +23,9 @@ init([IPAddr, PortNum]) ->
 sock_opts() -> [binary, 
                 {keepalive, true},
                 {nodelay, true},
-                {packet, 4}, 
-                {reuseaddr, true}, 
+                {packet, 4},
+                {reuseaddr, true},
+                {active, false},
                 {backlog, 64}].
 
 new_connection(Socket, State) ->

--- a/src/riak_repl_tcp_server.erl
+++ b/src/riak_repl_tcp_server.erl
@@ -99,7 +99,7 @@ send_peerinfo(timeout, #state{socket=Socket, sitename=SiteName} = State) ->
     case riak_repl_leader:leader_node()  of
         undefined -> % leader not elected yet
             %% check again in 5 seconds
-            erlang:send_after(5000, self(), timeout),
+            erlang:send_after(5000, self(), election_wait),
             {next_state, send_peerinfo, State};
         OurNode ->
             erlang:cancel_timer(State#state.election_timeout),
@@ -341,8 +341,8 @@ handle_info(election_timeout, _StateName, State) ->
     error_logger:error_msg("Timed out waiting for a leader to be elected~n",
         []),
     {stop, normal, State};
-handle_info(timeout, StateName, State) ->
-    ?MODULE:StateName(timeout, State);
+handle_info(election_wait, send_peerinfo, State) ->
+    ?MODULE:send_peerinfo(timeout, State);
 %% no-ops
 handle_info(_I, StateName, State) -> next_state(StateName, State).
 terminate(_Reason, _StateName, State) -> 


### PR DESCRIPTION
Previous to this commit if, for whatever reason, the gen_leader election
was taking less than a small amount of time and a replication connection
was established the repl_tcp_server would instantly close the
connection. This in turn led to the connecting client exiting and
hitting the supervisor's max restarts and having the supervisor restart.

This change makes the code wait up to 60 seconds for the result of an
election to to become known, checked in 5 second intervals. Until we
know what the status of the election is, we do not consume any data off
the socket (we put the socket in passive mode). If the timeout is hit,
we exit as before, but if the election completes we either start doing
replication or refer the client to the leader. A new starting state was
added to the FSM, send_peerinfo which is where the FSM waits until it
knows who the leader is. Once we know who the leader is we put the
socket in {active, once} mode and continue as before.
