### PR TITLE
add per-cluster fullsync scheduling

### DIFF
--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -47,7 +47,9 @@
     dirty_nodes = ordsets:new(),          % these nodes should run fullsync
     dirty_nodes_during_fs = ordsets:new(), % these nodes reported realtime errors
                                           % during an already running fullsync
-    fullsyncs_completed = 0
+    fullsyncs_completed = 0,
+    fullsync_start_time = undefined,
+    last_fullsync_duration = undefined
 }).
 
 %% ------------------------------------------------------------------
@@ -204,6 +206,11 @@ handle_call(status, _From, State = #state{socket=Socket}) ->
     SourceStats = gather_source_stats(State#state.running_sources),
     SocketStats = riak_core_tcp_mon:format_socket_stats(
         riak_core_tcp_mon:socket_status(Socket), []),
+    StartTime =
+        case State#state.fullsync_start_time of
+            undefined -> undefined;
+            N -> calendar:gregorian_seconds_to_datetime(State#state.fullsync_start_time)
+        end,
     SelfStats = [
         {cluster, State#state.other_cluster},
         {queued, queue:len(State#state.partition_queue)},
@@ -214,6 +221,9 @@ handle_call(status, _From, State = #state{socket=Socket}) ->
         {busy_nodes, sets:size(State#state.busy_nodes)},
         {running_stats, SourceStats},
         {socket, SocketStats},
+        {fullsyncs_completed, State#state.fullsyncs_completed},
+        {last_fullsync_started, StartTime},
+        {last_fullsync_duration, State#state.last_fullsync_duration},
         {fullsync_suggested,
             nodeset_to_string_list(State#state.dirty_nodes)},
         {fullsync_suggested_during_fs,
@@ -295,7 +305,8 @@ handle_cast(start_fullsync,  State) ->
                 owners = riak_core_ring:all_owners(Ring),
                 partition_queue = queue:from_list(Partitions),
                 successful_exits = 0,
-                error_exits = 0
+                error_exits = 0,
+                fullsync_start_time = riak_core_util:moment()
             },
             State3 = start_up_reqs(State2),
             {noreply, State3}
@@ -352,11 +363,14 @@ handle_info({'EXIT', Pid, Cause}, State) when Cause =:= normal; Cause =:= shutdo
                     % otherwise, don't do anything
                     State3 = notify_rt_dirty_nodes(State),
                     TotalFullsyncs = State#state.fullsyncs_completed + 1,
-
+                    Finish = riak_core_util:moment(),
+                    ElapsedSeconds = Finish - State#state.fullsync_start_time,
                     riak_repl_util:schedule_cluster_fullsync(State#state.other_cluster),
                     {noreply, State3#state{running_sources = Running,
                                            busy_nodes = NewBusies,
-                                           fullsyncs_completed = TotalFullsyncs
+                                           fullsyncs_completed = TotalFullsyncs,
+                                           fullsync_start_time = undefined,
+                                           last_fullsync_duration=ElapsedSeconds
                                           }};
                 _ ->
                     % there's something waiting for a response.
@@ -504,7 +518,7 @@ handle_socket_msg({location_down, Partition, _Node}, #state{whereis_waiting=Wait
     end.
 
 % try our best to reach maximum capacity by sending as many whereis requests
-% as we can under the condition that we don't overload our local nodes or 
+% as we can under the condition that we don't overload our local nodes or
 % remote nodes.
 start_up_reqs(State) ->
     Max = app_helper:get_env(riak_repl, max_fssource_cluster, ?DEFAULT_SOURCE_PER_CLUSTER),
@@ -545,7 +559,7 @@ send_next_whereis_req(State) ->
                     {defer, State#state{partition_queue = Queue}};
 
                 undefined ->
-                    % something may have gone wrong, but we have outstanding 
+                    % something may have gone wrong, but we have outstanding
                     % whereis requests or running sources, so we can wait for
                     % one of those to finish and try again
                     {defer, State#state{partition_queue = Queue}};
@@ -748,5 +762,3 @@ notify_rt_dirty_nodes(State = #state{dirty_nodes = DirtyNodes,
 
 nodeset_to_string_list(Set) ->
     string:join([erlang:atom_to_list(V) || V <- ordsets:to_list(Set)],",").
-
-

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -620,10 +620,9 @@ schedule_cluster_fullsync(Cluster, Pid) ->
                     start_fullsync_timer(Pid, FullsyncIvalMins),
                     ok
             end;
-        {ok, Tuple} when is_tuple(Tuple) ->
-            {_Cluster, FullsyncIvalMins} = Tuple,
-            start_fullsync_timer(Pid, FullsyncIvalMins),
-            ok;
+        {ok, {Cluster, FullsyncIvalMins}} ->
+            start_fullsync_timer(Pid, FullsyncIvalMins);
+        {ok, Tuple} when is_tuple(Tuple) -> ok;
         {ok, FullsyncIvalMins} ->
             %% this will affect ALL clusters that have fullsync enabled
             start_fullsync_timer(Pid, FullsyncIvalMins)

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -624,10 +624,11 @@ schedule_cluster_fullsync(Cluster, Pid) ->
             end;
         {ok, {Cluster, FullsyncIvalMins}} ->
             start_fullsync_timer(Pid, FullsyncIvalMins, Cluster);
-        {ok, Tuple} when is_tuple(Tuple) -> ok;
-        {ok, FullsyncIvalMins} ->
+        {ok, FullsyncIvalMins} when not is_tuple(FullsyncIvalMins) ->
             %% this will affect ALL clusters that have fullsync enabled
-            start_fullsync_timer(Pid, FullsyncIvalMins, Cluster)
+            start_fullsync_timer(Pid, FullsyncIvalMins, Cluster);
+        _ ->
+            ok
     end.
 
 %% Work out the elapsed time in seconds, rounded to centiseconds.

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -597,8 +597,10 @@ schedule_fullsync(Pid) ->
     end.
 
 
-start_fullsync_timer(Pid, FullsyncIvalMins) ->
+start_fullsync_timer(Pid, FullsyncIvalMins, Cluster) ->
     FullsyncIval = timer:minutes(FullsyncIvalMins),
+    lager:info("Fullsync for ~p scheduled in ~p minutes",
+               [Cluster, FullsyncIvalMins]),
     spawn(fun() ->
                 timer:sleep(FullsyncIval),
                 gen_server:cast(Pid, start_fullsync)
@@ -617,15 +619,15 @@ schedule_cluster_fullsync(Cluster, Pid) ->
             case proplists:lookup(Cluster, List) of
                 none -> ok;
                 {_, FullsyncIvalMins} ->
-                    start_fullsync_timer(Pid, FullsyncIvalMins),
+                    start_fullsync_timer(Pid, FullsyncIvalMins, Cluster),
                     ok
             end;
         {ok, {Cluster, FullsyncIvalMins}} ->
-            start_fullsync_timer(Pid, FullsyncIvalMins);
+            start_fullsync_timer(Pid, FullsyncIvalMins, Cluster);
         {ok, Tuple} when is_tuple(Tuple) -> ok;
         {ok, FullsyncIvalMins} ->
             %% this will affect ALL clusters that have fullsync enabled
-            start_fullsync_timer(Pid, FullsyncIvalMins)
+            start_fullsync_timer(Pid, FullsyncIvalMins, Cluster)
     end.
 
 %% Work out the elapsed time in seconds, rounded to centiseconds.


### PR DESCRIPTION
example:
{riak_repl, [
  {data_root, "./data/riak_repl/"},
  % clusters foo + bar have difference intervals (in minutes)
  {fullsync_interval, [{"bar", 1}, {"foo", 2}]}
]}
