### PR TITLE
Add max queue size and percentage used to repl status

### DIFF
--- a/src/bounded_queue.erl
+++ b/src/bounded_queue.erl
@@ -28,6 +28,7 @@
          in/2, 
          out/1, 
          byte_size/1, 
+         max_size/1,
          len/1,
          dropped_count/1]).
 
@@ -81,6 +82,8 @@ out(BQ=#bq{q=Q,s=Size}) ->
 %% @doc  The size of the queue, in bytes.
 -spec byte_size(bounded_queue()) -> non_neg_integer().
 byte_size(#bq{s=Size}) -> Size.
+
+max_size(#bq{m=Max}) -> Max.
 
 %% @spec len(bounded_queue()) ->  non_neg_integer()
 %% @doc  The number of items in the queue.

--- a/src/riak_repl_tcp_server.erl
+++ b/src/riak_repl_tcp_server.erl
@@ -120,7 +120,11 @@ handle_call(status, _From, #state{fullsync_worker=FSW, q=Q} = State) ->
             _ ->
                 [{dropped_count, bounded_queue:dropped_count(Q)},
                     {queue_length, bounded_queue:len(Q)},
-                    {queue_byte_size, bounded_queue:byte_size(Q)}]
+                    {queue_byte_size, bounded_queue:byte_size(Q)},
+                    {queue_max_size, bounded_queue:max_size(Q)},
+                    {queue_percentage, (bounded_queue:byte_size(Q) * 100) div
+                     bounded_queue:max_size(Q)}
+                ]
         end,
     {reply, {status, Desc ++ Res}, State}.
 


### PR DESCRIPTION
This should wait to be merged after 1.2.0 is released.
