### PR TITLE
Cet fs reservations

### DIFF
--- a/ebin/riak_repl.app
+++ b/ebin/riak_repl.app
@@ -28,6 +28,7 @@
                   'riak_repl2_fscoordinator_sup',
                   'riak_repl2_fscoordinator_serv',
                   'riak_repl2_fscoordinator_serv_sup',
+                  'riak_repl2_fs_node_reserver',
                   'riak_repl2_fssource',
                   'riak_repl2_fssource_sup',
                   'riak_repl2_fssink',

--- a/include/riak_repl.hrl
+++ b/include/riak_repl.hrl
@@ -25,6 +25,7 @@
 -define(DEFAULT_MAX_SINKS_NODE, 1).
 %% 20 seconds. sources should claim within 5 seconds, but give them a little more time
 -define(RESERVATION_TIMEOUT, (20 * 1000)).
+-define(DEFAULT_MAX_FS_BUSIES_TOLERATED, 10).
 
 -type(ip_addr_str() :: string()).
 -type(ip_portnum() :: non_neg_integer()).

--- a/include/riak_repl.hrl
+++ b/include/riak_repl.hrl
@@ -23,6 +23,8 @@
 -define(DEFAULT_SOURCE_PER_NODE, 1).
 -define(DEFAULT_SOURCE_PER_CLUSTER, 5).
 -define(DEFAULT_MAX_SINKS_NODE, 1).
+%% 20 seconds. sources should claim within 5 seconds, but give them a little more time
+-define(RESERVATION_TIMEOUT, (20 * 1000)).
 
 -type(ip_addr_str() :: string()).
 -type(ip_portnum() :: non_neg_integer()).

--- a/src/riak_repl2_fs_node_reserver.erl
+++ b/src/riak_repl2_fs_node_reserver.erl
@@ -1,0 +1,121 @@
+-module(riak_repl2_fs_node_reserver).
+-include("riak_repl.hrl").
+-behaviour(gen_server).
+-define(SERVER, ?MODULE).
+
+%% 20 seconds. sources should claim within 5 seconds, but give them a little more time
+-define(RESERVATION_TIMEOUT, (20 * 1000)).
+
+-record(state, {
+    leader :: node(),
+    reservations = []
+    }).
+
+%% ------------------------------------------------------------------
+%% API Function Exports
+%% ------------------------------------------------------------------
+
+-export([start_link/0]).
+-export([reserve/1, unreserve/1, claim_reservation/1]).
+
+%% ------------------------------------------------------------------
+%% gen_server Function Exports
+%% ------------------------------------------------------------------
+
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+%% ------------------------------------------------------------------
+%% API Function Definitions
+%% ------------------------------------------------------------------
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+reserve(Partition) ->
+    Node = get_partition_node(Partition),
+    % I don't want to crash the caller if the node is down
+    try gen_server:call({?SERVER, Node}, {reserve, Partition}) of
+        Out -> Out
+    catch
+        'EXIT':{noproc, _} ->
+            down;
+        'EXIT':{{nodedown, _}, _} ->
+            down
+    end.
+
+unreserve(Partition) ->
+    Node = get_partition_node(Partition),
+    gen_server:cast({?SERVER, Node}, {unreserve, Partition}).
+
+claim_reservation(Partition) ->
+    Node = get_partition_node(Partition),
+    gen_server:cast({?SERVER, Node}, {claim_reservation, Partition}).
+
+
+%% ------------------------------------------------------------------
+%% gen_server Function Definitions
+%% ------------------------------------------------------------------
+
+init(Args) ->
+    {ok, Args}.
+
+handle_call({reserve, Partition}, _From, State) ->
+    Kids = supervisor:which_children(riak_repl2_fssink_sup, node()),
+    Max = app_helper:get_env(riak_repl, max_fssink_node, ?DEFAULT_MAX_SINKS_NODE),
+    Running = length(Kids),
+    Reserved = length(State#state.reservations),
+    if
+        (Running + Reserved) < Max ->
+            Tref = erlang:send_after(?RESERVATION_TIMEOUT, self(), {reservation_expired, Partition}),
+            Reserved2 = [{Partition, Tref} | State#state.reservations],
+            {reply, ok, State#state{reservations = Reserved2}};
+        true ->
+            {reply, busy, State}
+    end;
+
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast({unreserve, Partition}, State) ->
+    Reserved2 = cancel_reservation_timeout(Partition, State#state.reservations),
+    {noreply, State#state{reservations = Reserved2}};
+
+handle_cast({claim_reservation, Partition}, State) ->
+    Reserved2 = cancel_reservation_timeout(Partition, State#state.reservations),
+    {noreply, State#state{reservations = Reserved2}};
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info({reservation_expired, Partition}, State) ->
+    Reserved2 = cancel_reservation_timeout(Partition, State#state.reservations),
+    {noreply, State#state{reservations = Reserved2}};
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------
+
+get_partition_node(Partition) ->
+    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+    Owners = riak_core_ring:all_owners(Ring),
+    proplists:get_value(Partition, Owners).
+
+cancel_reservation_timeout(Partition, Reserved) ->
+    case proplists:get_value(Partition, Reserved) of
+        undefined ->
+            Reserved;
+        Tref ->
+            erlang:cancel_timer(Tref),
+            proplists:delete(Partition, Reserved)
+    end.
+

--- a/src/riak_repl2_fs_node_reserver.erl
+++ b/src/riak_repl2_fs_node_reserver.erl
@@ -4,7 +4,6 @@
 -define(SERVER, ?MODULE).
 
 -record(state, {
-    leader :: node(),
     reservations = []
     }).
 

--- a/src/riak_repl2_fs_node_reserver.erl
+++ b/src/riak_repl2_fs_node_reserver.erl
@@ -38,9 +38,9 @@ reserve(Partition) ->
     try gen_server:call({?SERVER, Node}, {reserve, Partition}) of
         Out -> Out
     catch
-        'EXIT':{noproc, _} ->
+        exit:{noproc, _} ->
             down;
-        'EXIT':{{nodedown, _}, _} ->
+        exit:{{nodedown, _}, _} ->
             down
     end.
 

--- a/src/riak_repl2_fs_node_reserver.erl
+++ b/src/riak_repl2_fs_node_reserver.erl
@@ -3,9 +3,6 @@
 -behaviour(gen_server).
 -define(SERVER, ?MODULE).
 
-%% 20 seconds. sources should claim within 5 seconds, but give them a little more time
--define(RESERVATION_TIMEOUT, (20 * 1000)).
-
 -record(state, {
     leader :: node(),
     reservations = []

--- a/src/riak_repl2_fs_node_reserver.erl
+++ b/src/riak_repl2_fs_node_reserver.erl
@@ -57,11 +57,11 @@ claim_reservation(Partition) ->
 %% gen_server Function Definitions
 %% ------------------------------------------------------------------
 
-init(Args) ->
-    {ok, Args}.
+init(_Args) ->
+    {ok, #state{}}.
 
 handle_call({reserve, Partition}, _From, State) ->
-    Kids = supervisor:which_children(riak_repl2_fssink_sup, node()),
+    Kids = supervisor:which_children(riak_repl2_fssink_sup),
     Max = app_helper:get_env(riak_repl, max_fssink_node, ?DEFAULT_MAX_SINKS_NODE),
     Running = length(Kids),
     Reserved = length(State#state.reservations),

--- a/src/riak_repl2_fscoordinator_serv.erl
+++ b/src/riak_repl2_fscoordinator_serv.erl
@@ -6,9 +6,6 @@
 -behaviour(gen_server).
 -define(SERVER, ?MODULE).
 
-%% 20 seconds. sources should claim within 5 seconds, but give them a little more time
--define(RESERVATION_TIMEOUT, (20 * 1000)).
-
 -record(state, {
     transport,
     socket,

--- a/src/riak_repl2_fscoordinator_serv_sup.erl
+++ b/src/riak_repl2_fscoordinator_serv_sup.erl
@@ -3,13 +3,18 @@
 
 -export([init/1]).
 
--export([start_link/0, start_child/4, started/0, started/1]).
+-export([start_link/0, start_child/4, started/0, started/1, set_leader/2]).
 
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 start_child(Socket, Transport, Proto, Props) ->
     supervisor:start_child(?MODULE, [Socket, Transport, Proto, Props]).
+
+set_leader(Node, Pid) ->
+    Started = started(),
+    [riak_repl2_fscoordinator_serv:set_leader(KidPid, Node, Pid) ||
+        {_, KidPid} <- Started].
 
 init(_) ->
     ChildSpec = {id, {riak_repl2_fscoordinator_serv, start_link, []},

--- a/src/riak_repl2_fssink.erl
+++ b/src/riak_repl2_fssink.erl
@@ -125,5 +125,3 @@ terminate(_Reason, #state{fullsync_worker=FSW, work_dir=WorkDir}) ->
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
-
-

--- a/src/riak_repl_app.erl
+++ b/src/riak_repl_app.erl
@@ -63,8 +63,6 @@ start(_Type, _StartArgs) ->
             %% fullsync co-ordincation will follow leader
             riak_repl2_leader:register_notify_fun(
                 fun riak_repl2_fscoordinator_sup:set_leader/2),
-            riak_repl2_leader:register_notify_fun(
-                fun riak_repl2_fs_node_reserver:set_leader/2),
             name_this_cluster(),
             riak_core_node_watcher:service_up(riak_repl, Pid),
             riak_core:register(riak_repl, [{stat_mod, riak_repl_stats}]),

--- a/src/riak_repl_app.erl
+++ b/src/riak_repl_app.erl
@@ -63,6 +63,8 @@ start(_Type, _StartArgs) ->
             %% fullsync co-ordincation will follow leader
             riak_repl2_leader:register_notify_fun(
                 fun riak_repl2_fscoordinator_sup:set_leader/2),
+            riak_repl2_leader:register_notify_fun(
+                fun riak_repl2_fs_node_reserver:set_leader/2),
             name_this_cluster(),
             riak_core_node_watcher:service_up(riak_repl, Pid),
             riak_core:register(riak_repl, [{stat_mod, riak_repl_stats}]),

--- a/src/riak_repl_keylist_client.erl
+++ b/src/riak_repl_keylist_client.erl
@@ -120,7 +120,7 @@ request_partition(continue, #state{partitions=[], sitename=SiteName} = State) ->
 request_partition(continue, #state{partitions=[P|T], work_dir=WorkDir, socket=Socket} = State) ->
     lager:info("Full-sync with site ~p; starting fullsync for ~p",
         [State#state.sitename, P]),
-    riak_repl2_fscoordinator_serv:claim_reservation(P),
+    riak_repl2_fs_node_reserver:claim_reservation(P),
     application:set_env(riak_repl, {progress, State#state.sitename}, [P|T]),
     riak_repl_tcp_client:send(State#state.transport, Socket, {partition, P}),
     KeyListFn = riak_repl_util:keylist_filename(WorkDir, P, ours),

--- a/src/riak_repl_keylist_client.erl
+++ b/src/riak_repl_keylist_client.erl
@@ -120,6 +120,7 @@ request_partition(continue, #state{partitions=[], sitename=SiteName} = State) ->
 request_partition(continue, #state{partitions=[P|T], work_dir=WorkDir, socket=Socket} = State) ->
     lager:info("Full-sync with site ~p; starting fullsync for ~p",
         [State#state.sitename, P]),
+    riak_repl2_fscoordinator_serv:claim_reservation(P),
     application:set_env(riak_repl, {progress, State#state.sitename}, [P|T]),
     riak_repl_tcp_client:send(State#state.transport, Socket, {partition, P}),
     KeyListFn = riak_repl_util:keylist_filename(WorkDir, P, ours),

--- a/src/riak_repl_sup.erl
+++ b/src/riak_repl_sup.erl
@@ -33,6 +33,9 @@ init([]) ->
                  {riak_repl2_leader, {riak_repl2_leader, start_link, []},
                   permanent, 5000, worker, [riak_repl2_leader]},
 
+                 {riak_repl2_fs_node_reserver, {riak_repl2_fs_node_reserver, start_link, []},
+                  permanent, infinity, worker, [riak_repl2_fs_node_reserver]},
+
                  {riak_repl2_rt_sup, {riak_repl2_rt_sup, start_link, []},
                   permanent, infinity, supervisor, [riak_repl2_rt_sup]},
 


### PR DESCRIPTION
We experienced a problem at Anya where we had too many syncs running against the sink node. This caused latencies in the 90th percentile that were unacceptable. The issue is that the sink node was overloaded by too many syncs in progress that caused regular put/get slow down.

Technically, the problem was caused by a an over-commitment on the sink node. The protocol sends "whereis" requests from source to sink (via the full sync coordinator). Those return the IP address of the node that owns a partition too quickly and we've already scheduled up too much work for the sink node that hasn't actually started any work yet.

Our solution is to put in place a reservation system where the source side gets back a location_busy if the sink node has already got too many reservations placed against it. The sink side manages the reservations.
