### PR TITLE
Address fold issue and bad log output

### DIFF
--- a/src/riak_repl_keylist_server.erl
+++ b/src/riak_repl_keylist_server.erl
@@ -46,11 +46,11 @@
     ]).
 
 %% gen_fsm
--export([init/1, 
+-export([init/1,
          handle_event/3,
-         handle_sync_event/4, 
-         handle_info/3, 
-         terminate/3, 
+         handle_sync_event/4,
+         handle_info/3,
+         terminate/3,
          code_change/4]).
 
 %% states
@@ -558,6 +558,7 @@ bloom_fold(BK, V, {MPid, {serialized, SBloom}, Client, Transport, Socket, NSent,
     {ok, Bloom} = ebloom:deserialize(SBloom),
     bloom_fold(BK, V, {MPid, Bloom, Client, Transport, Socket, NSent, WinSz});
 bloom_fold({B, K}, V, {MPid, Bloom, Client, Transport, Socket, 0, WinSz} = Acc) ->
+    Monitor = riak_core_vnode:monitor(MPid),
     ?TRACE(lager:info("bloom_fold -> MPid(~p) : bloom_paused", [MPid])),
     gen_fsm:send_event(MPid, {self(), bloom_paused}),
     %% wait for a message telling us to stop, or to continue.
@@ -565,11 +566,16 @@ bloom_fold({B, K}, V, {MPid, Bloom, Client, Transport, Socket, 0, WinSz} = Acc) 
     receive
         {'$gen_call', From, stop} ->
             gen_server2:reply(From, ok),
+            erlang:demonitor(Monitor, [flush]),
             Acc;
         bloom_resume ->
             ?TRACE(lager:info("bloom_fold <- MPid(~p) : bloom_resume", [MPid])),
+            erlang:demonitor(Monitor, [flush]),
             bloom_fold({B,K}, V, {MPid, Bloom, Client, Transport, Socket, WinSz, WinSz});
+        {'DOWN', Monitor, process, MPid, _Reason} ->
+            throw(receiver_down);
         _Other ->
+            erlang:demonitor(Monitor, [flush]),
             ?TRACE(lager:info("bloom_fold <- ? : ~p", [_Other]))
     end;
 bloom_fold({B, K}, V, {MPid, Bloom, Client, Transport, Socket, NSent0, WinSz}) ->
@@ -583,4 +589,3 @@ bloom_fold({B, K}, V, {MPid, Bloom, Client, Transport, Socket, NSent0, WinSz}) -
                     NSent0
             end,
     {MPid, Bloom, Client, Transport, Socket, NSent, WinSz}.
-

--- a/src/riak_repl_tcp_server.erl
+++ b/src/riak_repl_tcp_server.erl
@@ -414,7 +414,8 @@ send(Transport, {Owner, Socket}, Data) when is_binary(Data) ->
             riak_repl_stats:server_bytes_sent(size(Data)),
             ok;
         {error, _} = Error ->
-            Owner ! {list_to_atom(Transport:name() ++ "_error"), Socket, Error},
+            TransportName = atom_to_list(Transport:name()),
+            Owner ! {list_to_atom(TransportName ++ "_error"), Socket, Error},
             Error
     end;
 send(Transport, Socket, Data) when is_binary(Data)->


### PR DESCRIPTION
These two problems cropped up at a customer site last week.
- There's an error in a lager statement in riak_repl_tcp_server where it treats an atom as a list and attempt to convert it to an atom.
- The `bloom_fold` function in `riak_repl_keylist_server` is used as the work function sent to the `riak_kv_vnode` async workers. There is a function clause of the `bloom_fold` function that waits for a response from the keylist server, but if the keylist server dies and the async worker is in this waiting state, it is never informed that the server has died. This can manifest itself as all of the async workers being tied up and waiting to get access to the bitcask key directory because the first worker has it locked and is waiting indefinitely for a response from a keylist server process that has died.

This was uncovered on a customer system where their WAN links are very unreliable and they were getting timeouts many times a day, often many times an hour. The first issue showed up in the log output every time the connection timed out and is a very straightforward fix. 

The second issue presented with symptoms of 2I and key list requests timing out. It generally only affected _some_ of the queries so after digging I discovered that the same small set of vnodes was involved any time a 2I or key list request timed out. Further digging revealed that the async worker pools on those vnodes were completely full (*i.e. all workers were busy) and checking the process info for those processes show them all to be stuck in the bitcask `frozen_keydir` function.

These changes have been distributed to the customer and installed and since then the problem has not resurfaced. Previously it was occurring several times per day. I do not have a reproducing test case handy for this, but the fact that it has addressed the customer issue I think is good evidence of the efficacy of this change.
