### PR TITLE
Fixed IP match in cases of subnet mismatch

### DIFF
--- a/src/riak_repl_app.erl
+++ b/src/riak_repl_app.erl
@@ -276,7 +276,15 @@ get_matching_address(IP, Mask) ->
                                     _Other ->
                                         ?TRACE(lager:info("IP ~p with CIDR ~p masked as ~p",
                                                           [MyIP, CIDR, _Other])),
-                                        Acc
+                                        case {Acc, rfc1918(IP), rfc1918(MyIP)} of
+                                            {undefined, _Rfc, _Rfc} ->
+                                                % we havn't found anything better, and this has a decent match
+                                                ?TRACE(lager:info("Using IP found so far")),
+                                                {MyIP, Port};
+                                            _ ->
+                                                ?TRACE(lager:debug("Either an IP already found, or nat detected")),
+                                                Acc
+                                        end
                                 end
                         end
                 end, undefined, MyIPs); %% TODO if result is undefined, check NAT


### PR DESCRIPTION
if
    \* On the sink, if the cluster_mgr is set to listen on {0.0.0.0}
    \* The source has an external IP on a given subnet mask
    \* The sink has an external IP using the same subnet mask
    \* The source and sink IP's are on different subnets
an ip would fail to match.
This patch checks to see if the two IP's are both external or both
internal, and in the case of a match, uses the IP unless a better one
(ie, subnet mask match) is found.
