### PR TITLE
Cet fullsync latency

### DIFF
--- a/src/riak_repl_fullsync_helper.erl
+++ b/src/riak_repl_fullsync_helper.erl
@@ -376,16 +376,16 @@ itr_next(Size, File, Tag) ->
 
 diff_keys(R, L, #diff_state{replies=0, fsm=FSM, ref=Ref, count=Count} = DiffState) ->
     gen_fsm:send_event(FSM, {Ref, diff_paused}),
-    lager:info("waiting for stop or resume"),
+%%    lager:info("waiting for stop or resume"),
     %% wait for a message telling us to stop, or to continue.
     %% TODO do this more correctly when there's more time.
     receive
         {'$gen_call', From, stop} ->
             gen_server2:reply(From, ok),
-            lager:info("stop request while diffing"),
+%%            lager:info("stop request while diffing"),
             DiffState;
         {Ref, diff_resume} ->
-            lager:info("resuming diff stream"),
+%%            lager:info("resuming diff stream"),
             diff_keys(R, L, DiffState#diff_state{replies=Count})
     end;
 diff_keys({{Key, Hash}, RNext}, {{Key, Hash}, LNext}, DiffState) ->

--- a/src/riak_repl_fullsync_helper.erl
+++ b/src/riak_repl_fullsync_helper.erl
@@ -376,6 +376,7 @@ itr_next(Size, File, Tag) ->
 
 diff_keys(R, L, #diff_state{replies=0, fsm=FSM, ref=Ref, count=Count} = DiffState) ->
     gen_fsm:send_event(FSM, {Ref, diff_paused}),
+    lager:info("waiting for stop or resume"),
     %% wait for a message telling us to stop, or to continue.
     %% TODO do this more correctly when there's more time.
     receive

--- a/src/riak_repl_fullsync_helper.erl
+++ b/src/riak_repl_fullsync_helper.erl
@@ -384,7 +384,7 @@ diff_keys(R, L, #diff_state{replies=0, fsm=FSM, ref=Ref, count=Count} = DiffStat
             lager:info("stop request while diffing"),
             DiffState;
         {Ref, diff_resume} ->
-            %lager:info("resuming diff stream"),
+            lager:info("resuming diff stream"),
             diff_keys(R, L, DiffState#diff_state{replies=Count})
     end;
 diff_keys({{Key, Hash}, RNext}, {{Key, Hash}, LNext}, DiffState) ->

--- a/src/riak_repl_keylist_server.erl
+++ b/src/riak_repl_keylist_server.erl
@@ -124,7 +124,8 @@ wait_for_partition({partition, Partition}, State) ->
         [State#state.sitename, Partition]),
     gen_fsm:send_event(self(), continue),
     {next_state, build_keylist, State#state{partition=Partition,
-            partition_start=now(), stage_start=now()}};
+                                            partition_start=now(), stage_start=now(),
+                                            pending_acks=0, generator_paused=false}};
 wait_for_partition(Event, State) ->
     lager:debug("Full-sync with site ~p; ignoring event ~p",
         [State#state.sitename, Event]),
@@ -222,10 +223,10 @@ wait_keylist(kl_eof, #state{their_kl_fh=FH} = State) ->
     %% to add some backpressure, while keeping the pipeline full (as long as the
     %% client continues to reply diff_ack).
     lager:info("Full-sync for ~p using ~p windows of batch_size ~p",
-               [State#state.partition, ?ACKS_IN_FLIGHT, State#state.diff_batch_size / ?ACKS_IN_FLIGHT]),
+               [State#state.partition, ?ACKS_IN_FLIGHT, State#state.diff_batch_size div ?ACKS_IN_FLIGHT]),
     {ok, Ref} = riak_repl_fullsync_helper:diff_stream(Pid, State#state.partition,
         State#state.kl_fn, State#state.their_kl_fn,
-        State#state.diff_batch_size / ?ACKS_IN_FLIGHT),
+        State#state.diff_batch_size div ?ACKS_IN_FLIGHT),
     {next_state, diff_keylist, State#state{diff_ref=Ref, diff_pid=Pid,
             stage_start=now()}};
 wait_keylist({skip_partition, Partition}, #state{partition=Partition} = State) ->
@@ -264,12 +265,12 @@ diff_keylist({Ref, diff_paused}, #state{socket=Socket, transport=Transport,
     WorkerPaused = case PendingAcks < ?ACKS_IN_FLIGHT of
                        true ->
                            %% another batch can be sent immediately
-                           lager:info("resuming diff generator with ~p pending acks",[PendingAcks]),
+%%                           lager:info("resuming diff generator with ~p pending acks",[PendingAcks]),
                            State#state.diff_pid ! {Ref, diff_resume},
                            false;
                        false ->
                            %% already ACKS_IN_FLIGHT batches out. Don't resume yet.
-                           lager:info("diff generator paused with ~p pending acks",[PendingAcks]),
+  %%                         lager:info("diff generator paused with ~p pending acks",[PendingAcks]),
                            true
                    end,
     {next_state, diff_keylist, State#state{pending_acks=PendingAcks, generator_paused=WorkerPaused}};
@@ -279,7 +280,6 @@ diff_keylist({diff_ack, Partition}, #state{partition=Partition, diff_ref=Ref,
                                            pending_acks=PendingAcks0} = State) ->
     %% That's one less "pending" ack from the client. Tell client to keep going.
     PendingAcks = PendingAcks0-1,
-    riak_repl_tcp_server:send(Transport, Socket, {diff_ack, Partition}),
     %% If the generator was paused, resume it. That would happen if there are already
     %% ACKS_IN_FLIGHT batches in flight. Better to check "paused" state than guess by
     %% pending acks count.

--- a/src/riak_repl_keylist_server.erl
+++ b/src/riak_repl_keylist_server.erl
@@ -99,7 +99,6 @@ init([SiteName, Transport, Socket, WorkDir, Client]) ->
     MaxPool = app_helper:get_env(riak_repl, max_get_workers, 100),
     VnodeGets = app_helper:get_env(riak_repl, vnode_gets, true),
     DiffBatchSize = app_helper:get_env(riak_repl, diff_batch_size, 100),
-%%    lager:info("diff_batch_size = ~p", [DiffBatchSize]),
     {ok, Pid} = poolboy:start_link([{worker_module, riak_repl_fullsync_worker},
             {worker_args, []},
             {size, MinPool}, {max_overflow, MaxPool}]),
@@ -260,19 +259,16 @@ diff_keylist({Ref, diff_paused}, #state{socket=Socket, transport=Transport,
     %% request ack from client
     riak_repl_tcp_server:send(Transport, Socket, {diff_ack, Partition}),
     PendingAcks = PendingAcks0+1,
-%%    lager:info("server ---ACK---> client, pending is now ~p", [PendingAcks]),
     %% If we have already received the ack for the previous batch, we immediately
     %% resume the generator, otherwise we wait for the ack from the client. We'll
     %% have at most ACKS_IN_FLIGHT windows of differences in flight.
     WorkerPaused = case PendingAcks < ?ACKS_IN_FLIGHT of
                        true ->
                            %% another batch can be sent immediately
-%%                           lager:info("resuming diff generator from diff_paused with ~p pending acks",[PendingAcks]),
                            State#state.diff_pid ! {Ref, diff_resume},
                            false;
                        false ->
                            %% already ACKS_IN_FLIGHT batches out. Don't resume yet.
-%%                           lager:info("diff generator paused with ~p pending acks",[PendingAcks]),
                            true
                    end,
     {next_state, diff_keylist, State#state{pending_acks=PendingAcks, generator_paused=WorkerPaused}};
@@ -282,13 +278,11 @@ diff_keylist({diff_ack, Partition}, #state{partition=Partition, diff_ref=Ref,
                                            pending_acks=PendingAcks0} = State) ->
     %% That's one less "pending" ack from the client. Tell client to keep going.
     PendingAcks = PendingAcks0-1,
-%%    lager:info("server <---ACK--- client, pending is now ~p", [PendingAcks]),
     %% If the generator was paused, resume it. That would happen if there are already
     %% ACKS_IN_FLIGHT batches in flight. Better to check "paused" state than guess by
     %% pending acks count.
     case WorkerPaused of
         true ->
-%%            lager:info("resuming diff generator from diff_ack with ~p pending acks",[PendingAcks]),
             State#state.diff_pid ! {Ref, diff_resume};
         false ->
             ok

--- a/src/riak_repl_keylist_server.erl
+++ b/src/riak_repl_keylist_server.erl
@@ -71,7 +71,9 @@
         partition_start,
         pool,
         vnode_gets = true,
-        diff_batch_size
+        diff_batch_size,
+        generator_paused = false,
+        pending_acks = 0
     }).
 
 
@@ -247,15 +249,39 @@ diff_keylist({Ref, {merkle_diff, {{B, K}, _VClock}}}, #state{
     end,
     {next_state, diff_keylist, State};
 diff_keylist({Ref, diff_paused}, #state{socket=Socket, transport=Transport,
-        partition=Partition, diff_ref=Ref} = State) ->
-    %% we've sent all the diffs in this batch, wait for the client to be ready
-    %% for more
+        partition=Partition, diff_ref=Ref, pending_acks=PendingAcks0} = State) ->
+    %% request ack from client
     riak_repl_tcp_server:send(Transport, Socket, {diff_ack, Partition}),
-    {next_state, diff_keylist, State};
-diff_keylist({diff_ack, Partition}, #state{partition=Partition, diff_ref=Ref} = State) ->
-    %% client has processed last batch of differences, generate some more
-    State#state.diff_pid ! {Ref, diff_resume},
-    {next_state, diff_keylist, State};
+    PendingAcks = PendingAcks0+1,
+    %% If we have already received the ack for the previous batch, we immediately
+    %% resume the generator, otherwise we wait for the ack from the client. We'll
+    %% have at most 2 windows of differences in flight.
+    WorkerPaused = case PendingAcks < 2 of
+                       true ->
+                           %% another batch can be sent immediately
+                           State#state.diff_pid ! {Ref, diff_resume},
+                           false;
+                       false ->
+                           %% already 2 batches out. Don't resume yet.
+                           true
+                   end,
+    {next_state, diff_keylist, State#state{pending_acks=PendingAcks, generator_paused=WorkerPaused}};
+diff_keylist({diff_ack, Partition}, #state{partition=Partition, diff_ref=Ref,
+                                           socket=Socket, transport=Transport,
+                                           generator_paused=WorkerPaused,
+                                           pending_acks=PendingAcks0} = State) ->
+    %% That's one less "pending" ack from the client. Tell client to keep going.
+    PendingAcks = PendingAcks0-1,
+    riak_repl_tcp_server:send(Transport, Socket, {diff_ack, Partition}),
+    %% If the generator was paused, resume it. That would happen if there are already
+    %% 2 batches in flight. Better to check "paused" state than guess by pending acks count.
+    case WorkerPaused of
+        true ->
+            State#state.diff_pid ! {Ref, diff_resume};
+        false ->
+            ok
+    end,
+    {next_state, diff_keylist, State#state{pending_acks=PendingAcks,generator_paused=false}};
 diff_keylist({Ref, diff_done}, #state{diff_ref=Ref} = State) ->
     lager:info("Full-sync with site ~p; differences exchanged for partition ~p (done in ~p secs)",
         [State#state.sitename, State#state.partition,

--- a/src/riak_repl_keylist_server.erl
+++ b/src/riak_repl_keylist_server.erl
@@ -76,6 +76,7 @@
         pending_acks = 0
     }).
 
+-define(ACKS_IN_FLIGHT,2).
 
 start_link(SiteName, Transport, Socket, WorkDir, Client) ->
     gen_fsm:start_link(?MODULE, [SiteName, Transport, Socket, WorkDir, Client], []).
@@ -217,10 +218,14 @@ wait_keylist(kl_eof, #state{their_kl_fh=FH} = State) ->
     lager:info("Full-sync with site ~p; calculating differences for ~p",
         [State#state.sitename, State#state.partition]),
     {ok, Pid} = riak_repl_fullsync_helper:start_link(self()),
-    %% generate differences in batches of 1000, to add some backpressure
+    %% generate differences in ACKS_IN_FLIGHT batches of diff_batch_size/ACKS_IN_FLIGHT,
+    %% to add some backpressure, while keeping the pipeline full (as long as the
+    %% client continues to reply diff_ack).
+    lager:info("Full-sync for ~p using ~p windows of batch_size ~p",
+               [State#state.partition, ?ACKS_IN_FLIGHT, State#state.diff_batch_size / ?ACKS_IN_FLIGHT]),
     {ok, Ref} = riak_repl_fullsync_helper:diff_stream(Pid, State#state.partition,
         State#state.kl_fn, State#state.their_kl_fn,
-        State#state.diff_batch_size),
+        State#state.diff_batch_size / ?ACKS_IN_FLIGHT),
     {next_state, diff_keylist, State#state{diff_ref=Ref, diff_pid=Pid,
             stage_start=now()}};
 wait_keylist({skip_partition, Partition}, #state{partition=Partition} = State) ->
@@ -255,14 +260,16 @@ diff_keylist({Ref, diff_paused}, #state{socket=Socket, transport=Transport,
     PendingAcks = PendingAcks0+1,
     %% If we have already received the ack for the previous batch, we immediately
     %% resume the generator, otherwise we wait for the ack from the client. We'll
-    %% have at most 2 windows of differences in flight.
-    WorkerPaused = case PendingAcks < 2 of
+    %% have at most ACKS_IN_FLIGHT windows of differences in flight.
+    WorkerPaused = case PendingAcks < ?ACKS_IN_FLIGHT of
                        true ->
                            %% another batch can be sent immediately
+                           lager:info("resuming diff generator with ~p pending acks",[PendingAcks]),
                            State#state.diff_pid ! {Ref, diff_resume},
                            false;
                        false ->
-                           %% already 2 batches out. Don't resume yet.
+                           %% already ACKS_IN_FLIGHT batches out. Don't resume yet.
+                           lager:info("diff generator paused with ~p pending acks",[PendingAcks]),
                            true
                    end,
     {next_state, diff_keylist, State#state{pending_acks=PendingAcks, generator_paused=WorkerPaused}};
@@ -274,7 +281,8 @@ diff_keylist({diff_ack, Partition}, #state{partition=Partition, diff_ref=Ref,
     PendingAcks = PendingAcks0-1,
     riak_repl_tcp_server:send(Transport, Socket, {diff_ack, Partition}),
     %% If the generator was paused, resume it. That would happen if there are already
-    %% 2 batches in flight. Better to check "paused" state than guess by pending acks count.
+    %% ACKS_IN_FLIGHT batches in flight. Better to check "paused" state than guess by
+    %% pending acks count.
     case WorkerPaused of
         true ->
             State#state.diff_pid ! {Ref, diff_resume};

--- a/src/riak_repl_keylist_server.erl
+++ b/src/riak_repl_keylist_server.erl
@@ -99,6 +99,7 @@ init([SiteName, Transport, Socket, WorkDir, Client]) ->
     MaxPool = app_helper:get_env(riak_repl, max_get_workers, 100),
     VnodeGets = app_helper:get_env(riak_repl, vnode_gets, true),
     DiffBatchSize = app_helper:get_env(riak_repl, diff_batch_size, 100),
+%%    lager:info("diff_batch_size = ~p", [DiffBatchSize]),
     {ok, Pid} = poolboy:start_link([{worker_module, riak_repl_fullsync_worker},
             {worker_args, []},
             {size, MinPool}, {max_overflow, MaxPool}]),
@@ -259,18 +260,19 @@ diff_keylist({Ref, diff_paused}, #state{socket=Socket, transport=Transport,
     %% request ack from client
     riak_repl_tcp_server:send(Transport, Socket, {diff_ack, Partition}),
     PendingAcks = PendingAcks0+1,
+%%    lager:info("server ---ACK---> client, pending is now ~p", [PendingAcks]),
     %% If we have already received the ack for the previous batch, we immediately
     %% resume the generator, otherwise we wait for the ack from the client. We'll
     %% have at most ACKS_IN_FLIGHT windows of differences in flight.
     WorkerPaused = case PendingAcks < ?ACKS_IN_FLIGHT of
                        true ->
                            %% another batch can be sent immediately
-%%                           lager:info("resuming diff generator with ~p pending acks",[PendingAcks]),
+%%                           lager:info("resuming diff generator from diff_paused with ~p pending acks",[PendingAcks]),
                            State#state.diff_pid ! {Ref, diff_resume},
                            false;
                        false ->
                            %% already ACKS_IN_FLIGHT batches out. Don't resume yet.
-  %%                         lager:info("diff generator paused with ~p pending acks",[PendingAcks]),
+%%                           lager:info("diff generator paused with ~p pending acks",[PendingAcks]),
                            true
                    end,
     {next_state, diff_keylist, State#state{pending_acks=PendingAcks, generator_paused=WorkerPaused}};
@@ -280,11 +282,13 @@ diff_keylist({diff_ack, Partition}, #state{partition=Partition, diff_ref=Ref,
                                            pending_acks=PendingAcks0} = State) ->
     %% That's one less "pending" ack from the client. Tell client to keep going.
     PendingAcks = PendingAcks0-1,
+%%    lager:info("server <---ACK--- client, pending is now ~p", [PendingAcks]),
     %% If the generator was paused, resume it. That would happen if there are already
     %% ACKS_IN_FLIGHT batches in flight. Better to check "paused" state than guess by
     %% pending acks count.
     case WorkerPaused of
         true ->
+%%            lager:info("resuming diff generator from diff_ack with ~p pending acks",[PendingAcks]),
             State#state.diff_pid ! {Ref, diff_resume};
         false ->
             ok


### PR DESCRIPTION
Full-sync replication, over a link with high latency, can perform sub-optimally due to large gaps in the flow of diff-objects from server to client. This was due to the server waiting for a handshake to return from the client before sending another batch of diffs.

This PR maintains the same protocol from the client's perspective, but keeps two half-sized batches in flight to maintain a full pipeline of diff-objects on the wire with no gaps. Gaps could occur if the client is unable to keep up and eventually can not acknowledge either of the two batches in flight from the server.

Compared to the previous implementation, this change was shown to improve performance over a link with 60 msec of latency from 39 Mb/sec to 50 Mb/sec, which equalled the maximum rate when there was zero latency. So, the result seems to show that we can achieve the same throughput as zero latency, even when the link has significant latency.
