### PR TITLE
az://303 vclock enhancements redux be2 membership

### DIFF
--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -46,7 +46,7 @@ do_repl_put(Object) ->
     ReqId = erlang:phash2(erlang:now()),
     B = riak_object:bucket(Object),
     K = riak_object:key(Object),
-    Opts = [disable_hooks, {update_last_modified, false}],
+    Opts = [asis, disable_hooks, {update_last_modified, false}],
 
     case B of
         <<"_rsid_", Idx/binary>> ->


### PR DESCRIPTION
Add the 'asis' option to the put FSM to prevent vclocks from being incremented.
