### PR TITLE
Gracefully handle partition conflicts during fullsync

### DIFF
--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -615,15 +615,30 @@ remote_node_available({_Partition, _, undefined}, _Busies) ->
 remote_node_available({_Partition, _, RemoteNode}, Busies) ->
     not sets:is_element(RemoteNode, Busies).
 
-start_fssource({Partition,_,_} = PartitionVal, Ip, Port, State) ->
+start_fssource(Partition2={Partition,_,_} = PartitionVal, Ip, Port, State) ->
     #state{owners = Owners} = State,
     LocalNode = proplists:get_value(Partition, Owners),
     lager:info("starting fssource for ~p on ~p to ~p", [Partition, LocalNode,
             Ip]),
-    {ok, Pid} = riak_repl2_fssource_sup:enable(LocalNode, Partition, {Ip, Port}),
-    link(Pid),
-    Running = orddict:store(Pid, PartitionVal, State#state.running_sources),
-    State#state{running_sources = Running}.
+    case riak_repl2_fssource_sup:enable(LocalNode, Partition, {Ip, Port}) of
+        {ok, Pid} ->
+            link(Pid),
+            Running = orddict:store(Pid, PartitionVal, State#state.running_sources),
+            State#state{running_sources = Running};
+        {error, Reason} ->
+            case Reason of
+                {already_started, OtherPid} ->
+                    lager:notice("A fullsync for partition ~p is already in"
+                        " progress for ~p", [Partition,
+                            riak_repl2_fssource:cluster_name(OtherPid)]);
+                _ ->
+                    lager:error("Failed to start fullsync for partition ~p :"
+                        " ~p", [Partition, Reason])
+            end,
+            PQueue = queue:in(Partition2, State#state.partition_queue),
+            %% Micah says don't mess with the busies here...
+            State#state{partition_queue=PQueue}
+    end.
 
 largest_n(Ring) ->
     Defaults = app_helper:get_env(riak_core, default_bucket_props, []),

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -635,8 +635,9 @@ start_fssource(Partition2={Partition,_,_} = PartitionVal, Ip, Port, State) ->
                     lager:error("Failed to start fullsync for partition ~p :"
                         " ~p", [Partition, Reason])
             end,
+            #state{transport = Transport, socket = Socket} = State,
+            Transport:send(Socket, term_to_binary({unreserve, Partition})),
             PQueue = queue:in(Partition2, State#state.partition_queue),
-            %% Micah says don't mess with the busies here...
             State#state{partition_queue=PQueue}
     end.
 

--- a/src/riak_repl2_fscoordinator_serv.erl
+++ b/src/riak_repl2_fscoordinator_serv.erl
@@ -189,6 +189,10 @@ handle_protocol_msg({whereis, Partition, ConnIP, _ConnPort}, State) ->
             {location_down, Partition, Node}
     end,
     Transport:send(Socket, term_to_binary(Reply)),
+    State;
+
+handle_protocol_msg({unreserve, Partition}, State) ->
+    riak_repl2_fs_node_reserver:unreserve(Partition),
     State.
 
 get_partition_node(Partition) ->

--- a/src/riak_repl2_fssource.erl
+++ b/src/riak_repl2_fssource.erl
@@ -4,7 +4,7 @@
 -behaviour(gen_server).
 %% API
 -export([start_link/2, connected/6, connect_failed/3, start_fullsync/1,
-         stop_fullsync/1, legacy_status/2]).
+         stop_fullsync/1, cluster_name/1, legacy_status/2]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -38,6 +38,10 @@ start_fullsync(Pid) ->
 
 stop_fullsync(Pid) ->
     gen_server:call(Pid, stop_fullsync).
+
+%% get the cluster name
+cluster_name(Pid) ->
+    gen_server:call(Pid, cluster_name).
 
 legacy_status(Pid, Timeout) ->
     gen_server:call(Pid, legacy_status, Timeout).
@@ -105,6 +109,14 @@ handle_call(legacy_status, _From, State=#state{fullsync_worker=FSW,
             {socket, SocketStats}
         ],
     {reply, Desc ++ Res, State};
+handle_call(cluster_name, _From, State) ->
+    Name = case State#state.cluster of
+        undefined ->
+            {connecting, State#state.ip};
+        ClusterName ->
+            ClusterName
+    end,
+    {reply, Name, State};
 handle_call(_Msg, _From, State) ->
     {reply, ok, State}.
 


### PR DESCRIPTION
The fssource_sup uses the partition in the childspec as the ID, so 2
fssources can't run for a single partition. However we weren't catching
a fssource startup failure, which was crashing the coordinator.
