### PR TITLE
Fix fullsync crashes on stale message and delayed_write errors

### DIFF
--- a/src/riak_repl_fullsync_helper.erl
+++ b/src/riak_repl_fullsync_helper.erl
@@ -273,8 +273,17 @@ handle_cast(merkle_finish, State) ->
     couch_merkle:close(State#state.merkle_pid),
     {noreply, State};
 handle_cast(kl_finish, State) ->
-    file:sync(State#state.kl_fp),
-    file:close(State#state.kl_fp),
+    %% delayed_write can mean sync/close might not work the first time around
+    %% because of a previous error that is only now being reported. In this case,
+    %% call close again. See http://www.erlang.org/doc/man/file.html#open-2
+    case file:sync(State#state.kl_fp) of
+        ok -> ok;
+        _ -> file:sync(State#state.kl_fp)
+    end,
+    case file:close(State#state.kl_fp) of
+        ok -> ok;
+        _ -> file:close(State#state.kl_fp)
+    end,
     gen_server2:cast(self(), kl_sort),
     {noreply, State};
 handle_cast(kl_sort, State) ->

--- a/src/riak_repl_keylist_client.erl
+++ b/src/riak_repl_keylist_client.erl
@@ -148,6 +148,10 @@ request_partition({kl_exchange, P}, #state{partition=P} = State) ->
         _ ->
             {next_state, request_partition, State#state{their_kl_ready=true}}
     end;
+request_partition({kl_exchange, P},  State) ->
+    lager:warning("Stale kl_exchange message received for ~p, ignoring",
+        [P]),
+    {next_state, request_partition, State};
 request_partition({Ref, {error, Reason}}, #state{socket=Socket, kl_ref=Ref,
         transport=Transport, skipping=Skip} = State) ->
     lager:warning("Full-sync with site ~p; skipping partition ~p because of error ~p",


### PR DESCRIPTION
The client can get a stale kl_exchange message if it told the server to
skip a partition but the server had already built the keylist.

Also, in some cases, the sync() done after writing the keylist can fail,
because of delayed_write silliness, and that will cause the filesorter
to crash with file_error errors. Double sync/closing the file seems to
prevent this from happening.
