### PR TITLE
Add a hook to log dropped realtime repl objects

### DIFF
--- a/src/riak_repl_leader.erl
+++ b/src/riak_repl_leader.erl
@@ -204,6 +204,7 @@ handle_cast({repl, Msg}, State) when State#state.i_am_leader =:= true ->
     %% timer:sleep(1),
     case State#state.receivers of
         [] ->
+            riak_repl_util:dropped_realtime_hook(Msg),
             riak_repl_stats:objects_dropped_no_clients(),
             {noreply, State};
         Receivers ->
@@ -250,11 +251,13 @@ handle_cast({repl, Msg}, State) when State#state.leader_node =/= undefined ->
             %% D = definitely drop
             %% io:format("D"),
             %% TODO: create a new stat rather than abusing this counter.
+            riak_repl_util:dropped_realtime_hook(Msg),
             riak_repl_stats:objects_dropped_no_clients()
     end,        
     {noreply, State};
 handle_cast({repl, _Msg}, State) ->
     %% No leader currently defined - cannot do anything
+    riak_repl_util:dropped_realtime_hook(Msg),
     riak_repl_stats:objects_dropped_no_leader(),
     {noreply, State};
 handle_cast(ensure_sites, State) ->

--- a/src/riak_repl_leader.erl
+++ b/src/riak_repl_leader.erl
@@ -255,7 +255,7 @@ handle_cast({repl, Msg}, State) when State#state.leader_node =/= undefined ->
             riak_repl_stats:objects_dropped_no_clients()
     end,        
     {noreply, State};
-handle_cast({repl, _Msg}, State) ->
+handle_cast({repl, Msg}, State) ->
     %% No leader currently defined - cannot do anything
     riak_repl_util:dropped_realtime_hook(Msg),
     riak_repl_stats:objects_dropped_no_leader(),

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -29,7 +29,9 @@
          schedule_fullsync/1,
          elapsed_secs/1,
          shuffle_partitions/2,
-         proxy_get_active/0
+         proxy_get_active/0,
+         log_dropped_realtime_obj/1,
+         dropped_realtime_hook/1
      ]).
 
 make_peer_info() ->

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -586,3 +586,19 @@ proxy_get_active() ->
         {ok, enabled} -> true;
         _ -> false
     end.
+
+
+log_dropped_realtime_obj(Obj) ->
+    DroppedKey = riak_object:key(Obj),
+    DroppedBucket = riak_object:bucket(Obj),
+    lager:info("REPL dropped object: ~p ~p",
+               [ DroppedBucket, DroppedKey]).
+
+dropped_realtime_hook(Obj) ->
+    Hook = app_helper:get_env(riak_repl, dropped_hook),
+    case Hook of
+        {Mod, Fun} ->
+                Mod:Fun(Obj);
+        _ -> pass
+    end.
+


### PR DESCRIPTION
To test:
Setup 2 clusters, add a listener + site. Point basho_bench at the primary cluster with this config:
https://gist.github.com/3903165

{riak_repl, [
      {data_root, "./data/riak_repl/"},
      {fullsync_on_connect, false},
      {fullsync_interval, disabled},
      {queue_size, 1},
      {dropped_hook, {riak_repl_util,log_dropped_realtime_obj}}
   ]}

setting queue_size to 1 with dropped_hook should display output like this:

2012-10-17 18:31:12.457 [info] <0.1042.0>@riak_repl_util:log_dropped_realtime_obj:596 REPL dropped object: <<"test">> <<236,21,0,0>>
2012-10-17 18:31:12.465 [info] <0.1042.0>@riak_repl_util:log_dropped_realtime_obj:596 REPL dropped object: <<"test">> <<163,31,0,0>>
