### PR TITLE
Improve realtime migration when riak_repl is stopping

### DIFF
--- a/src/riak_repl2_rtq_proxy.erl
+++ b/src/riak_repl2_rtq_proxy.erl
@@ -88,9 +88,7 @@ flush_pending_pushes(State) ->
     receive
         {'$gen_cast', Msg} ->
             {noreply, NewState} = handle_cast(Msg, State),
-            flush_pending_pushes(NewState);
-        _ ->
-            flush_pending_pushes(State)
+            flush_pending_pushes(NewState)
     after
         100 ->
             ok

--- a/src/riak_repl2_rtsource_sup.erl
+++ b/src/riak_repl2_rtsource_sup.erl
@@ -19,7 +19,7 @@ start_link() ->
 init([]) ->
     Processes =
         [{riak_repl2_rtq, {riak_repl2_rtq, start_link, []},
-          permanent, 50000, worker, [riak_repl2_rtq]},
+          transient, 50000, worker, [riak_repl2_rtq]},
 
          {riak_repl2_rtsource_conn_sup, {riak_repl2_rtsource_conn_sup, start_link, []},
           permanent, infinity, supervisor, [riak_repl2_rtsource_conn_sup]}],

--- a/src/riak_repl_app.erl
+++ b/src/riak_repl_app.erl
@@ -351,8 +351,11 @@ prep_stop(_State) ->
             {ok, _Pid} ->
                 lager:info("Started migration server"),
                 riak_repl_migration:migrate_queue();
-            {error, _} -> lager:error("Can't start replication migration server")
-        end
+            {error, _} ->
+                lager:error("Can't start replication migration server")
+        end,
+        %% stop it cleanly, don't just kill it
+        riak_repl2_rtq:stop()
        catch
         Type:Reason ->
             lager:error("Stopping application riak_api - ~p:~p.\n", [Type, Reason])


### PR DESCRIPTION
These changes are intended to avoid dropping realtime messages that
happen or are pending during riak_repl stopping. The key changes are
that we try to send realtime messages to the rtq_proxy first, which
avoids a race with the process dictionary. We also explicitly stop() the
repl2_rtq so that we can gurantee terminate() completes. To do that, we
needed to make it a transient child of its supervisor, so it wouldn't
immediately restart.
