### PR TITLE
Merge Intergation with rt_dirty fixes back to master

### DIFF
--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -140,7 +140,7 @@ node_dirty(Node) ->
     %%  2) running - don't clear these out when fullsync finishes
     case riak_core_cluster_mgr:get_leader() of
         undefined ->
-            lager:info("rt_dirty status updated locally, but not registered with leader");
+            lager:debug("rt_dirty status updated locally, but not registered with leader");
         Leader ->
             Fullsyncs = riak_repl2_fscoordinator_sup:started(Leader),
             [riak_repl2_fscoordinator:node_dirty(Pid, Node) ||

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -138,10 +138,14 @@ node_dirty(Node) ->
     %%  1) non-running - clear these out when fullsync finishes, and the node
     %%  doesn't appear in list 2
     %%  2) running - don't clear these out when fullsync finishes
-    Leader = riak_core_cluster_mgr:get_leader(),
-    Fullsyncs = riak_repl2_fscoordinator_sup:started(Leader),
-     [riak_repl2_fscoordinator:node_dirty(Pid, Node) ||
-        {_, Pid} <- Fullsyncs].
+    case riak_core_cluster_mgr:get_leader() of
+        undefined ->
+            lager:info("rt_dirty status updated locally, but not registered with leader");
+        Leader ->
+            Fullsyncs = riak_repl2_fscoordinator_sup:started(Leader),
+            [riak_repl2_fscoordinator:node_dirty(Pid, Node) ||
+                {_, Pid} <- Fullsyncs]
+    end.
 
 node_dirty(Pid, Node) ->
     gen_server:call(Pid, {node_dirty, Node}, infinity),

--- a/src/riak_repl_stats.erl
+++ b/src/riak_repl_stats.erl
@@ -128,10 +128,22 @@ rt_dirty() ->
         true ->
             %% the coordinator might not be up yet
             lager:debug("Notifying coordinator of rt_dirty"),
-            riak_repl2_fscoordinator:node_dirty(node()),
+            % notify the coordinator at a later time, hopefully
+            % after the fscoordinator is started. If it's not, then just
+            % log a warning.
+            spawn(fun() ->
+                      timer:sleep(30000),
+                      try
+                        riak_repl2_fscoordinator:node_dirty(node())
+                      catch
+                        _:_ ->
+                         lager:warning("Failed to notify coordinator of rt_dirty status")
+                      end
+            end),
             ok;
         false -> ok
     end.
+
 
 get_stats() ->
     case riak_core_stat_cache:get_stats(?APP) of

--- a/src/riak_repl_stats.erl
+++ b/src/riak_repl_stats.erl
@@ -137,7 +137,7 @@ rt_dirty() ->
                         riak_repl2_fscoordinator:node_dirty(node())
                       catch
                         _:_ ->
-                         lager:warning("Failed to notify coordinator of rt_dirty status")
+                         lager:debug("Failed to notify coordinator of rt_dirty status")
                       end
             end),
             ok;


### PR DESCRIPTION
@metadave made fixes for rt_dirty notifications to the coordinator so that it wouldn't puke if the coordinator wasn't alive at the time. Also, a change to avoid crashing stats when there is no leader. These need to get merged so that the replication2 riak_test can pass as well.

That work was on:
https://github.com/basho/riak_repl/pull/177
