### PR TITLE
Make Repl Client NAT-aware

### DIFF
--- a/src/riak_repl_console.erl
+++ b/src/riak_repl_console.erl
@@ -10,13 +10,19 @@
 
 add_listener(Params) ->
     Ring = get_ring(),
-    {ok, NewRing} = add_listener_internal(Ring,Params),
-    ok = maybe_set_ring(Ring, NewRing).
+    case add_listener_internal(Ring,Params) of
+        {ok, NewRing} ->
+            ok = maybe_set_ring(Ring, NewRing);
+        error -> error
+    end.
 
 add_nat_listener(Params) ->
     Ring = get_ring(),
-    {ok, NewRing} = add_nat_listener_internal(Ring, Params),
-    ok = maybe_set_ring(Ring, NewRing).
+    case add_nat_listener_internal(Ring, Params) of
+        {ok, NewRing} ->
+            ok = maybe_set_ring(Ring, NewRing);
+        error -> error
+    end.
 
 add_listener_internal(Ring, [NodeName, IP, Port]) ->
     Listener = make_listener(NodeName, IP, Port),
@@ -30,15 +36,15 @@ add_listener_internal(Ring, [NodeName, IP, Port]) ->
                 false ->
                     io:format("~p is not a valid IP address for ~p\n",
                               [IP, Listener#repl_listener.nodename]),
-                    {error,error};
+                    error;
                 Error ->
                     io:format("Node ~p must be available to add listener: ~p\n",
                               [Listener#repl_listener.nodename, Error]),
-                    {error,error}
+                    error
             end;
         false ->
             io:format("~p is not a member of the cluster\n", [Listener#repl_listener.nodename]),
-            {error, error}
+            error
     end.
 
 add_nat_listener_internal(Ring, [NodeName, IP, Port, PublicIP, PublicPort]) ->
@@ -51,14 +57,11 @@ add_nat_listener_internal(Ring, [NodeName, IP, Port, PublicIP, PublicPort]) ->
                     {ok, NewRing2};
                 {error, IPParseError} ->
                     io:format("Invalid NAT IP address: ~p~n", [IPParseError]),
-                    {error, error};
-                {_,Error} ->
-                    io:format("Error adding NAT Listener: ~s~n",[Error]),
-                    {error, error}
+                    error
             end;
         {error,_} ->
             io:format("Error adding nat address. ~n"),
-            {error, error}
+            error
     end.
 
 del_listener([NodeName, IP, Port]) ->

--- a/src/riak_repl_tcp_server.erl
+++ b/src/riak_repl_tcp_server.erl
@@ -28,7 +28,9 @@
 -export([start_fullsync/1, cancel_fullsync/1, pause_fullsync/1,
         resume_fullsync/1, handle_peerinfo/3, make_state/5]).
 
+-ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+-endif.
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -427,7 +429,7 @@ non_nat_redirect_test() ->
     ?assertEqual("127.0.0.1", Ip),
     ?assertEqual(9010, Port).
 
-skip_nap_test() ->
+skip_nat_test() ->
     Ring0 = riak_repl_ring:ensure_config_test(),
     NodeName   = "test@test",
     ListenAddr = "127.0.0.1",


### PR DESCRIPTION
Some thrashing at AT&T due to Network Address Translation presence sparked some interest in adding NAT-aware commands and behavior to replication. Dave P has already added the commands to a branch, and I'm adding the client code to riak_repl_tcp_client so that it won't try and connect to itself; and will use the remote site's public NAT'd addresses if they are present.
