### PR TITLE
Seperate the bounded_queue out into a seperate process

### DIFF
--- a/ebin/riak_repl.app
+++ b/ebin/riak_repl.app
@@ -11,6 +11,7 @@
                   'gen_leader',
                   'riak_repl',
                   'riak_repl_app',
+                  'riak_repl_bq',
                   'riak_repl_cinfo',
                   'riak_repl_client_sup',
                   'riak_repl_console',

--- a/src/bounded_queue.erl
+++ b/src/bounded_queue.erl
@@ -28,6 +28,7 @@
          in/2, 
          out/1, 
          byte_size/1, 
+         max_size/1,
          len/1,
          dropped_count/1]).
 
@@ -81,6 +82,8 @@ out(BQ=#bq{q=Q,s=Size}) ->
 %% @doc  The size of the queue, in bytes.
 -spec byte_size(bounded_queue()) -> non_neg_integer().
 byte_size(#bq{s=Size}) -> Size.
+
+max_size(#bq{m=Max}) -> Max.
 
 %% @spec len(bounded_queue()) ->  non_neg_integer()
 %% @doc  The number of items in the queue.

--- a/src/riak_repl_bq.erl
+++ b/src/riak_repl_bq.erl
@@ -1,7 +1,7 @@
 -module(riak_repl_bq).
 -behaviour(gen_server).
 
--export([start_link/2, q_ack/2, status/1]).
+-export([start_link/2, q_ack/2, status/1, stop/1]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -31,6 +31,9 @@ status(Pid) ->
         _:_ ->
             [{queue, too_busy}]
     end.
+
+stop(Pid) ->
+    gen_server:call(Pid, stop).
 
 %% gen_server
 
@@ -63,7 +66,9 @@ handle_call(status, _From, State = #state{q=Q}) ->
               {queue_pending, State#state.pending},
               {queue_max_pending, State#state.max_pending}
              ],
-    {reply, Status, State}.
+    {reply, Status, State};
+handle_call(stop, _From, State) ->
+    {stop, normal, ok, State}.
 
 handle_info({repl, RObj}, State) ->
     case riak_repl_util:repl_helper_send_realtime(RObj, State#state.client) of

--- a/src/riak_repl_bq.erl
+++ b/src/riak_repl_bq.erl
@@ -1,0 +1,115 @@
+-module(riak_repl_bq).
+-behaviour(gen_server).
+
+-export([start_link/2, q_ack/2, status/1]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-include("riak_repl.hrl").
+
+-record(state, {
+        transport,
+        socket,
+        q,
+        pending,
+        max_pending,
+        client
+        }).
+
+start_link(Transport, Socket) ->
+    gen_server:start_link(?MODULE, [Transport, Socket], []).
+
+q_ack(Pid, Count) ->
+    gen_server:cast(Pid, {q_ack, Count}).
+
+status(Pid) ->
+    try
+        gen_server:call(Pid, status, infinity)
+    catch
+        _:_ ->
+            [{queue, too_busy}]
+    end.
+
+%% gen_server
+
+init([Transport, Socket]) ->
+    QSize = app_helper:get_env(riak_repl,queue_size,
+                               ?REPL_DEFAULT_QUEUE_SIZE),
+    MaxPending = app_helper:get_env(riak_repl,server_max_pending,
+                                    ?REPL_DEFAULT_MAX_PENDING),
+    {ok, C} = riak:local_client(),
+    {ok, #state{q = bounded_queue:new(QSize),
+                max_pending = MaxPending,
+                pending = 0,
+                socket=Socket,
+                transport=Transport,
+                client=C
+               }}.
+
+
+handle_cast({q_ack, Count}, State = #state{pending=Pending}) ->
+    drain(State#state{pending=Pending - Count}).
+
+handle_call(status, _From, State = #state{q=Q}) ->
+    Status = [{queue_pid, self()},
+              {dropped_count, bounded_queue:dropped_count(Q)},
+              {queue_length, bounded_queue:len(Q)},
+              {queue_byte_size, bounded_queue:byte_size(Q)},
+              {queue_max_size, bounded_queue:max_size(Q)},
+              {queue_percentage, (bounded_queue:byte_size(Q) * 100) div
+               bounded_queue:max_size(Q)},
+              {queue_pending, State#state.pending},
+              {queue_max_pending, State#state.max_pending}
+             ],
+    {reply, Status, State}.
+
+handle_info({repl, RObj}, State) ->
+    case riak_repl_util:repl_helper_send_realtime(RObj, State#state.client) of
+        [] ->
+            %% no additional objects to queue
+            drain(enqueue(term_to_binary({diff_obj, RObj}), State));
+        Objects when is_list(Objects) ->
+            %% enqueue all the objects the hook asked us to send as a list.
+            %% They're enqueued together so that they can't be dumped from the
+            %% queue piecemeal if it overflows
+            NewState = enqueue([term_to_binary({diff_obj, O}) ||
+                        O <- Objects ++ [RObj]], State),
+            drain(NewState);
+        cancel ->
+            {noreply, State}
+    end.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+%% internal
+
+drain(State=#state{q=Q,pending=P,max_pending=M}) when P < M ->
+    case bounded_queue:out(Q) of
+        {{value, Msg}, NewQ} ->
+            drain(send_diffobj(Msg, State#state{q=NewQ}));
+        {empty, NewQ} ->
+            {noreply, State#state{q=NewQ}}
+    end;
+drain(State) ->
+    {noreply, State}.
+
+enqueue(Msg, State=#state{q=Q}) ->
+    State#state{q=bounded_queue:in(Q,Msg)}.
+
+send_diffobj(Msgs, State0) when is_list(Msgs) ->
+    %% send all the messages in the list
+    %% we correctly increment pending, so we should get enough q_acks
+    %% to restore pending to be less than max_pending when we're done.
+    lists:foldl(fun(Msg, State) ->
+                send_diffobj(Msg, State)
+        end, State0, Msgs);
+send_diffobj(Msg,State=#state{transport=Transport,socket=Socket,pending=Pending}) ->
+    riak_repl_tcp_server:send(Transport, Socket, Msg),
+    State#state{pending=Pending+1}.
+

--- a/src/riak_repl_tcp_client.erl
+++ b/src/riak_repl_tcp_client.erl
@@ -396,23 +396,17 @@ handle_peerinfo(#state{sitename=SiteName, transport=Transport,
             case app_helper:get_env(riak_repl, inverse_connection) == true
                 andalso get(inverted) /= true of
                 true ->
-                    case riak_repl_leader:add_receiver_pid(self()) of
-                        ok ->
-                            lager:info("Inverting connection"),
-                            self() ! {tcp, Socket, term_to_binary({peerinfo,
-                                        TheirPeerInfo, Capability})},
-                            put(inverted, true),
-                            gen_server:enter_loop(riak_repl_tcp_server,
-                                [],
-                                riak_repl_tcp_server:make_state(SiteName,
-                                    Transport, Socket, State#state.my_pi,
-                                    State#state.work_dir,
-                                    State#state.client)),
-                            {stop, normal, State};
-                        {error, _Reason} ->
-                            %% election has not completed.. apparently
-                            {stop, normal, State}
-                    end;
+                    lager:info("Inverting connection"),
+                    self() ! {tcp, Socket, term_to_binary({peerinfo,
+                                TheirPeerInfo, Capability})},
+                    put(inverted, true),
+                    gen_server:enter_loop(riak_repl_tcp_server,
+                        [],
+                        riak_repl_tcp_server:make_state(SiteName,
+                            Transport, Socket, State#state.my_pi,
+                            State#state.work_dir,
+                            State#state.client)),
+                    {stop, normal, State};
                 _ ->
 
                     ServerStrats = proplists:get_value(fullsync_strategies, Capability,

--- a/src/riak_repl_tcp_server.erl
+++ b/src/riak_repl_tcp_server.erl
@@ -208,13 +208,14 @@ handle_info(timeout, State) ->
 handle_info(_Event, State) ->
     {noreply, State}.
 
-terminate(_Reason, #state{fullsync_worker=FSW, work_dir=WorkDir}) ->
+terminate(_Reason, #state{fullsync_worker=FSW, work_dir=WorkDir,q=Q}) ->
     case is_pid(FSW) of
         true ->
             gen_fsm:sync_send_all_state_event(FSW, stop);
         _ ->
             ok
     end,
+    catch(riak_repl_bq:stop(Q)),
     %% clean up work dir
     Cmd = lists:flatten(io_lib:format("rm -rf ~s", [WorkDir])),
     os:cmd(Cmd).


### PR DESCRIPTION
Also, improves the queue info in 'riak-repl status'.
