### PR TITLE
Allow replication 'role reversal'

### DIFF
--- a/src/riak_repl_keylist_client.erl
+++ b/src/riak_repl_keylist_client.erl
@@ -87,7 +87,9 @@ wait_for_fullsync(Command, State)
     lager:info("Full-sync with site ~p starting; ~p partitions.",
                           [State#state.sitename, Remaining]),
     gen_fsm:send_event(self(), continue),
-    {next_state, request_partition, State#state{partitions=Partitions}}.
+    {next_state, request_partition, State#state{partitions=Partitions}};
+wait_for_fullsync(_Other, State) ->
+    {next_state, wait_for_fullsync, State}.
 
 request_partition(Command, #state{kl_pid=Pid, sitename=SiteName} = State)
         when Command == pause_fullsync; Command == cancel_fullsync ->

--- a/src/riak_repl_ring_handler.erl
+++ b/src/riak_repl_ring_handler.erl
@@ -119,13 +119,18 @@ update_leader(Ring) ->
                 {false, false} ->
                     Candidates=[],
                     Workers=[]
-            end,       
-            case Listeners of 
-                [] ->
+            end,
+            case {has_listeners(RC), has_sites(RC),
+                    app_helper:get_env(riak_repl, inverse_connection, false)} of 
+                {false, _, false} ->
                     ok; % No need to install hook if nobody is listening
-                _ ->
+                {true, _, false} ->
+                    riak_repl:install_hook();
+                {_, false, true} ->
+                    ok; %% no sites
+                {_, true, true} ->
                     riak_repl:install_hook()
-            end,            
+            end,
             riak_repl_leader:set_candidates(Candidates, Workers)
     end.
 

--- a/src/riak_repl_tcp_client.erl
+++ b/src/riak_repl_tcp_client.erl
@@ -330,7 +330,6 @@ handle_peerinfo(#state{sitename=SiteName, socket=Socket} = State, TheirPeerInfo,
             case app_helper:get_env(riak_repl, inverse_connection) == true
                 andalso get(inverted) /= true of
                 true ->
-                    riak_repl:install_hook(),
                     case riak_repl_leader:add_receiver_pid(self()) of
                         ok ->
                             lager:notice("added as receiver pid"),

--- a/src/riak_repl_tcp_client.erl
+++ b/src/riak_repl_tcp_client.erl
@@ -73,6 +73,8 @@ init([SiteName]) ->
             {ok, do_async_connect(State)}
     end.
 
+%% these fullsync control messages are for 'inverse' mode only, and only work
+%% with the keylist strategy.
 handle_call(start_fullsync, _From, #state{fullsync_worker=FSW} = State) ->
     gen_fsm:send_event(FSW, start_fullsync),
     {reply, ok, State};
@@ -85,6 +87,7 @@ handle_call(pause_fullsync, _From, #state{fullsync_worker=FSW} = State) ->
 handle_call(resume_fullsync, _From, #state{fullsync_worker=FSW} = State) ->
     gen_fsm:send_event(FSW, resume_fullsync),
     {reply, ok, State};
+
 handle_call(status, _From, #state{fullsync_worker=FSW} = State) ->
     Res = case is_pid(FSW) of
         true -> gen_fsm:sync_send_all_state_event(FSW, status, infinity);
@@ -357,7 +360,6 @@ handle_peerinfo(#state{sitename=SiteName, socket=Socket} = State, TheirPeerInfo,
                     StratMod = riak_repl_util:strategy_module(Strategy, client),
                     lager:info("Using fullsync strategy ~p with site ~p.", [StratMod,
                             State#state.sitename]),
-                    lager:notice("making workdir"),
                     {ok, WorkDir} = riak_repl_fsm_common:work_dir(Socket, SiteName),
                     {ok, FullsyncWorker} = StratMod:start_link(SiteName, Socket,
                         WorkDir),

--- a/src/riak_repl_tcp_client.erl
+++ b/src/riak_repl_tcp_client.erl
@@ -73,6 +73,18 @@ init([SiteName]) ->
             {ok, do_async_connect(State)}
     end.
 
+handle_call(start_fullsync, _From, #state{fullsync_worker=FSW} = State) ->
+    gen_fsm:send_event(FSW, start_fullsync),
+    {reply, ok, State};
+handle_call(cancel_fullsync, _From, #state{fullsync_worker=FSW} = State) ->
+    gen_fsm:send_event(FSW, cancel_fullsync),
+    {reply, ok, State};
+handle_call(pause_fullsync, _From, #state{fullsync_worker=FSW} = State) ->
+    gen_fsm:send_event(FSW, pause_fullsync),
+    {reply, ok, State};
+handle_call(resume_fullsync, _From, #state{fullsync_worker=FSW} = State) ->
+    gen_fsm:send_event(FSW, resume_fullsync),
+    {reply, ok, State};
 handle_call(status, _From, #state{fullsync_worker=FSW} = State) ->
     Res = case is_pid(FSW) of
         true -> gen_fsm:sync_send_all_state_event(FSW, status, infinity);

--- a/src/riak_repl_tcp_client.erl
+++ b/src/riak_repl_tcp_client.erl
@@ -16,7 +16,8 @@
 -behaviour(gen_server).
 
 %% API
--export([start_link/1, status/1, status/2, async_connect/3, send/2]).
+-export([start_link/1, status/1, status/2, async_connect/3, send/2,
+        handle_peerinfo/3, make_state/5]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -40,7 +41,11 @@
         keepalive_time
     }).
 
-
+make_state(SiteName, Socket, MyPI, WorkDir, Client) ->
+    {ok, {IP, Port}} = inet:sockname(Socket),
+    #state{sitename=SiteName, socket=Socket, my_pi=MyPI, work_dir=WorkDir,
+        client=Client, listeners=[], pending=[], listener={connected, IP,
+            Port}}.
 
 start_link(SiteName) ->
     gen_server:start_link(?MODULE, [SiteName], []).
@@ -136,34 +141,41 @@ handle_info({tcp, Socket, Data}, State=#state{socket=Socket}) ->
     inet:setopts(Socket, [{active, once}]),
     Msg = binary_to_term(Data),
     riak_repl_stats:client_bytes_recv(size(Data)),
-    NewState = case Msg of
+    Reply = case Msg of
         {diff_obj, RObj} ->
             %% realtime diff object, or a fullsync diff object from legacy
             %% repl. Because you can't tell the difference this can screw up
             %% the acking, but there's not really a way to fix it, other than
             %% not using legacy.
-            do_repl_put(RObj, State);
+            {noreply, do_repl_put(RObj, State)};
         {fs_diff_obj, RObj} ->
             %% fullsync diff objects
             Pool = State#state.pool_pid,
             Worker = poolboy:checkout(Pool, true, infinity),
             ok = riak_repl_fullsync_worker:do_put(Worker, RObj, Pool),
-            State;
+            {noreply, State};
         keepalive ->
             send(Socket, keepalive_ack),
-            State;
+            {noreply, State};
         keepalive_ack ->
             %% noop
-            State;
+            {noreply, State};
+        {peerinfo, TheirPI, Capability} ->
+            handle_peerinfo(State, TheirPI, Capability);
         _ ->
             gen_fsm:send_event(State#state.fullsync_worker, Msg),
-            State
+            {noreply, State}
     end,
-    case NewState#state.keepalive_time of
+    case State#state.keepalive_time of
         Time when is_integer(Time) ->
-            {noreply, NewState, Time};
+            case Reply of 
+                {noreply, NewState} ->
+                    {noreply, NewState, Time};
+                _ ->
+                    Reply
+            end;
         _ ->
-            {noreply, NewState}
+            Reply
     end;
 handle_info(try_connect, State) ->
     NewState = do_async_connect(State),
@@ -303,47 +315,74 @@ handle_peerinfo(#state{sitename=SiteName, socket=Socket} = State, TheirPeerInfo,
     MyPeerInfo = State#state.my_pi,
     case riak_repl_util:validate_peer_info(TheirPeerInfo, MyPeerInfo) of
         true ->
-            ServerStrats = proplists:get_value(fullsync_strategies, Capability,
-                [?LEGACY_STRATEGY]),
-            ClientStrats = app_helper:get_env(riak_repl, fullsync_strategies,
-                [?LEGACY_STRATEGY]),
-            Strategy = riak_repl_util:choose_strategy(ServerStrats, ClientStrats),
-            StratMod = riak_repl_util:strategy_module(Strategy, client),
-            lager:info("Using fullsync strategy ~p with site ~p.", [StratMod,
-                    State#state.sitename]),
-            {ok, WorkDir} = riak_repl_fsm_common:work_dir(Socket, SiteName),
-            {ok, FullsyncWorker} = StratMod:start_link(SiteName, Socket,
-                WorkDir),
-            %% Set up for bounded queue if remote server supports it
-            case proplists:get_bool(bounded_queue, Capability) of
+            case app_helper:get_env(riak_repl, inverse_connection) == true
+                andalso get(inverted) /= true of
                 true ->
-                    AckFreq = app_helper:get_env(riak_repl,client_ack_frequency,
-                        ?REPL_DEFAULT_ACK_FREQUENCY),
-                    State1 = State#state{count=0, 
-                        ack_freq=AckFreq};
-                false ->
-                    State1 = State
-            end,
-            case proplists:get_bool(keepalive, Capability) of
-                true ->
-                    KeepaliveTime = ?KEEPALIVE_TIME;
+                    %% we want to trap exits now
+                    process_flag(trap_exit, true),
+                    Pid = proc_lib:spawn_link(fun() ->
+                                put(inverted, true),
+                                gen_server:enter_loop(riak_repl_tcp_server,
+                                    [],
+                                    riak_repl_tcp_server:make_state(SiteName,
+                                        Socket, State#state.my_pi,
+                                        State#state.work_dir,
+                                        State#state.client))
+                        end),
+                    gen_tcp:controlling_process(Socket, Pid),
+                    %% send the peer info again
+                    Pid ! {tcp, Socket, term_to_binary({peerinfo,
+                                TheirPeerInfo, Capability})},
+                    %% block until the server exits, then exit ourselves
+                    receive
+                        {'EXIT', Pid, _} ->
+                            {stop, normal, State}
+                    end;
                 _ ->
-                    KeepaliveTime = undefined
-            end,
-            TheirRing = riak_core_ring:upgrade(TheirPeerInfo#peer_info.ring),
-            update_site_ips(riak_repl_ring:get_repl_config(TheirRing), SiteName),
-            inet:setopts(Socket, [{active, once}]),
-            riak_repl_stats:client_connects(),
-            MinPool = app_helper:get_env(riak_repl, min_put_workers, 5),
-            MaxPool = app_helper:get_env(riak_repl, max_put_workers, 100),
-            {ok, Pid} = poolboy:start_link([{worker_module, riak_repl_fullsync_worker},
-                    {worker_args, []},
-                    {size, MinPool}, {max_overflow, MaxPool}]),
-            {noreply, State1#state{work_dir = WorkDir,
-                    fullsync_worker=FullsyncWorker,
-                    fullsync_strategy=StratMod,
-                    keepalive_time=KeepaliveTime,
-                    pool_pid=Pid}};
+
+                    ServerStrats = proplists:get_value(fullsync_strategies, Capability,
+                        [?LEGACY_STRATEGY]),
+                    ClientStrats = app_helper:get_env(riak_repl, fullsync_strategies,
+                        [?LEGACY_STRATEGY]),
+                    Strategy = riak_repl_util:choose_strategy(ServerStrats, ClientStrats),
+                    StratMod = riak_repl_util:strategy_module(Strategy, client),
+                    lager:info("Using fullsync strategy ~p with site ~p.", [StratMod,
+                            State#state.sitename]),
+                    lager:notice("making workdir"),
+                    {ok, WorkDir} = riak_repl_fsm_common:work_dir(Socket, SiteName),
+                    {ok, FullsyncWorker} = StratMod:start_link(SiteName, Socket,
+                        WorkDir),
+                    %% Set up for bounded queue if remote server supports it
+                    case proplists:get_bool(bounded_queue, Capability) of
+                        true ->
+                            AckFreq = app_helper:get_env(riak_repl,client_ack_frequency,
+                                ?REPL_DEFAULT_ACK_FREQUENCY),
+                            State1 = State#state{count=0, 
+                                ack_freq=AckFreq};
+                        false ->
+                            State1 = State
+                    end,
+                    case proplists:get_bool(keepalive, Capability) of
+                        true ->
+                            KeepaliveTime = ?KEEPALIVE_TIME;
+                        _ ->
+                            KeepaliveTime = undefined
+                    end,
+                    TheirRing = riak_core_ring:upgrade(TheirPeerInfo#peer_info.ring),
+                    update_site_ips(riak_repl_ring:get_repl_config(TheirRing), SiteName),
+                    inet:setopts(Socket, [{active, once}]),
+                    riak_repl_stats:client_connects(),
+                    MinPool = app_helper:get_env(riak_repl, min_put_workers, 5),
+                    MaxPool = app_helper:get_env(riak_repl, max_put_workers, 100),
+                    {ok, Pid} = poolboy:start_link([{worker_module, riak_repl_fullsync_worker},
+                            {worker_args, []},
+                            {size, MinPool}, {max_overflow, MaxPool}]),
+                    {noreply, State1#state{work_dir = WorkDir,
+                            fullsync_worker=FullsyncWorker,
+                            fullsync_strategy=StratMod,
+                            keepalive_time=KeepaliveTime,
+                            pool_pid=Pid}}
+            end;
         false ->
             lager:error("Invalid peer info for site ~p, "
                 "ring sizes do not match.", [SiteName]),

--- a/src/riak_repl_tcp_server.erl
+++ b/src/riak_repl_tcp_server.erl
@@ -232,6 +232,7 @@ handle_peerinfo(#state{sitename=SiteName, socket=Socket, my_pi=MyPI} = State, Th
             case app_helper:get_env(riak_repl, inverse_connection) == true
                 andalso get(inverted) /= true of
                 true ->
+                    riak_repl_leader:rm_receiver_pid(self()),
                     self() ! {tcp, Socket, term_to_binary({peerinfo,
                                 TheirPI, Capability})},
                     put(inverted, true),

--- a/src/riak_repl_tcp_server.erl
+++ b/src/riak_repl_tcp_server.erl
@@ -26,7 +26,7 @@
 %% API
 -export([start_link/1, set_socket/2, send/2, status/1, status/2]).
 -export([start_fullsync/1, cancel_fullsync/1, pause_fullsync/1,
-        resume_fullsync/1]).
+        resume_fullsync/1, handle_peerinfo/3, make_state/5]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -47,6 +47,10 @@
         election_timeout :: undefined | reference(), % reference for the election timeout
         keepalive_time :: undefined | integer()
     }).
+
+make_state(Sitename, Socket, MyPI, WorkDir, Client) ->
+    #state{sitename=Sitename, socket=Socket, my_pi=MyPI, work_dir=WorkDir,
+        client=Client}.
 
 start_link(SiteName) ->
     gen_server:start_link(?MODULE, [SiteName], []).
@@ -208,54 +212,8 @@ code_change(_OldVsn, State, _Extra) ->
 handle_msg({peerinfo, PI}, State) ->
     Capability = riak_repl_util:capability_from_vsn(PI),
     handle_msg({peerinfo, PI, Capability}, State);
-handle_msg({peerinfo, TheirPI, Capability}, #state{my_pi=MyPI} = State) ->
-    case riak_repl_util:validate_peer_info(TheirPI, MyPI) of
-        true ->
-            ClientStrats = proplists:get_value(fullsync_strategies, Capability,
-                [?LEGACY_STRATEGY]),
-            ServerStrats = app_helper:get_env(riak_repl, fullsync_strategies,
-                [?LEGACY_STRATEGY]),
-            Strategy = riak_repl_util:choose_strategy(ServerStrats, ClientStrats),
-            StratMod = riak_repl_util:strategy_module(Strategy, server),
-            lager:info("Using fullsync strategy ~p.", [StratMod]),
-            {ok, FullsyncWorker} = StratMod:start_link(State#state.sitename,
-                State#state.socket, State#state.work_dir, State#state.client),
-            %% Set up bounded queue if remote supports it
-            case proplists:get_bool(bounded_queue, Capability) of
-                true ->
-                    QSize = app_helper:get_env(riak_repl,queue_size,
-                                               ?REPL_DEFAULT_QUEUE_SIZE),
-                    MaxPending = app_helper:get_env(riak_repl,server_max_pending,
-                                                    ?REPL_DEFAULT_MAX_PENDING),
-                    State1 = State#state{q = bounded_queue:new(QSize),
-                                         fullsync_worker = FullsyncWorker,
-                                         fullsync_strategy = StratMod,
-                                         max_pending = MaxPending,
-                                         pending = 0};
-                false ->
-                    State1 = State#state{fullsync_worker = FullsyncWorker,
-                                         fullsync_strategy = StratMod}
-            end,
-
-            case proplists:get_bool(keepalive, Capability) of
-                true ->
-                    KeepaliveTime = ?KEEPALIVE_TIME;
-                _ ->
-                    KeepaliveTime = undefined
-            end,
-
-            case app_helper:get_env(riak_repl, fullsync_on_connect, true) of
-                true ->
-                    FullsyncWorker ! start_fullsync,
-                    lager:info("Full-sync on connect"),
-                    {noreply, State1#state{keepalive_time=KeepaliveTime}};
-                false ->
-                    {noreply, State1#state{keepalive_time=KeepaliveTime}}
-            end;
-        false ->
-            lager:error("Invalid peer info, ring sizes do not match."),
-            {stop, normal, State}
-    end;
+handle_msg({peerinfo, TheirPI, Capability}, State) ->
+    handle_peerinfo(State, TheirPI, Capability);
 handle_msg({q_ack, N}, #state{pending=Pending} = State) ->
     drain(State#state{pending=Pending-N});
 handle_msg(keepalive, State) ->
@@ -267,6 +225,87 @@ handle_msg(keepalive_ack, State) ->
 handle_msg(Msg, #state{fullsync_worker = FSW} = State) ->
     gen_fsm:send_event(FSW, Msg),
     {noreply, State}.
+
+handle_peerinfo(#state{sitename=SiteName, socket=Socket, my_pi=MyPI} = State, TheirPI, Capability) ->
+    case riak_repl_util:validate_peer_info(TheirPI, MyPI) of
+        true ->
+            case app_helper:get_env(riak_repl, inverse_connection) == true
+                andalso get(inverted) /= true of
+                true ->
+                    %% we want to trap exits now
+                    process_flag(trap_exit, true),
+                    Pid = proc_lib:spawn_link(fun() ->
+                                put(inverted, true),
+                                NewState = riak_repl_tcp_client:make_state(SiteName,
+                                    Socket, State#state.my_pi,
+                                    State#state.work_dir,
+                                    State#state.client),
+                                %io:format("entering tcp_client loop with
+                                    %state ~p -- ~p~n", [NewState,
+                                    %tuple_size(NewState)]),
+                                gen_server:enter_loop(riak_repl_tcp_client,
+                                    [], NewState)
+
+                        end),
+                    gen_tcp:controlling_process(Socket, Pid),
+                    %% send the peer info again
+                    Pid ! {tcp, Socket, term_to_binary({peerinfo,
+                                TheirPI, Capability})},
+                    %% block until the server exits, then exit ourselves
+                    receive
+                        {'EXIT', Pid, _} ->
+                            {stop, normal, State}
+                    end;
+                _ ->
+
+                    ClientStrats = proplists:get_value(fullsync_strategies, Capability,
+                        [?LEGACY_STRATEGY]),
+                    ServerStrats = app_helper:get_env(riak_repl, fullsync_strategies,
+                        [?LEGACY_STRATEGY]),
+                    Strategy = riak_repl_util:choose_strategy(ServerStrats, ClientStrats),
+                    StratMod = riak_repl_util:strategy_module(Strategy, server),
+                    lager:info("Using fullsync strategy ~p.", [StratMod]),
+                    {ok, WorkDir} = riak_repl_fsm_common:work_dir(Socket, SiteName),
+                    {ok, FullsyncWorker} = StratMod:start_link(SiteName,
+                        Socket, WorkDir, State#state.client),
+                    %% Set up bounded queue if remote supports it
+                    case proplists:get_bool(bounded_queue, Capability) of
+                        true ->
+                            QSize = app_helper:get_env(riak_repl,queue_size,
+                                ?REPL_DEFAULT_QUEUE_SIZE),
+                            MaxPending = app_helper:get_env(riak_repl,server_max_pending,
+                                ?REPL_DEFAULT_MAX_PENDING),
+                            State1 = State#state{q = bounded_queue:new(QSize),
+                                fullsync_worker = FullsyncWorker,
+                                fullsync_strategy = StratMod,
+                                max_pending = MaxPending,
+                                work_dir = WorkDir,
+                                pending = 0};
+                        false ->
+                            State1 = State#state{fullsync_worker = FullsyncWorker,
+                                fullsync_strategy = StratMod}
+                    end,
+
+                    case proplists:get_bool(keepalive, Capability) of
+                        true ->
+                            KeepaliveTime = ?KEEPALIVE_TIME;
+                        _ ->
+                            KeepaliveTime = undefined
+                    end,
+
+                    case app_helper:get_env(riak_repl, fullsync_on_connect, true) of
+                        true ->
+                            FullsyncWorker ! start_fullsync,
+                            lager:info("Full-sync on connect"),
+                            {noreply, State1#state{keepalive_time=KeepaliveTime}};
+                        false ->
+                            {noreply, State1#state{keepalive_time=KeepaliveTime}}
+                    end
+            end;
+        false ->
+            lager:error("Invalid peer info, ring sizes do not match."),
+            {stop, normal, State}
+    end.
 
 send_peerinfo(#state{socket=Socket, sitename=SiteName} = State) ->
     OurNode = node(),
@@ -286,8 +325,7 @@ send_peerinfo(#state{socket=Socket, sitename=SiteName} = State) ->
                             [bounded_queue, keepalive, {fullsync_strategies,
                                     app_helper:get_env(riak_repl, fullsync_strategies,
                                         [?LEGACY_STRATEGY])}]}),
-                    {ok, WorkDir} = riak_repl_fsm_common:work_dir(Socket, SiteName),
-                    {noreply, State#state{work_dir = WorkDir,
+                    {noreply, State#state{
                             client=proplists:get_value(client, Props),
                             election_timeout=undefined,
                             my_pi=PI}};

--- a/src/riak_repl_tcp_server.erl
+++ b/src/riak_repl_tcp_server.erl
@@ -294,7 +294,7 @@ handle_peerinfo(#state{sitename=SiteName, socket=Socket, my_pi=MyPI} = State, Th
             {stop, normal, State}
     end.
 
-send_peerinfo(#state{socket=Socket, sitename=SiteName} = State) ->
+send_peerinfo(#state{socket=Socket} = State) ->
     OurNode = node(),
     case riak_repl_leader:leader_node()  of
         undefined -> % leader not elected yet


### PR DESCRIPTION
In situations when you can only connect outbound because of firewall policies, etc, you can't do outbound replication because TCP connection direction and replication direction are tied together.

These changes allow you to subvert that by switching roles for a connection once a connection is established. However, these changes are kind of a hack and should only be used as a last resort.

Some caveats:
- Both sides need to be _configured_ to do this, it is not negotiated
- You MUST use the new 'keylist' fullsync strategy, at least if you want start/stop/pause/resume to work
- If you turn this on, it is NOT backwards compatible
