### PR TITLE
Show fullsync/realtime enabled/running in riak-repl status and JSON stats

### DIFF
--- a/src/riak_repl2_fscoordinator_serv.erl
+++ b/src/riak_repl2_fscoordinator_serv.erl
@@ -49,7 +49,7 @@ status() ->
                 [] ->
                     [];
                 Repls ->
-                    [status(Pid) || {Remote, Pid} <- Repls]
+                    [status(Pid) || {_Remote, Pid} <- Repls]
             end
     end.
 

--- a/src/riak_repl2_fscoordinator_sup.erl
+++ b/src/riak_repl2_fscoordinator_sup.erl
@@ -2,7 +2,7 @@
 %% in response to leader changes.
 -module(riak_repl2_fscoordinator_sup).
 -export([start_link/0, set_leader/2, start_coord/2, stop_coord/2,
-    started/0, started/1]).
+    started/0, started/1, coord_for_cluster/1]).
 -export([init/1]).
 
 -define(SHUTDOWN, 5000).
@@ -37,6 +37,14 @@ started() ->
 started(Node) ->
     [{Remote, Pid} || {Remote, Pid, _, _} <-
         supervisor:which_children({?MODULE, Node}), is_pid(Pid)].
+
+coord_for_cluster(Cluster) ->
+    Coords = [{Remote, Pid} || {Remote, Pid, _, _} <- supervisor:which_children(?MODULE),
+                      is_pid(Pid), Remote == Cluster],
+    case Coords of
+        [] -> undefined;
+        [{_,CoordPid}|_] -> CoordPid
+    end.
 
 %% @private
 init(_) ->

--- a/src/riak_repl_console.erl
+++ b/src/riak_repl_console.erl
@@ -13,6 +13,8 @@
          connect/1, disconnect/1, connections/1,
          realtime/1, fullsync/1
         ]).
+-export([rt_remotes_status/0,
+         fs_remotes_status/0]).
 
 -export([get_config/0,
          cluster_mgr_stats/0,
@@ -21,6 +23,7 @@
          server_stats/0,
          coordinator_stats/0,
          coordinator_srv_stats/0]).
+
 -export([set_modes/1, get_modes/0]).
 
 add_listener(Params) ->
@@ -115,6 +118,8 @@ status(quiet) ->
 status2(Verbose) ->
     Config = get_config(),
     Stats1 = lists:sort(riak_repl_stats:get_stats()),
+    RTRemotesStatus = rt_remotes_status(),
+    FSRemotesStatus = fs_remotes_status(),
     LeaderStats = leader_stats(),
     ClientStats = client_stats(),
     ServerStats = server_stats(),
@@ -123,13 +128,32 @@ status2(Verbose) ->
     CMgrStats = cluster_mgr_stats(),
     RTQStats = rtq_stats(),
     All =
-        Config++Stats1++LeaderStats++ClientStats++ServerStats++
-        CoordStats++CoordSrvStats++CMgrStats++RTQStats,
+          RTRemotesStatus ++ FSRemotesStatus ++ Config++Stats1++
+          LeaderStats++ClientStats++ServerStats++
+          CoordStats++CoordSrvStats++CMgrStats++RTQStats,
     if Verbose ->
             format_counter_stats(All);
        true ->
             All
     end.
+
+rt_remotes_status() ->
+    Ring = get_ring(),
+    Enabled = string:join(riak_repl_ring:rt_enabled(Ring),", "),
+    Started = string:join(riak_repl_ring:rt_started(Ring),", "),
+    [{realtime_enabled, Enabled},
+     {realtime_started, Started}].
+
+fs_remotes_status() ->
+    Ring = get_ring(),
+    Sinks = riak_repl_ring:fs_enabled(Ring),
+    RunningSinks = [Sink || Sink <- Sinks, cluster_fs_running(Sink)],
+    [{fullsync_enabled, string:join(Sinks, ", ")},
+     {fullsync_running, string:join(RunningSinks, ", ")}].
+
+cluster_fs_running(Sink) ->
+    ClusterCoord = riak_repl2_fscoordinator_sup:coord_for_cluster(Sink),
+    riak_repl2_fscoordinator:is_running(ClusterCoord).
 
 start_fullsync([]) ->
     [riak_repl_tcp_server:start_fullsync(Pid) ||

--- a/src/riak_repl_ring.erl
+++ b/src/riak_repl_ring.erl
@@ -313,7 +313,7 @@ rt_start_trans(Ring, Remote) ->
 rt_stop_trans(Ring, Remote) ->
     del_list_trans(Remote, rt_started, Ring).
 
-%% Get list of RT enabled remotes
+%% Get list of RT started remotes
 rt_started(Ring) ->
     get_list(rt_started, Ring).
 

--- a/src/riak_repl_wm_stats.erl
+++ b/src/riak_repl_wm_stats.erl
@@ -84,6 +84,8 @@ pretty_print(RD1, C1=#ctx{}) ->
     {json_pp:print(binary_to_list(list_to_binary(Json))), RD2, C2}.
 
 get_stats() ->
+    RTRemotesStatus = riak_repl_console:rt_remotes_status(),
+    FSRemotesStatus = riak_repl_console:fs_remotes_status(),
     Stats1 = riak_repl_stats:get_stats(),
     CMStats = riak_repl_console:cluster_mgr_stats(),
     LeaderStats = riak_repl_console:leader_stats(),
@@ -92,7 +94,7 @@ get_stats() ->
     Coord = riak_repl_console:coordinator_stats(),
     CoordSrv = riak_repl_console:coordinator_srv_stats(),
     RTQ = [{realtime_queue_stats, riak_repl2_rtq:status()}],
-    CMStats ++ Stats1 ++ LeaderStats
+    jsonify_stats(RTRemotesStatus,[]) ++ jsonify_stats(FSRemotesStatus,[]) ++ CMStats ++ Stats1 ++ LeaderStats
         ++ jsonify_stats(Clients, [])
         ++ jsonify_stats(Servers, [])
     ++ RTQ 


### PR DESCRIPTION
riak_repl2_fscoordinator:is_running doesn't seem to be working correctly.
