### PR TITLE
Fix repl so it can be disabled in default_bucket_props

### DIFF
--- a/src/riak_repl.erl
+++ b/src/riak_repl.erl
@@ -16,10 +16,6 @@ stop() ->
     application:stop(riak_repl).
 
 install_hook() ->
-    {ok, DefaultBucketProps} = application:get_env(riak_core, 
-                                                   default_bucket_props),
-    application:set_env(riak_core, default_bucket_props, 
-                        proplists:delete(repl, DefaultBucketProps)),
     riak_core_bucket:append_bucket_defaults([{repl, true}]),
     ok.
 


### PR DESCRIPTION
The code to delete the repl property before adding it back to the
default bucket properties was a holdover from when it was deleting the
repl postcommit hook and then re-adding it, in case it had changed.

This is actually harmful now, because it means you CANNOT disable the
realtime repl hook globally, if you wish (and enable it only on specific
buckets). The code has therefore been removed.
