### PR TITLE
added stats to indicate rt errors

### DIFF
--- a/src/riak_core_connection.erl
+++ b/src/riak_core_connection.erl
@@ -102,7 +102,7 @@ exchange_handshakes_with(host, Socket, Transport, MyCaps) ->
                         {?CTRL_ACK, TheirRev, TheirCaps} ->
                             Props = [{local_revision, ?CTRL_REV}, {remote_revision, TheirRev} | TheirCaps],
                             {ok,Props};
-                        {error, Reason} = Error ->
+                        {error, _Reason} = Error ->
                             Error;
                         Msg ->
                             {error, Msg}

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -689,9 +689,10 @@ notify_rt_dirty_nodes(State = #state{dirty_nodes = DirtyNodes,
     State1 = case ordsets:size(DirtyNodes) > 0 of
         true ->
             lager:info("Notifying dirty nodes after fullsync"),
-            % if there are nodes that are in BOTH sets, then don't notify
-            % those nodes below
-            NodesToNotify = ordsets:subtract(DirtyNodes, DirtyNodesDuringFS),
+            % notify all nodes in case some weren't registered with the coord
+            AllNodesList = riak_core_node_watcher:nodes(riak_repl),
+            NodesToNotify = lists:subtract(AllNodesList,
+                                           ordsets:to_list(DirtyNodesDuringFS)),
             lager:info("Notifying nodes ~p", [ NodesToNotify]),
             rpc:multicall(NodesToNotify, riak_repl_stats, clear_rt_dirty, []),
             % TODO: Check return values, only clear those that passed

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -234,9 +234,11 @@ handle_call({node_dirty, Node}, _From,
         end,
     {reply, ok, NewState};
 
-handle_call({node_clean, Node}, _From, State) ->
+handle_call({node_clean, Node}, _From, State = #state{dirty_nodes=DirtyNodes}) ->
     lager:debug("Marking ~p clean after fullsync", [Node]),
-   {reply, ok, State};
+    NewDirtyNodes = ordsets:del_element(Node, DirtyNodes),
+    NewState = State#state{dirty_nodes=NewDirtyNodes},
+    {reply, ok, NewState};
 
 handle_call(_Request, _From, State) ->
     lager:info("ignoring ~p", [_Request]),

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -43,7 +43,10 @@
     running_sources = [],
     successful_exits = 0,
     error_exits = 0,
-    pending_fullsync = false
+    pending_fullsync = false,
+    dirty_nodes = ordsets:new(),          % these nodes should run fullsync
+    dirty_nodes_during_fs = ordsets:new() % these nodes reported realtime errors
+                                          % during an already running fullsync
 }).
 
 %% ------------------------------------------------------------------
@@ -51,7 +54,8 @@
 %% ------------------------------------------------------------------
 
 -export([start_link/1, start_fullsync/1, stop_fullsync/1,
-    status/0, status/1, status/2, is_running/1]).
+    status/0, status/1, status/2, is_running/1,
+        node_dirty/1, node_dirty/2, node_clean/1, node_clean/2]).
 
 %% ------------------------------------------------------------------
 %% gen_server Function Exports
@@ -128,6 +132,32 @@ is_running(Pid) when is_pid(Pid) ->
 is_running(_Other) ->
     false.
 
+node_dirty(Node) ->
+    %% if fullsync running
+    %% keep 2 lists:
+    %%  1) non-running - clear these out when fullsync finishes, and the node
+    %%  doesn't appear in list 2
+    %%  2) running - don't clear these out when fullsync finishes
+    Leader = riak_core_cluster_mgr:get_leader(),
+    Fullsyncs = riak_repl2_fscoordinator_sup:started(Leader),
+     [riak_repl2_fscoordinator:node_dirty(Pid, Node) ||
+        {_, Pid} <- Fullsyncs].
+
+node_dirty(Pid, Node) ->
+    gen_server:call(Pid, {node_dirty, Node}, infinity),
+    lager:info("Node ~p marked dirty and needs a fullsync",[Node]).
+
+node_clean(Node) ->
+    Leader = riak_core_cluster_mgr:get_leader(),
+    Fullsyncs = riak_repl2_fscoordinator_sup:started(Leader),
+     [riak_repl2_fscoordinator:node_clean(Pid, Node) ||
+        {_, Pid} <- Fullsyncs].
+
+node_clean(Pid, Node) ->
+    gen_server:call(Pid, {node_clean, Node}, infinity),
+    lager:info("Node ~p marked clean",[Node]).
+
+
 %% ------------------------------------------------------------------
 %% connection manager callbacks
 %% ------------------------------------------------------------------
@@ -177,29 +207,40 @@ handle_call(status, _From, State = #state{socket=Socket}) ->
         {error_exits, State#state.error_exits},
         {busy_nodes, sets:size(State#state.busy_nodes)},
         {running_stats, SourceStats},
-        {socket, SocketStats}
+        {socket, SocketStats},
+        {fullsync_suggested,
+            nodeset_to_string_list(State#state.dirty_nodes)},
+        {fullsync_suggested_during_fs,
+            nodeset_to_string_list(State#state.dirty_nodes_during_fs)}
     ],
     {reply, SelfStats, State};
 
 handle_call(is_running, _From, State) ->
-    RunningSrcs = State#state.running_sources,
-    % are we done?
-    QEmpty = queue:is_empty(State#state.partition_queue),
-    Waiting = State#state.whereis_waiting,
-    case {RunningSrcs, QEmpty, Waiting} of
-        {[], true, []} ->
-            % nothing outstanding, so we can exit.
-            {reply, false, State};
-        _ ->
-            % there's something waiting for a response.
-            {reply, true, State}
-    end;
+    IsRunning = is_fullsync_in_progress(State),
+    {reply, IsRunning, State};
 
+handle_call({node_dirty, Node}, _From,
+            State = #state{
+                dirty_nodes=DirtyNodes,
+                dirty_nodes_during_fs=DirtyDuringFS}) ->
+    NewState =
+        case is_fullsync_in_progress(State) of
+          true -> lager:info("Node dirty during fullsync from ~p ", [Node]),
+                  NewDirty = ordsets:add_element(Node, DirtyDuringFS),
+                  State#state{dirty_nodes_during_fs = NewDirty};
+          false -> lager:info("Node dirty from ~p ", [Node]),
+                   NewDirty = ordsets:add_element(Node, DirtyNodes),
+                   State#state{dirty_nodes = NewDirty}
+        end,
+    {reply, ok, NewState};
+
+handle_call({node_clean, Node}, _From, State) ->
+    lager:info("Marking ~p clean after fullsync", [Node]),
+   {reply, ok, State};
 
 handle_call(_Request, _From, State) ->
     lager:info("ignoring ~p", [_Request]),
     {reply, ok, State}.
-
 
 %% @hidden
 handle_cast({connected, Socket, Transport, _Endpoint, _Proto}, State) ->
@@ -295,8 +336,11 @@ handle_info({'EXIT', Pid, Cause}, State) when Cause =:= normal; Cause =:= shutdo
             case {EmptyRunning, QEmpty, Waiting} of
                 {true, true, []} ->
                     lager:info("fullsync complete"),
+                    % clear the "rt dirty" stat if it's set,
+                    % otherwise, don't do anything
+                    State3 = notify_rt_dirty_nodes(State),
                     riak_repl_stats:server_fullsyncs(),
-                    {noreply, State2#state{running_sources = Running, busy_nodes = NewBusies}};
+                    {noreply, State3#state{running_sources = Running, busy_nodes = NewBusies}};
                 _ ->
                     % there's something waiting for a response.
                     State3 = start_up_reqs(State2#state{running_sources = Running, busy_nodes = NewBusies}),
@@ -628,3 +672,47 @@ is_fullsync_in_progress(State) ->
         _ ->
             true
     end.
+
+% dirty_nodes is the set of nodes that are marked "dirty"
+% due to a realtime repl issue while fullsync isn't running.
+% dirty_nodes_during_fs is the set of nodes that are marked "dirty"
+% due to a realtime repl issue while fullsync IS running.
+% After a fullsync, notify all dirty_nodes that fullsync is complete
+% and they are now clear/clean. Also, move any nodes that were marked
+% as dirty_nodes_during_fs to dirty_nodes, as they should be cleared out
+% during the next fullsync. If any state is lost in the coordinator,
+% a dirty node won't lose it's dirty state as a persistent file is kept
+% on that node.
+notify_rt_dirty_nodes(State = #state{dirty_nodes = DirtyNodes,
+                                     dirty_nodes_during_fs =
+                                     DirtyNodesDuringFS}) ->
+    State1 = case ordsets:size(DirtyNodes) > 0 of
+        true ->
+            lager:info("Notifying dirty nodes after fullsync"),
+            % if there are nodes that are in BOTH sets, then don't notify
+            % those nodes below
+            NodesToNotify = ordsets:subtract(DirtyNodes, DirtyNodesDuringFS),
+            lager:info("Notifying nodes ~p", [ NodesToNotify]),
+            rpc:multicall(NodesToNotify, riak_repl_stats, clear_rt_dirty, []),
+            % TODO: Check return values, only clear those that passed
+            State#state{dirty_nodes=ordsets:new()};
+        false ->
+            lager:info("No dirty nodes before fullsync started"),
+            State
+    end,
+    case ordsets:size(DirtyNodesDuringFS) > 0 of
+        true ->
+            lager:info("Nodes marked dirty during fullsync"),
+            % move dirty_nodes_during_fs to dirty_nodes so they will be
+            % cleaned out during the next fullsync
+            State#state{dirty_nodes = DirtyNodesDuringFS,
+                          dirty_nodes_during_fs = ordsets:new()};
+        false ->
+            lager:info("No nodes marked dirty during fullsync"),
+            State1
+        end.
+
+nodeset_to_string_list(Set) ->
+    string:join([erlang:atom_to_list(V) || V <- ordsets:to_list(Set)],",").
+
+

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -695,7 +695,6 @@ notify_rt_dirty_nodes(State = #state{dirty_nodes = DirtyNodes,
                                            ordsets:to_list(DirtyNodesDuringFS)),
             lager:info("Notifying nodes ~p", [ NodesToNotify]),
             rpc:multicall(NodesToNotify, riak_repl_stats, clear_rt_dirty, []),
-            % TODO: Check return values, only clear those that passed
             State#state{dirty_nodes=ordsets:new()};
         false ->
             lager:info("No dirty nodes before fullsync started"),

--- a/src/riak_repl2_rtq.erl
+++ b/src/riak_repl2_rtq.erl
@@ -296,6 +296,7 @@ deliver_item(C, DeliverFun, {Seq,_NumItem, _Bin} = QEntry) ->
         C#c{cseq = Seq, deliver = undefined}
     catch
         _:_ ->
+            riak_repl_stats:rt_source_errors(),
             %% do not advance head so it will be delivered again
             C#c{errs = C#c.errs + 1, deliver = undefined}
     end.

--- a/src/riak_repl2_rtq_proxy.erl
+++ b/src/riak_repl2_rtq_proxy.erl
@@ -55,6 +55,7 @@ handle_call(_Request, _From, State) ->
 
 handle_cast({push, NumItems, _Bin}, State = #state{nodes=[]}) ->
     lager:warning("No available nodes to proxy ~p objects to~n", [NumItems]),
+    riak_repl_stats:rt_source_errors(),
     {noreply, State};
 handle_cast({push, NumItems, Bin}, State) ->
     Node = hd(State#state.nodes),
@@ -66,6 +67,7 @@ handle_cast(_Msg, State) ->
     {noreply, State}.
 
 handle_info({'DOWN', _Ref, _, {riak_repl2_rtq, Node}, _}, State) ->
+    riak_repl_stats:rt_source_errors(),
     lager:info("rtq proxy target ~p is down", [Node]),
     {noreply, State#state{nodes=State#state.nodes -- [Node]}};
 handle_info(_Info, State) ->

--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -182,6 +182,7 @@ handle_info({tcp_closed, _S},
         0 ->
             ok;
         NumBytes ->
+            riak_repl_stats:rt_source_errors(),
             lager:warning("Realtime connection ~p to ~p closed with partial receive of ~b bytes\n",
                           [peername(State), Remote, NumBytes])
     end,
@@ -191,6 +192,7 @@ handle_info({tcp_closed, _S},
     {stop, normal, State};
 handle_info({tcp_error, _S, Reason}, 
             State = #state{remote = Remote, cont = Cont}) ->
+    riak_repl_stats:rt_source_errors(),
     lager:warning("Realtime connection ~p to ~p network error ~p - ~b bytes pending\n",
                   [peername(State), Remote, Reason, size(Cont)]),
     {stop, normal, State};
@@ -222,6 +224,7 @@ recv(TcpBin, State = #state{remote = Name}) ->
             recv(Cont, State);
         {error, Reason} ->
             %% Something bad happened
+            riak_repl_stats:rt_source_errors(),
             {stop, {framing_error, Reason}, State}
     end.
 
@@ -230,5 +233,6 @@ peername(#state{transport = T, socket = S}) ->
         {ok, Res} ->
             Res;
         {error, Reason} ->
+            riak_repl_stats:rt_source_errors(),
             {lists:flatten(io_lib:format("error:~p", [Reason])), 0}
     end.

--- a/src/riak_repl2_rtsource_helper.erl
+++ b/src/riak_repl2_rtsource_helper.erl
@@ -48,6 +48,7 @@ init([Remote, Transport, Socket]) ->
     {ok, State}.
 
 handle_call({pull, {error, Reason}}, _From, State) ->
+    riak_repl_stats:rt_source_errors(),
     {stop, {queue_error, Reason}, State};
 handle_call({pull, {Seq, NumObjects, BinObjs}}, From,
             State = #state{transport = T, socket = S, objects = Objects}) ->

--- a/src/riak_repl_app.erl
+++ b/src/riak_repl_app.erl
@@ -360,9 +360,10 @@ prep_stop(_State) ->
        Stats = riak_repl_stats:get_stats(),
        SourceErrors = proplists:get_value(rt_source_errors, Stats, 0),
        SinkErrors = proplists:get_value(rt_sink_errors, Stats, 0),
-       lager:info("There were ~p rt_source_errors upon shutdown",
+       % Setting these to debug as I'm not sure they are entirely accurate
+       lager:debug("There were ~p rt_source_errors upon shutdown",
                   [SourceErrors]),
-       lager:info("There were ~p rt_sink_errors upon shutdown",
+       lager:debug("There were ~p rt_sink_errors upon shutdown",
                   [SinkErrors]),
     stopping.
 

--- a/src/riak_repl_app.erl
+++ b/src/riak_repl_app.erl
@@ -356,7 +356,14 @@ prep_stop(_State) ->
        catch
         Type:Reason ->
             lager:error("Stopping application riak_api - ~p:~p.\n", [Type, Reason])
-    end,
+       end,
+       Stats = riak_repl_stats:get_stats(),
+       SourceErrors = proplists:get_value(rt_source_errors, Stats, 0),
+       SinkErrors = proplists:get_value(rt_sink_errors, Stats, 0),
+       lager:info("There were ~p rt_source_errors upon shutdown",
+                  [SourceErrors]),
+       lager:info("There were ~p rt_sink_errors upon shutdown",
+                  [SinkErrors]),
     stopping.
 
 

--- a/src/riak_repl_migration.erl
+++ b/src/riak_repl_migration.erl
@@ -74,7 +74,8 @@ drain_queue(false, Peer) ->
                         % probably too much spam in the logs for this warning
                         %lager:warning("Dropped object during replication queue migration"),
                         % is this the correct stat?
-                        riak_repl_stats:objects_dropped_no_clients()
+                        riak_repl_stats:objects_dropped_no_clients(),
+                        riak_repl_stats:rt_source_errors()
                 end,
              ok end),
     drain_queue(riak_repl2_rtq:is_empty(qm), Peer);
@@ -88,6 +89,7 @@ queue_handoff(State) ->
         0 -> %% TODO: bump up riak_repl_stats dropped_objects stats
             %% should we have a new stat? riak_repl_stats:objects_dropped_no_leader()
             lager:error("No nodes available to migrate replication data"),
+            riak_repl_stats:rt_source_errors(),
             {reply, error, State};
         _N ->
             lager:info("Starting queue migration"),

--- a/src/riak_repl_stats.erl
+++ b/src/riak_repl_stats.erl
@@ -368,11 +368,7 @@ test_populate_stats() ->
     ok = elections_elected(),
     ok = elections_leader_changed(),
     ok = rt_source_errors(),
-    ok = rt_sink_errors(),
-    %% incrementing rt_source_errors + rt_sink_errors 
-    %% should set rt_dirty to 2, then the call to rt_dirty()
-    %% will set it to 3
-    ok = rt_dirty().
+    ok = rt_sink_errors().
 
 test_check_stats() ->
     ?assertEqual([{server_bytes_sent,1000},
@@ -397,7 +393,7 @@ test_check_stats() ->
                   {server_tx_kbps,[]},
                   {rt_source_errors,1},
                   {rt_sink_errors, 1},
-                  {rt_dirty, 3}], get_stats()).
+                  {rt_dirty, 2}], get_stats()).
 
 test_report() ->
     Bytes = 1024 * 60,

--- a/src/riak_repl_stats.erl
+++ b/src/riak_repl_stats.erl
@@ -127,7 +127,7 @@ rt_dirty() ->
     case Stat > 0 andalso Stat < 5 of
         true ->
             %% the coordinator might not be up yet
-            lager:info("Notifying coordinator of rt_dirty"),
+            lager:debug("Notifying coordinator of rt_dirty"),
             riak_repl2_fscoordinator:node_dirty(node());
         false -> pass
     end.
@@ -148,15 +148,15 @@ init([]) ->
     schedule_report_bw(),
     case is_rt_dirty() of
         true ->
-            lager:info("Warning: RT marked as dirty upon startup"),
+            lager:warning("RT marked as dirty upon startup"),
             folsom_metrics:notify_existing_metric({?APP, rt_dirty}, {inc, 1},
                                                   counter),
             % let the coordinator know about the dirty state when the node
             % comes back up
-            lager:info("Notifying coordinator of rt_dirty state"),
+            lager:debug("Notifying coordinator of rt_dirty state"),
             riak_repl2_fscoordinator:node_dirty(node());
         false ->
-            lager:info("RT is NOT dirty")
+            lager:debug("RT is NOT dirty")
     end,
     {ok, ok}.
 
@@ -286,7 +286,7 @@ touch_rt_dirty_file() ->
     DirtyRTFile = rt_dirty_filename(),
     ok = filelib:ensure_dir(DirtyRTFile),
     case file:write_file(DirtyRTFile, "") of
-        ok -> lager:info("RT dirty file written to ~p", [DirtyRTFile]);
+        ok -> lager:debug("RT dirty file written to ~p", [DirtyRTFile]);
         ER -> lager:warning("Can't write to file ~p due to ~p",[DirtyRTFile,
                                                                 ER])
     end.
@@ -294,7 +294,7 @@ touch_rt_dirty_file() ->
 remove_rt_dirty_file() ->
     DirtyRTFile = rt_dirty_filename(),
     case file:delete(DirtyRTFile) of
-        ok -> lager:info("RT dirty flag cleared");
+        ok -> lager:debug("RT dirty flag cleared");
         {error, Reason} ->
             %% this is a lager:debug because each fullsync
             %% would display this warning.


### PR DESCRIPTION
If a source node detects a RT error, increment the rt_source_error or rt_sink_error stat. Any increment to rt_source_error or rt_sink_error will automatically incremement rt_dirty. The rt_dirty value is written to a file to persist across restarts. When any of these stats are incremented and their value == 1, the node is registered with the FS coordinator (if it's running). Also, if a node is restarted, it will again try to register itself with the coordinator if its rt_dirty value > 0. When a fullsync is complete, the coordinator will clear rt_dirty (and remove the rt_dirty file from the filesystem) from all registered dirty nodes. If any nodes become dirty during fullsync, keep them rt_dirty even if the fullsync completes. The next pass at fullsync will clear this status. 

Note: if there is some type of disconnect between the source node and the coordinator, restarting the source node will re-register with the coordinator if it's still dirty.

misc:
you can test json stats with this:
curl -q http://localhost:8091/riak-repl/stats | python -mjson.tool
