### PR TITLE
Fixes fullsync poor capacity by setting application env values on all nodes

### DIFF
--- a/include/riak_repl.hrl
+++ b/include/riak_repl.hrl
@@ -27,6 +27,7 @@
 -define(RESERVATION_TIMEOUT, (20 * 1000)).
 -define(DEFAULT_MAX_FS_BUSIES_TOLERATED, 10).
 -define(RETRY_WHEREIS_INTERVAL, 1000).
+-define(CONSOLE_RPC_TIMEOUT, 5000).
 
 -type(ip_addr_str() :: string()).
 -type(ip_portnum() :: non_neg_integer()).

--- a/src/riak_repl2_fs_node_reserver.erl
+++ b/src/riak_repl2_fs_node_reserver.erl
@@ -83,6 +83,8 @@ handle_call({reserve, Partition}, _From, State) ->
             Reserved2 = [{Partition, Tref} | State#state.reservations],
             {reply, ok, State#state{reservations = Reserved2}};
         true ->
+            lager:debug("Node busy for partition ~p. running=~p reserved=~p max=~p",
+                        [Partition, Running, Reserved, Max]),
             {reply, busy, State}
     end;
 

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -148,10 +148,8 @@ connect_failed(_ClientProto, Reason, SourcePid) ->
 %% @hidden
 init(Cluster) ->
     process_flag(trap_exit, true),
-    %% ensure that the ring has values for fullsync parameters or load them from the ring
-    %% into our application environment.
-    riak_repl_ring:reconcile_fs_params_with_ring([{max_fssource_node, ?DEFAULT_SOURCE_PER_NODE},
-                                                  {max_fssource_cluster, ?DEFAULT_SOURCE_PER_CLUSTER}]),
+    Max = app_helper:get_env(riak_repl, max_fssource_node, ?DEFAULT_SOURCE_PER_NODE),
+    lager:info("Starting fullsync coordinator (source) with max_fssource_node=~p", [Max]),
     TcpOptions = [
         {kepalive, true},
         {nodelay, true},
@@ -238,10 +236,6 @@ handle_cast(start_fullsync,  State) ->
             lager:warning("Fullsync already in progress; ignoring start"),
             {noreply, State};
         false ->
-            MaxSource = app_helper:get_env(riak_repl, max_fssource_node, ?DEFAULT_SOURCE_PER_NODE),
-            MaxCluster = app_helper:get_env(riak_repl, max_fssource_cluster, ?DEFAULT_SOURCE_PER_CLUSTER),
-            lager:info("Starting fullsync (source) with max_fssource_node=~p and max_fssource_cluster=~p",
-                       [MaxSource, MaxCluster]),
             {ok, Ring} = riak_core_ring_manager:get_my_ring(),
             N = largest_n(Ring),
             Partitions = sort_partitions(Ring),

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -148,8 +148,6 @@ connect_failed(_ClientProto, Reason, SourcePid) ->
 %% @hidden
 init(Cluster) ->
     process_flag(trap_exit, true),
-    Max = app_helper:get_env(riak_repl, max_fssource_node, ?DEFAULT_SOURCE_PER_NODE),
-    lager:info("Starting fullsync coordinator (source) with max_fssource_node=~p", [Max]),
     TcpOptions = [
         {kepalive, true},
         {nodelay, true},
@@ -236,6 +234,10 @@ handle_cast(start_fullsync,  State) ->
             lager:warning("Fullsync already in progress; ignoring start"),
             {noreply, State};
         false ->
+            MaxSource = app_helper:get_env(riak_repl, max_fssource_node, ?DEFAULT_SOURCE_PER_NODE),
+            MaxCluster = app_helper:get_env(riak_repl, max_fssource_cluster, ?DEFAULT_SOURCE_PER_CLUSTER),
+            lager:info("Starting fullsync (source) with max_fssource_node=~p and max_fssource_cluster=~p",
+                       [MaxSource, MaxCluster]),
             {ok, Ring} = riak_core_ring_manager:get_my_ring(),
             N = largest_n(Ring),
             Partitions = sort_partitions(Ring),

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -148,6 +148,8 @@ connect_failed(_ClientProto, Reason, SourcePid) ->
 %% @hidden
 init(Cluster) ->
     process_flag(trap_exit, true),
+    Max = app_helper:get_env(riak_repl, max_fssource_node, ?DEFAULT_SOURCE_PER_NODE),
+    lager:info("Starting fullsync coordinator (source) with max_fssource_node=~p", [Max]),
     TcpOptions = [
         {kepalive, true},
         {nodelay, true},

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -148,8 +148,10 @@ connect_failed(_ClientProto, Reason, SourcePid) ->
 %% @hidden
 init(Cluster) ->
     process_flag(trap_exit, true),
-    Max = app_helper:get_env(riak_repl, max_fssource_node, ?DEFAULT_SOURCE_PER_NODE),
-    lager:info("Starting fullsync coordinator (source) with max_fssource_node=~p", [Max]),
+    %% ensure that the ring has values for fullsync parameters or load them from the ring
+    %% into our application environment.
+    riak_repl_ring:reconcile_fs_params_with_ring([{max_fssource_node, ?DEFAULT_SOURCE_PER_NODE},
+                                                  {max_fssource_cluster, ?DEFAULT_SOURCE_PER_CLUSTER}]),
     TcpOptions = [
         {kepalive, true},
         {nodelay, true},
@@ -236,6 +238,10 @@ handle_cast(start_fullsync,  State) ->
             lager:warning("Fullsync already in progress; ignoring start"),
             {noreply, State};
         false ->
+            MaxSource = app_helper:get_env(riak_repl, max_fssource_node, ?DEFAULT_SOURCE_PER_NODE),
+            MaxCluster = app_helper:get_env(riak_repl, max_fssource_cluster, ?DEFAULT_SOURCE_PER_CLUSTER),
+            lager:info("Starting fullsync (source) with max_fssource_node=~p and max_fssource_cluster=~p",
+                       [MaxSource, MaxCluster]),
             {ok, Ring} = riak_core_ring_manager:get_my_ring(),
             N = largest_n(Ring),
             Partitions = sort_partitions(Ring),

--- a/src/riak_repl2_fscoordinator_serv.erl
+++ b/src/riak_repl2_fscoordinator_serv.erl
@@ -98,6 +98,9 @@ start_service(Socket, Transport, Proto, _Args, Props) ->
 
 %% @hidden
 init({Socket, Transport, Proto, _Props}) ->
+    %% ensure that the ring has values for fullsync parameters or load them from the ring
+    %% into our application environment.
+    riak_repl_ring:reconcile_fs_params_with_ring([{max_fssink_node, ?DEFAULT_MAX_SINKS_NODE}]),
     Max = app_helper:get_env(riak_repl, max_fssink_node, ?DEFAULT_MAX_SINKS_NODE),
     lager:info("Starting fullsync coordinator server (sink) with max_fssink_node=~p", [Max]),
     SocketTag = riak_repl_util:generate_socket_tag("fs_coord_srv", Socket),

--- a/src/riak_repl2_fscoordinator_serv.erl
+++ b/src/riak_repl2_fscoordinator_serv.erl
@@ -98,9 +98,6 @@ start_service(Socket, Transport, Proto, _Args, Props) ->
 
 %% @hidden
 init({Socket, Transport, Proto, _Props}) ->
-    %% ensure that the ring has values for fullsync parameters or load them from the ring
-    %% into our application environment.
-    riak_repl_ring:reconcile_fs_params_with_ring([{max_fssink_node, ?DEFAULT_MAX_SINKS_NODE}]),
     Max = app_helper:get_env(riak_repl, max_fssink_node, ?DEFAULT_MAX_SINKS_NODE),
     lager:info("Starting fullsync coordinator server (sink) with max_fssink_node=~p", [Max]),
     SocketTag = riak_repl_util:generate_socket_tag("fs_coord_srv", Socket),

--- a/src/riak_repl2_fscoordinator_serv.erl
+++ b/src/riak_repl2_fscoordinator_serv.erl
@@ -98,6 +98,8 @@ start_service(Socket, Transport, Proto, _Args, Props) ->
 
 %% @hidden
 init({Socket, Transport, Proto, _Props}) ->
+    Max = app_helper:get_env(riak_repl, max_fssink_node, ?DEFAULT_MAX_SINKS_NODE),
+    lager:info("Starting fullsync coordinator server (sink) with max_fssink_node=~p", [Max]),
     SocketTag = riak_repl_util:generate_socket_tag("fs_coord_srv", Socket),
     lager:debug("Keeping stats for " ++ SocketTag),
     riak_core_tcp_mon:monitor(Socket, {?TCP_MON_FULLSYNC_APP, coordsrv,
@@ -181,6 +183,7 @@ handle_protocol_msg({whereis, Partition, ConnIP, _ConnPort}, State) ->
                     {location_down, Partition, Node}
             end;
         busy ->
+            lager:debug("node_reserver returned location_busy for partition ~p on node ~p", [Partition, Node]),
             {location_busy, Partition, Node};
         down ->
             {location_down, Partition, Node}

--- a/src/riak_repl_console.erl
+++ b/src/riak_repl_console.erl
@@ -26,8 +26,7 @@
 -export([modes/1, set_modes/1, get_modes/0,
          max_fssource_node/1,
          max_fssource_cluster/1,
-         max_fssink_node/1,
-         set_fullsync_param/2]).
+         max_fssink_node/1]).
 
 add_listener(Params) ->
     Ring = get_ring(),
@@ -437,11 +436,6 @@ modes(NewModes) ->
 %% becomes the fullsync coordinator will have the correct values. TODO: what happens when a
 %% machine bounces and becomes leader? It won't know the new value. Seems like we need a central
 %% place to hold these configuration values.
-set_fullsync_param(Param, Value) ->
-    Ring = get_ring(),
-    NewRing = riak_repl_ring:set_simple_param(Ring,Param,Value),
-    maybe_set_ring(Ring, NewRing).
-
 max_fssource_node([]) ->
     %% show the default so as not to confuse the user
     io:format("max_fssource_node value = ~p~n",
@@ -450,7 +444,6 @@ max_fssource_node([]) ->
 max_fssource_node([FSSourceNode]) ->
     NewVal = erlang:list_to_integer(FSSourceNode),
     riak_core_util:rpc_every_member(?MODULE, max_fssource_node, [NewVal], ?CONSOLE_RPC_TIMEOUT),
-    set_fullsync_param(max_fssource_node, NewVal),
     max_fssource_node([]),
     ok;
 max_fssource_node(NewVal) ->
@@ -464,7 +457,6 @@ max_fssource_cluster([]) ->
 max_fssource_cluster([FSSourceCluster]) ->
     NewVal = erlang:list_to_integer(FSSourceCluster),
     riak_core_util:rpc_every_member(?MODULE, max_fssource_cluster, [NewVal], ?CONSOLE_RPC_TIMEOUT),
-    set_fullsync_param(max_fssource_cluster, NewVal),
     max_fssource_cluster([]),
     ok;
 max_fssource_cluster(NewVal) ->
@@ -476,7 +468,6 @@ max_fssink_node([]) ->
 max_fssink_node([FSSinkNode]) ->
     NewVal = erlang:list_to_integer(FSSinkNode),
     riak_core_util:rpc_every_member(?MODULE, max_fssink_node, [NewVal], ?CONSOLE_RPC_TIMEOUT),
-    set_fullsync_param(max_fssink_node, NewVal),
     max_fssink_node([]),
     ok;
 max_fssink_node(NewVal) ->

--- a/src/riak_repl_console.erl
+++ b/src/riak_repl_console.erl
@@ -26,7 +26,8 @@
 -export([modes/1, set_modes/1, get_modes/0,
          max_fssource_node/1,
          max_fssource_cluster/1,
-         max_fssink_node/1]).
+         max_fssink_node/1,
+         set_fullsync_param/2]).
 
 add_listener(Params) ->
     Ring = get_ring(),
@@ -436,6 +437,11 @@ modes(NewModes) ->
 %% becomes the fullsync coordinator will have the correct values. TODO: what happens when a
 %% machine bounces and becomes leader? It won't know the new value. Seems like we need a central
 %% place to hold these configuration values.
+set_fullsync_param(Param, Value) ->
+    Ring = get_ring(),
+    NewRing = riak_repl_ring:set_simple_param(Ring,Param,Value),
+    maybe_set_ring(Ring, NewRing).
+
 max_fssource_node([]) ->
     %% show the default so as not to confuse the user
     io:format("max_fssource_node value = ~p~n",
@@ -444,6 +450,7 @@ max_fssource_node([]) ->
 max_fssource_node([FSSourceNode]) ->
     NewVal = erlang:list_to_integer(FSSourceNode),
     riak_core_util:rpc_every_member(?MODULE, max_fssource_node, [NewVal], ?CONSOLE_RPC_TIMEOUT),
+    set_fullsync_param(max_fssource_node, NewVal),
     max_fssource_node([]),
     ok;
 max_fssource_node(NewVal) ->
@@ -457,6 +464,7 @@ max_fssource_cluster([]) ->
 max_fssource_cluster([FSSourceCluster]) ->
     NewVal = erlang:list_to_integer(FSSourceCluster),
     riak_core_util:rpc_every_member(?MODULE, max_fssource_cluster, [NewVal], ?CONSOLE_RPC_TIMEOUT),
+    set_fullsync_param(max_fssource_cluster, NewVal),
     max_fssource_cluster([]),
     ok;
 max_fssource_cluster(NewVal) ->
@@ -468,6 +476,7 @@ max_fssink_node([]) ->
 max_fssink_node([FSSinkNode]) ->
     NewVal = erlang:list_to_integer(FSSinkNode),
     riak_core_util:rpc_every_member(?MODULE, max_fssink_node, [NewVal], ?CONSOLE_RPC_TIMEOUT),
+    set_fullsync_param(max_fssink_node, NewVal),
     max_fssink_node([]),
     ok;
 max_fssink_node(NewVal) ->

--- a/src/riak_repl_ring.erl
+++ b/src/riak_repl_ring.erl
@@ -34,7 +34,10 @@
          set_modes/2,
          get_modes/1,
          compose/2,
-         multicompose/1
+         multicompose/1,
+         get_simple_param/2,
+         set_simple_param/3,
+         reconcile_fs_params_with_ring/1
          ]).
 
 -ifdef(TEST).
@@ -420,6 +423,55 @@ get_modes(Ring) ->
         error ->
             %% default to mixed modes
             [mode_repl12, mode_repl13]
+    end.
+
+%% Get the ring and iterate over the passed Params, which should be things like
+%% max_fssource_cluster, max_fssink_node, etc. But they can be any replication
+%% parameters really. Each Param is a tuple of {Name, Value} where names are atoms.
+%% This function will check to see if that param is defined in the ring already;
+%% if it is, we set our application environment var to mirror the ring value. If
+%% it isn't set, we set it from our app env using Value as the default.
+%%
+%% So, the result is that the ring wins if it has a value, but gets updated if not.
+reconcile_fs_params_with_ring(Params) ->
+    {ok, Ring0} = riak_core_ring_manager:get_my_ring(),
+    Ring1 = ensure_config(Ring0),
+    lists:foldl(fun({Param, Default}, Ring) ->
+                        case get_simple_param(Param, Ring) of
+                            undefined ->
+                                Max = app_helper:get_env(riak_repl, Param, Default),
+                                F = fun(InRing, ReplConfig) ->
+                                            {new_ring, riak_repl_ring:set_repl_config(InRing, ReplConfig)}
+                                    end,
+                                R = set_simple_param(Ring,Param,Max),
+                                RC = riak_repl_ring:get_repl_config(R),
+                                {ok, NewRing} = riak_core_ring_manager:ring_trans(F, RC),
+                                NewRing;
+                            Value ->
+                                application:set_env(riak_repl, Param, Value),
+                                Ring
+                        end
+                end,
+                Ring1,
+                Params).
+
+%% @doc Update a simple replication parameter in the ring
+set_simple_param(Ring,Param,Value) ->
+    RC = get_repl_config(Ring),
+    %% just overwrite whatever was there before
+    NewRing = riak_core_ring:update_meta(
+                ?MODULE,
+                dict:store(Param, Value, RC),
+                Ring),
+    NewRing.
+
+%% @doc Return a simple replication parameter from the ring or undefined.
+get_simple_param(Param, Ring) ->
+    RC = get_repl_config(Ring),
+    case dict:find(Param, RC) of
+        {ok, Value} -> Value;
+        error ->
+            undefined
     end.
 
 %% Function composition


### PR DESCRIPTION
The reason that fullsync was not maxing out it's connections was that the console commands to change the maximums (fssource, fssink, cluster) was only changing the application env on the node where the command was issued.

The solution used here was to make an rpc multi-call (using a riak_core_utility function) to set the app env value on all nodes of the riak cluster. Then, running a fullsync, I observed that the coordinator would correctly schedule multiple syncs per node, according to the maximums set.

While in there, I also added a couple of info and debug statements to make diagnosis of future problems easier. It might also be nice to print these maximums in the repl-status, but that's for another day.

One potential problem I see here is when the maximums are altered via the console, and then a node joins the system; the new node will not have the new value. This is a problem because new nodes often become the coordinator. It seems unreasonable for customers to have to reset the maximums after every node bounce. I don't have a good answer for this yet.
