### PR TITLE
Fix cluster connection client so it retries on connect_failed.

### DIFF
--- a/src/riak_core_cluster_conn.erl
+++ b/src/riak_core_cluster_conn.erl
@@ -93,7 +93,9 @@ ctrlClientProcess(Remote, connecting, Members0) ->
                             Error
                     end;
                 {error, closed} ->
-                    {error, connection_closed}
+                    {error, connection_closed};
+                Error ->
+                    Error
             end;
         {_From, poll_cluster} ->
             %% cluster manager doesn't know we haven't connected yet.

--- a/src/riak_core_cluster_conn.erl
+++ b/src/riak_core_cluster_conn.erl
@@ -88,7 +88,9 @@ ctrlClientProcess(Remote, connecting, Members0) ->
                                             {cluster_updated, Name, Members, Addr, Remote}),
                             ctrlClientProcess(Remote, {Name, Socket, Transport, Addr}, Members);
                         {error, closed} ->
-                            {error, connection_closed}
+                            {error, connection_closed};
+                        Error ->
+                            Error
                     end;
                 {error, closed} ->
                     {error, connection_closed}
@@ -123,7 +125,9 @@ ctrlClientProcess(Remote, {Name, Socket, Transport, Addr}, Members0) ->
                                             {cluster_updated, Name1, Members, Addr, Remote}),
                             ctrlClientProcess(Remote, {Name1, Socket, Transport, Addr}, Members);
                         {error, closed} ->
-                            {error, connection_closed}
+                            {error, connection_closed};
+                        Error ->
+                            Error
                     end;
                 {error, closed} ->
                     {error, connection_closed}

--- a/src/riak_core_cluster_conn_sup.erl
+++ b/src/riak_core_cluster_conn_sup.erl
@@ -31,7 +31,7 @@ start_link() ->
 add_remote_connection(Remote) ->
     case is_connected(Remote) of
         false ->
-            lager:debug("Connecting to remote cluster: ~p", [Remote]),
+            lager:info("Connecting to remote cluster: ~p", [Remote]),
             ChildSpec = make_remote(Remote),
             supervisor:start_child(?MODULE, ChildSpec);
         _ ->

--- a/src/riak_core_cluster_mgr.erl
+++ b/src/riak_core_cluster_mgr.erl
@@ -632,12 +632,12 @@ ctrlServiceProcess(Socket, Transport, MyVer, RemoteVer, ClientAddr) ->
             case read_ip_address(Socket, Transport, ClientAddr) of
                 {error, closed} ->
                     {error, connection_closed};
-                Error ->
-                    Error;
                 {ok, MyAddr} ->
                     BalancedMembers = gen_server:call(?SERVER, {get_my_members, MyAddr}),
                     ok = Transport:send(Socket, term_to_binary(BalancedMembers)),
-                    ctrlServiceProcess(Socket, Transport, MyVer, RemoteVer, ClientAddr)
+                    ctrlServiceProcess(Socket, Transport, MyVer, RemoteVer, ClientAddr);
+                Error ->
+                    Error
             end;
         {error, timeout} ->
             %% timeouts are OK, I think.

--- a/src/riak_core_connection.erl
+++ b/src/riak_core_connection.erl
@@ -104,7 +104,6 @@ exchange_handshakes_with(host, Socket, Transport) ->
                     {ok,TheirName};
                 {error, Reason} ->
                     ?TRACE(?debugFmt("Failed to exchange handshake with host. Error = ~p", [Reason])),
-                    lager:error("Failed to exchange handshake with host. Error = ~p", [Reason]),
                     {error, Reason}
             end;
         Error ->

--- a/src/riak_core_connection_mgr.erl
+++ b/src/riak_core_connection_mgr.erl
@@ -358,7 +358,7 @@ handle_info({'EXIT', From, Reason}, State = #state{pending = Pending}) ->
                     lager:warning("handle_info: endpoint ~p failed: ~p. removed Ref ~p",
                                   [Cur, Reason, Ref]),
                     State2 = fail_endpoint(Cur, Reason, ProtocolId, State),
-                    %% the connection helper will retry
+                    %% the connection helper will not retry. It's up the caller.
                     {noreply, State2}
             end
     end;
@@ -569,6 +569,7 @@ fail_request(Reason, #req{ref = Ref, spec = Spec},
              State = #state{pending = Pending}) ->
     %% Tell the module it failed
     {Proto, {_TcpOptions, Module,Args}} = Spec,
+    lager:error("connect_failed for ~p", [Spec]),
     Module:connect_failed(Proto, {error, Reason}, Args),
     %% Remove the request from the pending list
     State#state{pending = lists:keydelete(Ref, #req.ref, Pending)}.

--- a/src/riak_core_connection_mgr.erl
+++ b/src/riak_core_connection_mgr.erl
@@ -569,7 +569,6 @@ fail_request(Reason, #req{ref = Ref, spec = Spec},
              State = #state{pending = Pending}) ->
     %% Tell the module it failed
     {Proto, {_TcpOptions, Module,Args}} = Spec,
-    lager:error("connect_failed for ~p", [Spec]),
     Module:connect_failed(Proto, {error, Reason}, Args),
     %% Remove the request from the pending list
     State#state{pending = lists:keydelete(Ref, #req.ref, Pending)}.


### PR DESCRIPTION
Some cosmetic changes for anti-SPAM.

Restore the rtsource connection so that it doesn't delete it's connection request on connect_failed. It was doing the right thing before I messed with it.

The bigger change is in the cluster_conn client, which needed to abort if it gets a connect_failed.

I also cleaned up the client so that it doesn't fail it's pattern match when the other side hangs up. {error, closed} should be handled more gracefully.
