### PR TITLE
Allow buckets to be fullsynced, but not participate in realtime repl

### DIFF
--- a/src/riak_repl.erl
+++ b/src/riak_repl.erl
@@ -26,7 +26,7 @@ install_hook() ->
 fixup(_Bucket, BucketProps) ->
     CleanPostcommit = strip_postcommit(BucketProps),
     case proplists:get_value(repl, BucketProps) of
-        true ->
+        Val when Val==true; Val==realtime; Val==both ->
             UpdPostcommit = CleanPostcommit ++ [?REPL_HOOK],
 
             {ok, lists:keystore(postcommit, 1, BucketProps, 

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -131,7 +131,7 @@ repl_helper_recv([{App, Mod}|T], Object) ->
 repl_helper_send(Object, C) ->
     B = riak_object:bucket(Object),
     case proplists:get_value(repl, C:get_bucket(B)) of
-        true ->
+        Val when Val==true; Val==fullsync; Val==both ->
             case application:get_env(riak_core, repl_helper) of
                 undefined -> [];
                 {ok, Mods} ->


### PR DESCRIPTION
This is done via new values for the 'repl' bucket property:
- {repl, both} - both types of replication, same as {repl, true}
- {repl, fullsync} - only fullsync this bucket, no realtime
- {repl, realtime} - only realtime repl this bucket, no fullsync
  
  As noted above, {repl, true} is a synonym for {repl, both} and so old
  configurations will upgrade gracefully.
