### PR TITLE
Make replication Search aware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ebin/*.beam
+deps

--- a/rebar.config
+++ b/rebar.config
@@ -4,5 +4,7 @@
 {lib_dirs, [".."]}.
 {deps, [
         {riak_kv, "0.14.*", {git, "git://github.com/basho/riak_kv", {branch, "master"}}},
+        {riak_search, "0.14.*", {git, "git://github.com/basho/riak_search",
+                                 {branch, "master"}}},
         {meck, ".*", {git, "git://github.com/eproxus/meck.git", "HEAD"}}
        ]}.

--- a/src/riak_repl_tcp_client.erl
+++ b/src/riak_repl_tcp_client.erl
@@ -401,14 +401,14 @@ update_site_ips(TheirReplConfig, SiteName) ->
     ok.    
 
 do_repl_put(Obj, State=#state{ack_freq = undefined}) -> % q_ack not supported
-    riak_repl_util:do_repl_put(Obj),
+    spawn(riak_repl_util, do_repl_put, [Obj]),
     State;
 do_repl_put(Obj, State=#state{count=C, ack_freq=F}) when (C < (F-1)) ->
-    riak_repl_util:do_repl_put(Obj),
+    spawn(riak_repl_util, do_repl_put, [Obj]),
     State#state{count=C+1};
 do_repl_put(Obj, State=#state{socket=S, ack_freq=F}) ->
     send(S, {q_ack, F}),
-    riak_repl_util:do_repl_put(Obj),
+    spawn(riak_repl_util, do_repl_put, [Obj]),
     State#state{count=0}.
     
 %% Decide when it is time to leave the merkle_recv state and whether


### PR DESCRIPTION
az551

This commit enables replication to successfully replicate all
Search related data no matter how indexing has occured.  That is,
whether it was an object stored in a bucket with the search hook
installed, a local document installed via `search-cmd` or a solr
document replication will see it and replicate it.  This also goes
for deleting a document.

The key to getting this to work is to teach replication to recognize
Search "proxy objects."  A proxy object (PO) is one that encapsultes all
the postings for an indexed document (whether it be a KV object or
local file) so that they may be deleted later.  When a replication
client sees a PO come across the wire it knows that the postings
inside it must be enetered into the local index.  If the incoming
object is a tombstone then replication knows it needs to
remove the entries.

Things are only slightly more complicated for an indexed KV object.
In the case of a fullsync there is a chance that there could be a great
delay between the replication of the KV oject and the PO.  Furtermore,
you want to replicate the PO before it's corresponding KV object to
stay consistent with how it works on a single cluster.  This means that
during fullsync replication will perform checks to determine if the object
it is about to replicate is a member of a pair of KV/PO objects that must
be replicated together.  If it is then fullsync will make sure to
replicate both and send them in the preferred order.

Initially I had planned on using some form of caching to determine
if an object is a PO or not but I have decided against this.  First,
the Search hook could be installed onto a bucket during fullsync
which causes the cache to become invalid.  Second, I'm not convinced
the code to determine PO status is dominant.  Third, it would complicate
the code causing more opportunity for failure.  Fourth, it's in
the works to completely rewrite replication.
