### PR TITLE
Realtime discards with large mailboxes

### DIFF
--- a/src/riak_repl_leader.erl
+++ b/src/riak_repl_leader.erl
@@ -202,7 +202,7 @@ handle_cast({repl, Msg}, State) when State#state.i_am_leader =:= true ->
             {noreply, State};
         Receivers ->
             case timer:now_diff(os:timestamp(), State#state.lastpoll) of
-                X when X > 5000000 ->
+                X when X > 1000000 ->
                     R2 = lists:map(fun({Mref, Pid, _}) ->
                                     S = case erlang:process_info(Pid,message_queue_len) of
                                         {message_queue_len, L} when L < 20000 ->
@@ -212,7 +212,6 @@ handle_cast({repl, Msg}, State) when State#state.i_am_leader =:= true ->
                                     end,
                                     {Mref, Pid, S}
                             end, Receivers),
-                    lager:info("poll result ~p", [R2]),
                     [P ! {repl, Msg} || {_Mref, P, send} <- R2],
                     riak_repl_stats:objects_sent(),
                     {noreply, State#state{receivers=R2,


### PR DESCRIPTION
There are 3 mailboxes that can grow large when realtime load is high and replication throughput is slower:
- Local gen_leader candidate mailbox (from postcommit hook)
- Elected gen_leader candidate (from gen_leader candidate)
- riak_repl_tcp_server (from elected gen_leader)

The strategy used to mitigate this is to inspect the mailbox size of the process we're sending the message to and to drop the message if the destination mailbox is over a certain size (20 kilomessages). Because polling this on every request involves getting a lock, which can cause the process asking for the data getting descheduled (when the target is running), we try to poll intermittently to avoid that. In addition, the cross-node call for the candidate->leader has 2 thresholds and will drop a % of messages in order to try to keep the mailbox below the limit, rather than switch purely between drop and send.
