### PR TITLE
repl_leader_eqc fixes against master

### DIFF
--- a/test/repl_leader_eqc.erl
+++ b/test/repl_leader_eqc.erl
@@ -448,7 +448,7 @@ helper_leader_node(N, S) ->
     ?DBG("Candidate replication nodes\n~p\n", [CRNs]),
     UpCandidates = [CRN#replnode.node || CRN <- CRNs,
                                          CRN#replnode.running =:= true,
-                                         CRN#replnode.type =:= candidate,
+                                         lists:member(CRN#replnode.node, C),
                                          CRN#replnode.candidates =:= C,
                                          CRN#replnode.workers =:= W],
     case UpCandidates of

--- a/test/repl_leader_eqc.erl
+++ b/test/repl_leader_eqc.erl
@@ -40,7 +40,7 @@
         eqc:on_output(fun(Str, Args) -> io:format(user, Str, Args) end, P)).
 
 -define(DBG(Fmt,Args),ok).
-%-define(DBG(Fmt,Args),io:format(user, Fmt, Args)).
+%% -define(DBG(Fmt,Args),io:format(user, Fmt, Args)).
 
 qc_test_() ->
     %% try and clean the repl controller before cover ever runs
@@ -247,7 +247,14 @@ set_candidates(Node, Candidates, Workers, S) ->
     %% Request the helper leader node to make any elections stabalize 
     %% before calling the rest of the quickcheck code, otherwise results
     %% are totally unpredictable.
-    {_HLN, _UpCand} = helper_leader_node(Node, S),
+
+    %% Have to duplicate some work done in next_state here - helper_leader_node
+    %% needs an updated [#replnode{}].
+    ReplNode = get_replnode(Node, S),
+    UpdS = upd_replnode(ReplNode#replnode{candidates = lists:sort(Candidates),
+                                          workers = lists:sort(Workers)},
+                        S),
+    {_HLN, _UpCand} = helper_leader_node(Node, UpdS),
     ?DBG("Set candidates for ~p, HLN=~p, UpCand=~p\n", [Node, _HLN, _UpCand]),
     ok.
 
@@ -362,8 +369,10 @@ add_replnode(Node, S) ->
     S#state{replnodes = UpdReplNodes}.
 
 upd_replnode(ReplNode, S) ->
+    ?DBG("Updating ~p\nin ~p\n", [ReplNode, S]),
     UpdReplNodes = lists:keyreplace(ReplNode#replnode.node, #replnode.node,
                                     S#state.replnodes, ReplNode),
+    ?DBG("Updated ~p\n", [UpdReplNodes]),
     S#state{replnodes = UpdReplNodes}.
 
 %% Check if a node exists in the state
@@ -408,10 +417,12 @@ wait_for_helper(Node, Retries) ->
 %% candidate nodes should be up, otherwise it will block waiting for any
 %% candidate.
 helper_leader_node(N, S) ->
+    ?DBG("Handler leader node ~p\nState:\n~p\n", [N, S]),
     RN = get_replnode(N, S),
     C = RN#replnode.candidates,
     W = RN#replnode.workers,
     CRNs = [get_replnode(X, S) || X <- C],
+    ?DBG("Candidate replication nodes\n~p\n", [CRNs]),
     UpCandidates = [CRN#replnode.node || CRN <- CRNs,
                                          CRN#replnode.running =:= true,
                                          CRN#replnode.type =:= candidate,

--- a/test/repl_leader_eqc.erl
+++ b/test/repl_leader_eqc.erl
@@ -47,7 +47,7 @@ qc_test_() ->
     code:purge(riak_repl_controller), 
     code:delete(riak_repl_controller),
     ?DBG("Cover modules:\n~p\n", [cover:modules()]),
-    Prop = ?QC_OUT(eqc:numtests(100, prop_main())),
+    Prop = ?QC_OUT(eqc:numtests(40, prop_main())),
     case testcase() of
         [] ->
             {timeout, ?TEST_TIMEOUT, fun() -> ?assert(eqc:quickcheck(Prop)) end};
@@ -127,7 +127,7 @@ next_state_data(_From, _To, S, _Res, {call, ?MODULE, toggle_type, [Node]}) ->
         worker->
             UpdReplNode=ReplNode#replnode{type = candidate};
         candidate ->
-            UpdReplNode=ReplNode#replnode{type = candidate}
+            UpdReplNode=ReplNode#replnode{type = worker}
     end,
     upd_replnode(UpdReplNode, S);
 next_state_data(_From, _To, S, _Res, {call, ?MODULE, set_candidates,

--- a/test/repl_leader_eqc.erl
+++ b/test/repl_leader_eqc.erl
@@ -163,7 +163,10 @@ postcondition(_From, _To, S, {call, ?MODULE, ping, [Node]}, Res) ->
             Res == pang
     end;
 postcondition(_From, _To, S, {call, ?MODULE, check_leaders, _}, LeaderByNode) ->
-    NodesByCandidates = nodes_by_candidates(running_replnodes(S)),
+    NodesByCandidates0 = nodes_by_candidates(running_replnodes(S)),
+    NodesByCandidates = lists:filter(fun({{Candidates, _}, Nodes}) ->
+                lists:all(fun(Cand) -> lists:member(Cand, Nodes) end, Candidates) 
+        end, NodesByCandidates0),
     check_same_leaders(NodesByCandidates, LeaderByNode);
 postcondition(_From, _To, _S, {call, ?MODULE, add_receiver, [Node]}, {Node, Res, _Pid}) ->
     %% The node believes itself to be a leader


### PR DESCRIPTION
Fixes to the leadership eqc test made during bz://1146, zd://773.

Gives additional time for elections to take place.
Ensures election completed after restarting nodes.
Does not expect elections to happen when all candidate nodes are down.
Fixes toggle_type to change between candidate/worker correctly rather than just promoting to candidate.

Against master.  'git am' didn't automatically merge the second commit correctly so there will be a minor difference in commit ids.
