### PR TITLE
Add heartbeat to repl protocol

### DIFF
--- a/include/riak_repl.hrl
+++ b/include/riak_repl.hrl
@@ -15,6 +15,7 @@
         {send_timeout_close, true}]).
 -define(REPL_VERSION, 3).
 -define(LEGACY_STRATEGY, syncv1).
+-define(KEEPALIVE_TIME, 60000).
 
 -type(ip_addr_str() :: string()).
 -type(ip_portnum() :: non_neg_integer()).


### PR DESCRIPTION
The default connection timeout on linux works like this:

If no activity after net.ipv4.tcp_keepalive_time (default 7200 seconds, or 2 hours) the tcp stack will start sending keepalives every net.ipv4.tcp_keepalive_intvl (default 75 seconds) until net.ipv4.tcp_keepalive_probe (default 9) keepalives get retransmitted.

This boils down to the fact that interrupted connection will take 2 hours to timeout and close, unless the user modifies their TCP configuration globally on the server via sysctl.

Other operating systems have similar defaults, but the configuration is different:

http://www.gnugk.org/keepalive.html

A solution to this would be to add a heartbeat message to repl, so it can notice, independently, when the connection dies. Just a simple ping-pong would be sufficient.
