### PR TITLE
Fix repl between 1.0 and 0.14 clusters

### DIFF
--- a/src/riak_repl_tcp_client.erl
+++ b/src/riak_repl_tcp_client.erl
@@ -158,8 +158,8 @@ wait_peerinfo({peerinfo, TheirPeerInfo, Capability},
             end,
            
             {ok, WorkDir} = riak_repl_fsm:work_dir(Socket, SiteName),
-            update_site_ips(riak_repl_ring:get_repl_config(
-                              TheirPeerInfo#peer_info.ring), SiteName),
+            TheirRing = riak_core_ring:upgrade(TheirPeerInfo#peer_info.ring),
+            update_site_ips(riak_repl_ring:get_repl_config(TheirRing), SiteName),
             {next_state, merkle_exchange, State1#state{work_dir = WorkDir}};
         false ->
             lager:error("Replication - invalid peer_info ~p",

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -19,9 +19,10 @@
 
 make_peer_info() ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+    SafeRing = riak_core_ring:downgrade(1, Ring),
     {ok, RiakVSN} = application:get_key(riak_kv, vsn),
     {ok, ReplVSN} = application:get_key(riak_repl, vsn),
-    #peer_info{riak_version=RiakVSN, repl_version=ReplVSN, ring=Ring}.
+    #peer_info{riak_version=RiakVSN, repl_version=ReplVSN, ring=SafeRing}.
 
 validate_peer_info(T=#peer_info{}, M=#peer_info{}) ->
     TheirPartitions = get_partitions(T#peer_info.ring),


### PR DESCRIPTION
This prevents future changes to the ring from breaking if both repl
clusters are not running the same version of riak.
