### PR TITLE
fs max_fssource_node & max_fssource_cluster cmds

### DIFF
--- a/include/riak_repl.hrl
+++ b/include/riak_repl.hrl
@@ -20,6 +20,8 @@
 -define(TCP_MON_RT_APP, repl_rt).
 -define(TCP_MON_FULLSYNC_APP, repl_fullsync).
 -define(DEFAULT_REPL_MODE, mode_repl12).
+-define(DEFAULT_SOURCE_PER_NODE, 2).
+-define(DEFAULT_SOURCE_PER_CLUSTER, 5).
 
 -type(ip_addr_str() :: string()).
 -type(ip_portnum() :: non_neg_integer()).

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -23,8 +23,7 @@
 
 -behaviour(gen_server).
 -define(SERVER, ?MODULE).
--define(DEFAULT_SOURCE_PER_NODE, 2).
--define(DEFAULT_SOURCE_PER_CLUSTER, 5).
+
 % how long to wait for a reply from remote cluster before moving on to
 % next partition.
 -define(WAITING_TIMEOUT, 5000).

--- a/src/riak_repl_console.erl
+++ b/src/riak_repl_console.erl
@@ -23,7 +23,9 @@
          server_stats/0,
          coordinator_stats/0,
          coordinator_srv_stats/0]).
--export([modes/1, set_modes/1, get_modes/0]).
+-export([modes/1, set_modes/1, get_modes/0,
+         max_fssource_node/1,
+         max_fssource_cluster/1]).
 
 add_listener(Params) ->
     Ring = get_ring(),
@@ -427,6 +429,28 @@ modes(NewModes) ->
     Modes = [ list_to_atom(Mode) || Mode <- NewModes],
     set_modes(Modes),
     modes([]).
+
+max_fssource_node([]) ->
+    %% show the default so as not to confuse the user
+    io:format("max_fssource_node value = ~p~n",
+              [app_helper:get_env(riak_repl, max_fssource_node,
+                                  ?DEFAULT_SOURCE_PER_NODE)]);
+max_fssource_node([FSSourceNode]) ->
+    NewVal = erlang:list_to_integer(FSSourceNode),
+    application:set_env(riak_repl, max_fssource_node, NewVal),
+    max_fssource_node([]),
+    ok.
+
+max_fssource_cluster([]) ->
+    %% show the default so as not to confuse the user
+    io:format("max_fssource_cluster value = ~p~n",
+              [app_helper:get_env(riak_repl, max_fssource_cluster,
+                                  ?DEFAULT_SOURCE_PER_CLUSTER)]);
+max_fssource_cluster([FSSourceCluster]) ->
+    NewVal = erlang:list_to_integer(FSSourceCluster),
+    application:set_env(riak_repl, max_fssource_cluster, NewVal),
+    max_fssource_cluster([]),
+    ok.
 
 %% helper functions
 


### PR DESCRIPTION
This PR depends on https://github.com/basho/riak_ee/pull/107

allow max_fssource_node and max_fssource_cluster to be changed at
runtime from the riak-repl shell script.

Note: A fullsync stop and start is required for these values to take
effect.

see ticket https://help.basho.com/tickets/3024 for more info
