### PR TITLE
Use a lock-free queue and try to size packets better

### DIFF
--- a/ebin/riak_repl.app
+++ b/ebin/riak_repl.app
@@ -42,6 +42,7 @@
                   ssl,
                   riak_core,
                   riak_kv,
+                  erl_lfq,
                   ranch]},
   {registered,   [riak_repl_connector_sup,
                   riak_repl_leader,

--- a/rebar.config
+++ b/rebar.config
@@ -7,5 +7,6 @@
         {riak_search, "1.2.*", {git, "git://github.com/basho/riak_search",
                                  {branch, "1.2"}}},
         {meck, "0.7.2", {git, "git://github.com/eproxus/meck.git", {tag, "0.7.2"}}},
+        {erl_lfq, ".*", {git, "git://github.com/argv0/erl_lfq.git", "HEAD"}},
         {ranch, "0.2.1", {git, "git://github.com/extend/ranch.git", {tag, "0.2.1"}}}
        ]}.

--- a/src/riak_repl_bq.erl
+++ b/src/riak_repl_bq.erl
@@ -1,7 +1,7 @@
 -module(riak_repl_bq).
 -behaviour(gen_server).
 
--export([start_link/2, q_ack/2, status/1, stop/1]).
+-export([start_link/0, get_handle/1, status/1, stop/1]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -10,19 +10,17 @@
 -include("riak_repl.hrl").
 
 -record(state, {
-        transport,
-        socket,
         q,
-        pending,
-        max_pending,
-        client
+        client,
+        max_size,
+        dropped_count=0
         }).
 
-start_link(Transport, Socket) ->
-    gen_server:start_link(?MODULE, [Transport, Socket], []).
+start_link() ->
+    gen_server:start_link(?MODULE, [], []).
 
-q_ack(Pid, Count) ->
-    gen_server:cast(Pid, {q_ack, Count}).
+get_handle(Pid) ->
+    gen_server:call(Pid, get_handle).
 
 status(Pid) ->
     try
@@ -37,38 +35,37 @@ stop(Pid) ->
 
 %% gen_server
 
-init([Transport, Socket]) ->
+init([]) ->
     QSize = app_helper:get_env(riak_repl,queue_size,
                                ?REPL_DEFAULT_QUEUE_SIZE),
-    MaxPending = app_helper:get_env(riak_repl,server_max_pending,
-                                    ?REPL_DEFAULT_MAX_PENDING),
     {ok, C} = riak:local_client(),
-    {ok, #state{q = bounded_queue:new(QSize),
-                max_pending = MaxPending,
-                pending = 0,
-                socket=Socket,
-                transport=Transport,
-                client=C
+    {ok, Q} = erl_lfq:new(),
+    {ok, #state{q = Q,
+                client=C,
+                max_size=QSize
                }}.
 
 
-handle_cast({q_ack, Count}, State = #state{pending=Pending}) ->
-    drain(State#state{pending=Pending - Count}).
+handle_cast(_, State) ->
+    {noreply, State}.
 
 handle_call(status, _From, State = #state{q=Q}) ->
     Status = [{queue_pid, self()},
-              {dropped_count, bounded_queue:dropped_count(Q)},
-              {queue_length, bounded_queue:len(Q)},
-              {queue_byte_size, bounded_queue:byte_size(Q)},
-              {queue_max_size, bounded_queue:max_size(Q)},
-              {queue_percentage, (bounded_queue:byte_size(Q) * 100) div
-               bounded_queue:max_size(Q)},
-              {queue_pending, State#state.pending},
-              {queue_max_pending, State#state.max_pending}
+              {queue_msg_queue, process_info(self(), message_queue_len)},
+              {dropped_count, State#state.dropped_count},
+              {queue_length, erl_lfq:len(Q)},
+              {queue_byte_size, erl_lfq:byte_size(Q)},
+              {queue_max_size, State#state.max_size},
+              {queue_percentage, (erl_lfq:byte_size(Q) * 100) div
+               State#state.max_size}
+              %{queue_pending, State#state.pending},
+              %{queue_max_pending, State#state.max_pending}
              ],
     {reply, Status, State};
 handle_call(stop, _From, State) ->
-    {stop, normal, ok, State}.
+    {stop, normal, ok, State};
+handle_call(get_handle, _From, State = #state{q=Q}) ->
+    {reply, Q, State}.
 
 handle_info({repl, RObj}, State) ->
     case riak_repl_util:repl_helper_send_realtime(RObj, State#state.client) of
@@ -94,60 +91,16 @@ terminate(_Reason, _State) ->
 
 %% internal
 
-enqueue(Msg, State=#state{q=Q}) ->
-    State#state{q=bounded_queue:in(Q,Msg)}.
+enqueue(Msg, State=#state{q=Q, max_size=M}) ->
+    %lager:error("getting queue size"),
+    case erl_lfq:byte_size(Q) of
+        X when X > M  ->
+            %lager:error("dropping, size was ~p", [X]),
+            State#state{dropped_count=State#state.dropped_count+1};
+        _ ->
+            %lager:error("enqueueing, size was ~p : ~p", [X, byte_size(Msg)]),
+            erl_lfq:in(Q,Msg),
+            State
+    end.
 
-drain(State=#state{pending=P,max_pending=M}) when P < M ->
-    drain(State, {0, []});
-drain(State) ->
-    {noreply, State}.
 
-drain(State=#state{q=Q,pending=P,max_pending=M,
-        transport=Transport,socket=Socket}, OldBuf) when P < M ->
-    %lager:error("dequeueing"),
-    case bounded_queue:out(Q) of
-        {empty, NewQ} ->
-            case OldBuf of
-                {0, []} ->
-                    ok;
-                {_N, Buf} ->
-                    %lager:notice("flushing final ~p bytes from buffer", [_N]),
-                    riak_repl_tcp_server:send(Transport, Socket,
-                        buffer_to_packets(Buf))
-            end,
-            {noreply, State#state{q=NewQ}};
-        {{value, Msg}, NewQ} ->
-            {State2, Buffer} = send_diffobj(Msg, State, OldBuf),
-            drain(State2#state{q=NewQ}, Buffer)
-    end;
-drain(State, {0, []}) ->
-    %% nothing left in the buffer
-    {noreply, State};
-drain(State=#state{transport=Transport,socket=Socket}, {_N, Buffer}) ->
-    %% send the rest of the buffer
-    %lager:notice("flushing final ~p bytes from buffer", [_N]),
-    riak_repl_tcp_server:send(Transport, Socket, buffer_to_packets(Buffer)),
-    {noreply, State}.
-
-send_diffobj(Msgs, State0, Buffer0) when is_list(Msgs) ->
-    %% send all the messages in the list
-    %% we correctly increment pending, so we should get enough q_acks
-    %% to restore pending to be less than max_pending when we're done.
-    lists:foldl(fun(Msg, {State, Buffer}) ->
-                send_diffobj(Msg, State, Buffer)
-        end, {State0, Buffer0}, Msgs);
-send_diffobj(Msg,State=#state{transport=Transport,socket=Socket,pending=Pending},
-        {BufferSz, Buffer}) ->
-    NewBuffer = case (BufferSz + byte_size(Msg)) > 1400 of
-        true ->
-            %lager:notice("intermediate buffer flush"),
-            riak_repl_tcp_server:send(Transport, Socket,
-                buffer_to_packets(lists:reverse(Buffer))),
-            {byte_size(Msg), [Msg]};
-        false ->
-            {BufferSz+byte_size(Msg), [Msg|Buffer]}
-    end,
-    {State#state{pending=Pending+1}, NewBuffer}.
-
-buffer_to_packets(Buf) ->
-    term_to_binary({diff_objs, Buf}).

--- a/src/riak_repl_bq.erl
+++ b/src/riak_repl_bq.erl
@@ -74,14 +74,14 @@ handle_info({repl, RObj}, State) ->
     case riak_repl_util:repl_helper_send_realtime(RObj, State#state.client) of
         [] ->
             %% no additional objects to queue
-            drain(enqueue(term_to_binary({diff_obj, RObj}), State));
+            {noreply, enqueue(term_to_binary({diff_obj, RObj}), State)};
         Objects when is_list(Objects) ->
             %% enqueue all the objects the hook asked us to send as a list.
             %% They're enqueued together so that they can't be dumped from the
             %% queue piecemeal if it overflows
             NewState = enqueue([term_to_binary({diff_obj, O}) ||
                         O <- Objects ++ [RObj]], State),
-            drain(NewState);
+            {noreply, NewState};
         cancel ->
             {noreply, State}
     end.

--- a/src/riak_repl_tcp_client.erl
+++ b/src/riak_repl_tcp_client.erl
@@ -131,7 +131,7 @@ handle_info({connected, Transport, Socket}, #state{listener={_, IPAddr, Port}} =
     ok = riak_repl_util:configure_socket(Transport, Socket),
     Transport:send(Socket, State#state.sitename),
     Props = riak_repl_fsm_common:common_init(Transport, Socket),
-    erlang:send_after(3000, self(), flush_q_ack),
+    erlang:send_after(1000, self(), flush_q_ack),
     NewState = State#state{
         listener = {connected, IPAddr, Port},
         socket=Socket,
@@ -244,7 +244,7 @@ handle_info(flush_q_ack, State=#state{transport=T,socket=S,count=C}) ->
         false ->
             State
     end,
-    erlang:send_after(3000, self(), flush_q_ack),
+    erlang:send_after(1000, self(), flush_q_ack),
     {noreply, NewState};
 handle_info(_Event, State) ->
     {noreply, State}.

--- a/src/riak_repl_tcp_client.erl
+++ b/src/riak_repl_tcp_client.erl
@@ -42,7 +42,8 @@
         fullsync_worker,
         fullsync_strategy,
         pool_pid,
-        keepalive_time
+        keepalive_time,
+        last_ack={0,0,0}
     }).
 
 make_state(SiteName, Transport, Socket, MyPI, WorkDir, Client) ->
@@ -130,6 +131,7 @@ handle_info({connected, Transport, Socket}, #state{listener={_, IPAddr, Port}} =
     ok = riak_repl_util:configure_socket(Transport, Socket),
     Transport:send(Socket, State#state.sitename),
     Props = riak_repl_fsm_common:common_init(Transport, Socket),
+    erlang:send_after(3000, self(), flush_q_ack),
     NewState = State#state{
         listener = {connected, IPAddr, Port},
         socket=Socket,
@@ -234,6 +236,16 @@ handle_info(timeout, State) ->
         _ ->
             {noreply, State}
     end;
+handle_info(flush_q_ack, State=#state{transport=T,socket=S,count=C}) ->
+    NewState = case timer:now_diff(os:timestamp(), State#state.last_ack) > 1000000 of
+        true ->
+            send(T, S, {q_ack, C}),
+            State#state{count=0, last_ack=os:timestamp()};
+        false ->
+            State
+    end,
+    erlang:send_after(3000, self(), flush_q_ack),
+    {noreply, NewState};
 handle_info(_Event, State) ->
     {noreply, State}.
 
@@ -317,10 +329,10 @@ do_repl_put(Obj, State=#state{count=C, ack_freq=F, pool_pid=Pool}) when (C < (F-
     ok = riak_repl_fullsync_worker:do_put(Worker, Obj, Pool),
     State#state{count=C+1};
 do_repl_put(Obj, State=#state{transport=T,socket=S, ack_freq=F, pool_pid=Pool}) ->
+    send(T, S, {q_ack, F}),
     Worker = poolboy:checkout(Pool, true, infinity),
     ok = riak_repl_fullsync_worker:do_put(Worker, Obj, Pool),
-    send(T, S, {q_ack, F}),
-    State#state{count=0}.
+    State#state{count=0, last_ack=os:timestamp()}.
 
 recv_peerinfo(#state{transport=T,socket=Socket, listener={_, ConnIP, _Port}} = State) ->
     Proto = T:name(),

--- a/src/riak_repl_tcp_client.erl
+++ b/src/riak_repl_tcp_client.erl
@@ -182,6 +182,11 @@ handle_info({Proto, Socket, Data},
     Msg = binary_to_term(Data),
     riak_repl_stats:client_bytes_recv(size(Data)),
     Reply = case Msg of
+        {diff_objs, RObjList} ->
+            {noreply, lists:foldl(fun(E, S) ->
+                            {diff_obj, RObj} = binary_to_term(E),
+                            do_repl_put(RObj, S)
+                    end, State, RObjList)};
         {diff_obj, RObj} ->
             %% realtime diff object, or a fullsync diff object from legacy
             %% repl. Because you can't tell the difference this can screw up


### PR DESCRIPTION
DO NOT MERGE - this change does not work with rolling upgrades!

The rationale behind these changes is to try to size the packets on the wire close to the MTU (or above, for larger objects). Also, the queue is not drained when things are enqueued, only when the client requests us to do so (either by hitting the ack_freq or by a timer that fires if the ack_freq hasn't been hit recently).

Additionally, the bounded_queue has been replaced by erl_lfq, a lock-free single-producer single-consumer queue where the producer is the queue process and the consumer is the TCP server process. This avoid the problem of the message to flush the queue being buried in the mailbox of the queue itself, behind lots of elements to be enqueued.
