### PR TITLE
Various minor cleanups to repl

### DIFF
--- a/src/riak_repl_listener.erl
+++ b/src/riak_repl_listener.erl
@@ -58,7 +58,7 @@ handle_call(config, _From, State) ->
 handle_call(_Req, _From, State) -> {reply, ok, State}.
 
 handle_cast(stop, State) ->
-    lager:notice("Replication listener for ~s:~p shutting down",
+    lager:info("Replication listener for ~s:~p shutting down",
         [State#state.ipaddr, State#state.portnum]),
     {stop, normal, State}.
 
@@ -71,18 +71,21 @@ code_change(_OldVsn, State, _Extra) -> {ok, State}.
 %% helper functions
 
 connection_made(Socket, Pid, State) ->
+    lager:debug("Replication client connected"),
     gen_tcp:controlling_process(Socket, Pid),
     riak_repl_tcp_server:set_socket(Pid, Socket),
     riak_repl_stats:server_connects(),
     {ok, State}.
 
 connection_error({Reason, Backtrace}, SiteName, State) ->
-    lager:error("Error accepting connection from site: ~p:~p",
+    %% use debug severity to prevent DOS issues
+    lager:debug("Error accepting connection from site: ~p:~p",
               [SiteName, {Reason, Backtrace}]),
     riak_repl_stats:server_connect_errors(),
     {ok, State};
 connection_error(Reason, SiteName, State) ->
-    lager:error("Error accepting connection from site: ~p:~p",
+    %% use debug severity to prevent DOS issues
+    lager:debug("Error accepting connection from site: ~p:~p",
               [SiteName, Reason]),
     riak_repl_stats:server_connect_errors(),
     {ok, State}.

--- a/src/riak_repl_syncv1_server.erl
+++ b/src/riak_repl_syncv1_server.erl
@@ -87,20 +87,19 @@ init([SiteName, Socket, WorkDir, Client]) ->
     riak_repl_util:schedule_fullsync(),
     State = case application:get_env({progress, SiteName}) of
         {ok, Partitions} when is_list(Partitions) ->
-            lager:notice("Resuming incomplete fullsync for ~p, ~p partitions remain",
+            lager:info("Resuming incomplete fullsync for ~p, ~p partitions remain",
                 [SiteName, length(Partitions)]),
             State0#state{partitions=Partitions};
         _ ->
             State0
     end,
-    lager:notice("repl strategy started"),
     {ok, wait_for_fullsync, State}.
 
 wait_for_fullsync(cancel_fullsync, State) ->
     next_state(wait_for_fullsync,
         do_cancel_fullsync(State#state{paused=false}));
 wait_for_fullsync(start_fullsync, State) ->
-    lager:notice("Full-sync with ~p starting.", [State#state.sitename]),
+    lager:info("Full-sync with ~p starting.", [State#state.sitename]),
     next_state(merkle_send, do_start_fullsync(State)).
 
 merkle_send(cancel_fullsync, State) ->


### PR DESCRIPTION
- Don't fetch vector clocks when they aren't needed
- Switch all lager:notices to infos
- Log the sitename in all fullsync messages
- Various improvements in cleaning up stale files
- Avoid ring_trans if there's nothing to do
- Comment on the algorithim used for choosing the strategy
