### PR TITLE
Don't crash if the peerinfo from a 1.1 server doesn't include natlisters

### DIFF
--- a/src/riak_repl_tcp_client.erl
+++ b/src/riak_repl_tcp_client.erl
@@ -469,7 +469,12 @@ handle_peerinfo(#state{sitename=SiteName, transport=Transport,
 %% then use the NAT addresses. Otherwise, use local addresses. If
 %% there are no NAT addresses, then use the local ones.
 get_public_listener_addrs(ReplConfig, ConnectedIP) ->
-    NatListeners = dict:fetch(natlisteners, ReplConfig),
+    NatListeners = case dict:find(natlisteners, ReplConfig) of
+        {ok, Value} ->
+            Value;
+        error ->
+            []
+    end,
     NatListenAddrs = [R#nat_listener.nat_addr || R <- NatListeners],
     UseNats = lists:keymember(ConnectedIP, 1, NatListenAddrs),
     case UseNats of

--- a/src/riak_repl_tcp_client.erl
+++ b/src/riak_repl_tcp_client.erl
@@ -296,7 +296,7 @@ async_connect(Parent, IPAddr, Port) ->
             Parent ! {connect_failed, Reason}
     end.
 
-send(Transport, Socket, Data) when is_binary(Data) -> 
+send(Transport, Socket, Data) when is_binary(Data) ->
     R = Transport:send(Socket, Data),
     riak_repl_stats:client_bytes_sent(size(Data)),
     R;
@@ -490,7 +490,11 @@ get_public_listener_addrs(ReplConfig, ConnectedIP) ->
 get_all_listener_addrs(ReplConfig) ->
     Listeners = dict:fetch(listeners, ReplConfig),
     ListenAddrs = [R#repl_listener.listen_addr || R <- Listeners],
-    NatListeners = dict:fetch(natlisteners, ReplConfig),
+    NatListeners =
+        case dict:find(natlisteners, ReplConfig) of
+            {ok, Value} -> Value;
+            error  -> []
+        end,
     NatAddrs = [R#nat_listener.nat_addr || R <- NatListeners],
     NatListenAddrs = [R#nat_listener.listen_addr || R <- NatListeners],
     ListenAddrs++NatAddrs++NatListenAddrs.

--- a/src/riak_repl_tcp_server.erl
+++ b/src/riak_repl_tcp_server.erl
@@ -188,7 +188,7 @@ handle_info(init_ack, State=#state{transport=Transport, socket=Socket}) ->
     %% acknowledge the change of socket ownership
     ok = ranch:accept_ack(State#state.listener),
     ok = Transport:setopts(Socket, [
-            binary, 
+            binary,
             {keepalive, true},
             {nodelay, true},
             {packet, 4},
@@ -425,7 +425,11 @@ ip_and_port_for_node(Node, Ring, ConnectedIp) ->
     Listeners = dict:fetch(listeners, ReplConfig),
     NodeListeners = [L || L <- Listeners,
                           L#repl_listener.nodename == Node],
-    NatListeners = dict:fetch(natlisteners, ReplConfig),
+    NatListeners =
+        case dict:find(natlisteners, ReplConfig) of
+            {ok, Value} -> Value;
+            error -> []
+        end,
     NatNodeListeners = [N || N <- NatListeners,
                              N#nat_listener.nodename == Node],
     NatListenAddrs = [R#nat_listener.nat_addr || R <- NatListeners],


### PR DESCRIPTION
@metadave Please review and check that I didn't miss any other places you did this unsafely. get_all_listener_addrs should be safe since it is only called on the local repl config. Although this may be unsafe if the ring is one upgraded from 1.1.
