### PR TITLE
match on # of partitions left in json stats

### DIFF
--- a/src/riak_repl_wm_stats.erl
+++ b/src/riak_repl_wm_stats.erl
@@ -33,6 +33,9 @@
         ]).
 
 -include_lib("webmachine/include/webmachine.hrl").
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
 
 -record(ctx, {}).
 
@@ -127,3 +130,17 @@ jsonify_stats([{S,{A,B,C,D},Port}|T], Acc) when is_atom(S) andalso is_integer(Po
 jsonify_stats([{K,V}|T], Acc) ->
     jsonify_stats(T, [{K,V}|Acc]).
 
+-ifdef(TEST).
+
+jsonify_stats_test_() ->
+    [{"fullsync partitions left", fun() ->
+      Stats = [{fullsync,63,left},
+        {partition,251195593916248939066258330623111144003363405824},
+        {partition_start,0.88},{stage_start,0.88}],
+      Expected = [{"partitions_left",63},
+        {partition,251195593916248939066258330623111144003363405824},
+        {partition_start,0.88}, {stage_start,0.88}],
+      ?assertEqual(Expected, jsonify_stats(Stats, []))
+    end}].
+
+-endif.

--- a/src/riak_repl_wm_stats.erl
+++ b/src/riak_repl_wm_stats.erl
@@ -109,6 +109,8 @@ get_stats() ->
 
 jsonify_stats([], Acc) ->
     lists:flatten(lists:reverse(Acc));
+jsonify_stats([{fullsync, Num, _Left}|T], Acc) ->
+    jsonify_stats(T, [{"partitions_left", Num} | Acc]);
 jsonify_stats([{K,V}|T], Acc) when is_pid(V) ->
     jsonify_stats(T, [{K,list_to_binary(riak_repl_util:safe_pid_to_list(V))}|Acc]);
 jsonify_stats([{K,V=[{_,_}|_Tl]}|T], Acc) when is_list(V) ->


### PR DESCRIPTION
When repl stats would contain {fullsync, NumberOfPartitions, left}, jsonify_stats would blow up due to invalid pattern matching.
fixes https://github.com/basho/riak_repl/issues/173

Public issue @ https://github.com/basho/riak_ee-issues/issues/1
