### PR TITLE
Change intitial connection protocol to incude {major,minor} Rev and Capabilities

### DIFF
--- a/include/riak_core_connection.hrl
+++ b/include/riak_core_connection.hrl
@@ -3,6 +3,7 @@
 
 %% handshake messages to safely initiate a connection. Let's not accept
 %% a connection to a telnet session by accident!
+-define(CTRL_REV, {1,0}).
 -define(CTRL_HELLO, <<"riak-ctrl:hello">>).
 -define(CTRL_TELL_IP_ADDR, <<"riak-ctrl:ip_addr">>).
 -define(CTRL_ACK, <<"riak-ctrl:ack">>).

--- a/src/riak_core_service_mgr.erl
+++ b/src/riak_core_service_mgr.erl
@@ -360,9 +360,12 @@ exchange_handshakes_with(client, Socket, Transport, MyCaps) ->
                     Props = [{local_revision, ?CTRL_REV}, {remote_revision, TheirRev} | TheirCaps],
                     {ok,Props};
                 Msg ->
+                    %% tell other side we are failing them
+                    Error = {error, bad_handshake},
+                    Transport:send(Socket, erlang:term_to_binary(Error)),
                     lager:error("Control protocol handshake with client got unexpected hello: ~p",
                                 [Msg]),
-                    {error, bad_handshake}
+                    Error
             end;
         {error, Reason} ->
             lager:error("Failed to exchange handshake with client. Error = ~p", [Reason]),


### PR DESCRIPTION
## This PR updates our connection protocol so that it can be extended in the future, with a "live" upgrade path.
- Added {Major,Minor} revision to handshake
- Added Capabilities to handshake, including the initial cluster name. This makes it possible to connect to something that doesn't involve a cluster or require a name.
- Caps are just a prop list.
- Dispatched services and client callbacks are passed the Caps list as "Props", which also include the protocol base revisions of both local and remote clusters.

For example, a service might get dispatched with a props list like this...

```
[{local_revision, {1,0}}, {remote_revision, {1,0}}, {clustername, "Bob"}]
```

The client sends something like this: `Hello 1.0 [{clustername, "Bob"}]"`
And the service responds with `Ack 1.0 [{clustername, "Betty"}]`

In the future, we can change either client and service to add additional negotiation phases after they receive the revision numbers and caps list and can agree on extra messages to send/recv.

I think this is sufficient for allowing full rolling upgrades of clusters in the future.
## But note this is a BREAKING change for communicating with current BNW clusters.

Comments welcome.
