### PR TITLE
add an indicator that shows rt src/sink errors

### DIFF
--- a/src/riak_repl2_rtq.erl
+++ b/src/riak_repl2_rtq.erl
@@ -296,6 +296,7 @@ deliver_item(C, DeliverFun, {Seq,_NumItem, _Bin} = QEntry) ->
         C#c{cseq = Seq, deliver = undefined}
     catch
         _:_ ->
+            riak_repl_stats:rt_source_errors(),
             %% do not advance head so it will be delivered again
             C#c{errs = C#c.errs + 1, deliver = undefined}
     end.

--- a/src/riak_repl2_rtq_proxy.erl
+++ b/src/riak_repl2_rtq_proxy.erl
@@ -55,6 +55,7 @@ handle_call(_Request, _From, State) ->
 
 handle_cast({push, NumItems, _Bin}, State = #state{nodes=[]}) ->
     lager:warning("No available nodes to proxy ~p objects to~n", [NumItems]),
+    riak_repl_stats:rt_source_errors(),
     {noreply, State};
 handle_cast({push, NumItems, Bin}, State) ->
     Node = hd(State#state.nodes),
@@ -66,6 +67,7 @@ handle_cast(_Msg, State) ->
     {noreply, State}.
 
 handle_info({'DOWN', _Ref, _, {riak_repl2_rtq, Node}, _}, State) ->
+    riak_repl_stats:rt_source_errors(),
     lager:info("rtq proxy target ~p is down", [Node]),
     {noreply, State#state{nodes=State#state.nodes -- [Node]}};
 handle_info(_Info, State) ->

--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -182,6 +182,7 @@ handle_info({tcp_closed, _S},
         0 ->
             ok;
         NumBytes ->
+            riak_repl_stats:rt_source_errors(),
             lager:warning("Realtime connection ~p to ~p closed with partial receive of ~b bytes\n",
                           [peername(State), Remote, NumBytes])
     end,
@@ -191,6 +192,7 @@ handle_info({tcp_closed, _S},
     {stop, normal, State};
 handle_info({tcp_error, _S, Reason}, 
             State = #state{remote = Remote, cont = Cont}) ->
+    riak_repl_stats:rt_source_errors(),
     lager:warning("Realtime connection ~p to ~p network error ~p - ~b bytes pending\n",
                   [peername(State), Remote, Reason, size(Cont)]),
     {stop, normal, State};
@@ -222,6 +224,7 @@ recv(TcpBin, State = #state{remote = Name}) ->
             recv(Cont, State);
         {error, Reason} ->
             %% Something bad happened
+            riak_repl_stats:rt_source_errors(),
             {stop, {framing_error, Reason}, State}
     end.
 
@@ -230,5 +233,6 @@ peername(#state{transport = T, socket = S}) ->
         {ok, Res} ->
             Res;
         {error, Reason} ->
+            riak_repl_stats:rt_source_errors(),
             {lists:flatten(io_lib:format("error:~p", [Reason])), 0}
     end.

--- a/src/riak_repl2_rtsource_helper.erl
+++ b/src/riak_repl2_rtsource_helper.erl
@@ -48,6 +48,7 @@ init([Remote, Transport, Socket]) ->
     {ok, State}.
 
 handle_call({pull, {error, Reason}}, _From, State) ->
+    riak_repl_stats:rt_source_errors(),
     {stop, {queue_error, Reason}, State};
 handle_call({pull, {Seq, NumObjects, BinObjs}}, From,
             State = #state{transport = T, socket = S, objects = Objects}) ->

--- a/src/riak_repl_app.erl
+++ b/src/riak_repl_app.erl
@@ -356,7 +356,14 @@ prep_stop(_State) ->
        catch
         Type:Reason ->
             lager:error("Stopping application riak_api - ~p:~p.\n", [Type, Reason])
-    end,
+       end,
+       Stats = riak_repl_stats:get_stats(),
+       SourceErrors = proplists:get_value(rt_source_errors, Stats, 0),
+       SinkErrors = proplists:get_value(rt_sink_errors, Stats, 0),
+       lager:info("There were ~p rt_source_errors upon shutdown",
+                  [SourceErrors]),
+       lager:info("There were ~p rt_sink_errors upon shutdown",
+                  [SinkErrors]),
     stopping.
 
 

--- a/src/riak_repl_migration.erl
+++ b/src/riak_repl_migration.erl
@@ -74,7 +74,8 @@ drain_queue(false, Peer) ->
                         % probably too much spam in the logs for this warning
                         %lager:warning("Dropped object during replication queue migration"),
                         % is this the correct stat?
-                        riak_repl_stats:objects_dropped_no_clients()
+                        riak_repl_stats:objects_dropped_no_clients(),
+                        riak_repl_stats:rt_source_errors()
                 end,
              ok end),
     drain_queue(riak_repl2_rtq:is_empty(qm), Peer);
@@ -88,6 +89,7 @@ queue_handoff(State) ->
         0 -> %% TODO: bump up riak_repl_stats dropped_objects stats
             %% should we have a new stat? riak_repl_stats:objects_dropped_no_leader()
             lager:error("No nodes available to migrate replication data"),
+            riak_repl_stats:rt_source_errors(),
             {reply, error, State};
         _N ->
             lager:info("Starting queue migration"),


### PR DESCRIPTION
used to indicate that a fullsync may be needed (at the users discretion). They'll need to monitor both source and sink for errors.

Any thoughts?
