### PR TITLE
Replication using binary riak object formats

### DIFF
--- a/include/riak_repl.hrl
+++ b/include/riak_repl.hrl
@@ -43,6 +43,15 @@
 -type(repl_node_sites() :: {node(), [{repl_sitename(), pid()}]}).
 -type(ring() :: tuple()).
 -type(repl_config() :: dict()|undefined).
+%% wire_version() is an atom that defines which wire format a binary
+%% encoding of one of more riak objects is packaged into. For details of
+%% the to_wire() and from_wire() operations, see riak_repl_util.erl.
+%% Also see analagous binary_version() in riak_object, which is carried
+%% inside the wire format in "BinObj". w0 implies v0. w1 imples v1.
+-type(wire_version() :: w0   %% simple term_to_binary() legacy encoding
+                      | w1). %% <<?MAGIC:8/integer, 1:8/integer,
+                             %% BLen:32/integer, B:BLen/binary,
+                             %% KLen:32/integer, K:KLen/binary, BinObj/binary>>.
 
 -record(peer_info, {
           riak_version :: string(), %% version number of the riak_kv app

--- a/src/riak_repl2_fssink.erl
+++ b/src/riak_repl2_fssink.erl
@@ -23,7 +23,8 @@ start_link(Socket, Transport, Proto, Props) ->
 
 %% Register with service manager
 register_service() ->
-    ProtoPrefs = {fullsync,[{1,0}]},
+    %% use 1,1 proto for new binary object
+    ProtoPrefs = {fullsync,[{1,1}]},
     TcpOptions = [{keepalive, true}, % find out if connection is dead, this end doesn't send
                   {packet, 4},
                   {active, false},
@@ -44,7 +45,10 @@ legacy_status(Pid, Timeout) ->
 
 %% gen server
 
-init([Socket, Transport, _Proto, Props]) ->
+init([Socket, Transport, OKProto, Props]) ->
+    %% TODO: remove annoying 'ok' from service mgr proto
+    {ok, Proto} = OKProto,
+    Ver = deduce_wire_version_from_proto(Proto),
     SocketTag = riak_repl_util:generate_socket_tag("fs_sink", Socket),
     lager:debug("Keeping stats for " ++ SocketTag),
     riak_core_tcp_mon:monitor(Socket, {?TCP_MON_FULLSYNC_APP, sink,
@@ -57,7 +61,18 @@ init([Socket, Transport, _Proto, Props]) ->
     {ok, FullsyncWorker} = riak_repl_keylist_client:start_link(Cluster,
         Transport, Socket, WorkDir),
     {ok, #state{cluster=Cluster, transport=Transport, socket=Socket,
-            fullsync_worker=FullsyncWorker, work_dir=WorkDir, Ver=w0}}.
+            fullsync_worker=FullsyncWorker, work_dir=WorkDir, ver=Ver}}.
+
+deduce_wire_version_from_proto({_Proto,{CommonMajor,CMinor},{CommonMajor,HMinor}}) ->
+    %% if common protocols are both >= 1.1, then we know the new binary wire protocol
+    case CommonMajor >= 1 andalso CMinor >= 1 andalso HMinor >= 1 of
+        true ->
+            %% new sink. yay! new wire protocol supported.
+            w1;
+        _False ->
+            %% old sink mandates old wire protocol only.
+            w0
+    end.
 
 handle_call(legacy_status, _From, State=#state{fullsync_worker=FSW,
                                                socket=Socket}) ->
@@ -99,16 +114,11 @@ handle_info({ssl_error, _Socket, Reason}, State) ->
 handle_info({Proto, Socket, Data},
         State=#state{socket=Socket,transport=Transport}) when Proto==tcp; Proto==ssl ->
     Transport:setopts(Socket, [{active, once}]),
-    Msg = binary_to_term(Data),
-    V = State#state.ver,
-    case {V,Msg} of
-        {w0, {fs_diff_obj, Obj}} ->
-            riak_repl_util:do_repl_put(Obj);
-        {_V, {fs_diff_obj, BObj}} ->
-            Obj = riak_repl_util:from_wire(BObj),
-            riak_repl_util:do_repl_put(Obj);
-        {_V,_} ->
-            gen_fsm:send_event(State#state.fullsync_worker, Msg)
+    case decode_obj_msg(Data) of
+        {fs_diff_obj, RObj} ->
+            riak_repl_util:do_repl_put(RObj);
+        Other ->
+            gen_fsm:send_event(State#state.fullsync_worker, Other)
     end,
     {noreply, State};
 handle_info(init_ack, State=#state{socket=Socket, transport=Transport}) ->
@@ -116,6 +126,18 @@ handle_info(init_ack, State=#state{socket=Socket, transport=Transport}) ->
     {noreply, State};
 handle_info(_Msg, State) ->
     {noreply, State}.
+
+decode_obj_msg(Data) ->
+    Msg = binary_to_term(Data),
+    case Msg of
+        {fs_diff_obj, BObj} when is_binary(BObj) ->
+            RObj = riak_repl_util:from_wire(BObj),
+            {fs_diff_obj, RObj};
+        {fs_diff_obj, _RObj} ->
+            Msg;
+        Other ->
+            Other
+    end.
 
 terminate(_Reason, #state{fullsync_worker=FSW, work_dir=WorkDir}) ->
     case is_pid(FSW) of

--- a/src/riak_repl2_fssink.erl
+++ b/src/riak_repl2_fssink.erl
@@ -48,7 +48,7 @@ legacy_status(Pid, Timeout) ->
 init([Socket, Transport, OKProto, Props]) ->
     %% TODO: remove annoying 'ok' from service mgr proto
     {ok, Proto} = OKProto,
-    Ver = deduce_wire_version_from_proto(Proto),
+    Ver = riak_repl_util:deduce_wire_version_from_proto(Proto),
     SocketTag = riak_repl_util:generate_socket_tag("fs_sink", Socket),
     lager:debug("Keeping stats for " ++ SocketTag),
     riak_core_tcp_mon:monitor(Socket, {?TCP_MON_FULLSYNC_APP, sink,
@@ -62,17 +62,6 @@ init([Socket, Transport, OKProto, Props]) ->
         Transport, Socket, WorkDir),
     {ok, #state{cluster=Cluster, transport=Transport, socket=Socket,
             fullsync_worker=FullsyncWorker, work_dir=WorkDir, ver=Ver}}.
-
-deduce_wire_version_from_proto({_Proto,{CommonMajor,CMinor},{CommonMajor,HMinor}}) ->
-    %% if common protocols are both >= 1.1, then we know the new binary wire protocol
-    case CommonMajor >= 1 andalso CMinor >= 1 andalso HMinor >= 1 of
-        true ->
-            %% new sink. yay! new wire protocol supported.
-            w1;
-        _False ->
-            %% old sink mandates old wire protocol only.
-            w0
-    end.
 
 handle_call(legacy_status, _From, State=#state{fullsync_worker=FSW,
                                                socket=Socket}) ->

--- a/src/riak_repl2_fssource.erl
+++ b/src/riak_repl2_fssource.erl
@@ -18,7 +18,8 @@
         cluster,
         connection_ref,
         fullsync_worker,
-        work_dir
+        work_dir,
+        ver
     }).
 
 start_link(Partition, IP) ->
@@ -53,7 +54,7 @@ init([Partition, IP]) ->
                   {nodelay, true},
                   {packet, 4},
                   {active, false}],
-    ClientSpec = {{fullsync,[{1,0}]}, {TcpOptions, ?MODULE, self()}},
+    ClientSpec = {{fullsync,[{1,1}]}, {TcpOptions, ?MODULE, self()}},
 
     %% TODO: check for bad remote name
     lager:info("connecting to remote ~p", [IP]),
@@ -66,8 +67,20 @@ init([Partition, IP]) ->
             {stop, Reason}
     end.
 
-handle_call({connected, Socket, Transport, _Endpoint, _Proto, Props}, _From,
+deduce_wire_version_from_proto({_Proto,{CommonMajor,CMinor},{CommonMajor,HMinor}}) ->
+    %% if common protocols are both >= 1.1, then we know the new binary wire protocol
+    case CommonMajor >= 1 andalso CMinor >= 1 andalso HMinor >= 1 of
+        true ->
+            %% new sink. yay! new wire protocol supported.
+            w1;
+        _False ->
+            %% old sink mandates old wire protocol only.
+            w0
+    end.
+
+handle_call({connected, Socket, Transport, _Endpoint, Proto, Props}, _From,
         State=#state{ip=IP, partition=Partition}) ->
+    Ver = deduce_wire_version_from_proto(Proto),
     Cluster = proplists:get_value(clustername, Props),
     lager:info("fullsync connection to ~p for ~p",[IP, Partition]),
 
@@ -85,7 +98,7 @@ handle_call({connected, Socket, Transport, _Endpoint, _Proto, Props}, _From,
     riak_repl_keylist_server:start_fullsync(FullsyncWorker, [Partition]),
     {reply, ok, State#state{transport=Transport, socket=Socket,
             cluster=Cluster,
-            fullsync_worker=FullsyncWorker, work_dir=WorkDir}};
+            fullsync_worker=FullsyncWorker, work_dir=WorkDir, ver=Ver}};
 handle_call(start_fullsync, _From, State=#state{fullsync_worker=FSW}) ->
     riak_repl_keylist_server:start_fullsync(FSW),
     {reply, ok, State};

--- a/src/riak_repl2_fssource.erl
+++ b/src/riak_repl2_fssource.erl
@@ -67,20 +67,10 @@ init([Partition, IP]) ->
             {stop, Reason}
     end.
 
-deduce_wire_version_from_proto({_Proto,{CommonMajor,CMinor},{CommonMajor,HMinor}}) ->
-    %% if common protocols are both >= 1.1, then we know the new binary wire protocol
-    case CommonMajor >= 1 andalso CMinor >= 1 andalso HMinor >= 1 of
-        true ->
-            %% new sink. yay! new wire protocol supported.
-            w1;
-        _False ->
-            %% old sink mandates old wire protocol only.
-            w0
-    end.
-
 handle_call({connected, Socket, Transport, _Endpoint, Proto, Props}, _From,
         State=#state{ip=IP, partition=Partition}) ->
-    Ver = deduce_wire_version_from_proto(Proto),
+    Ver = riak_repl_util:deduce_wire_version_from_proto(Proto),
+    lager:debug("Negotiated ~p wire format", [Ver]),
     Cluster = proplists:get_value(clustername, Props),
     lager:info("fullsync connection to ~p for ~p",[IP, Partition]),
 

--- a/src/riak_repl2_rt.erl
+++ b/src/riak_repl2_rt.erl
@@ -144,10 +144,11 @@ postcommit(RObj) ->
             %% map riak objects to their wire format, according to the highest
             %% commonly supported object format between the two clusters.
             Ver = v0,
-            BinObjs = case Ver of
-                          v0 -> riak_repl_util:to_wire(w0, Objects);
-                          _V -> riak_repl_util:to_wire(w1, Objects)
-                      end,
+            W = case Ver of
+                    v0 -> w0;
+                    _V -> w1
+                end,
+            BinObjs = riak_repl_util:to_wire(W, Objects),
             %% try the proxy first, avoids race conditions with unregister()
             %% during shutdown
             case whereis(riak_repl2_rtq_proxy) of

--- a/src/riak_repl2_rt.erl
+++ b/src/riak_repl2_rt.erl
@@ -145,10 +145,8 @@ postcommit(RObj) ->
             %% commonly supported object format between the two clusters.
             Ver = v0,
             BinObjs = case Ver of
-                          v0 -> term_to_binary(Objects);
-                          _V ->
-                              BObjs = [riak_object:to_binary(Ver,O) || O <- Objects],
-                              term_to_binary(BObjs)
+                          v0 -> riak_repl_util:to_wire(w0, Objects);
+                          _V -> riak_repl_util:to_wire(w1, Objects)
                       end,
             %% try the proxy first, avoids race conditions with unregister()
             %% during shutdown

--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -153,8 +153,8 @@ handle_call({connected, Socket, Transport, EndPoint, Proto}, _From,
     %% before turning it active (e.g. handoff of riak_core_service_mgr to handler
     case Transport:send(Socket, <<>>) of
         ok ->
-            Ver = deduce_wire_version_from_proto(Proto),
-            lager:info("Negotiated ~p wire format", [Ver]),
+            Ver = riak_repl_util:deduce_wire_version_from_proto(Proto),
+            lager:debug("Negotiated ~p wire format", [Ver]),
             {ok, HelperPid} = riak_repl2_rtsource_helper:start_link(Remote,
                                                                     Transport, Socket,
                                                                     Ver),
@@ -171,17 +171,6 @@ handle_call({connected, Socket, Transport, EndPoint, Proto}, _From,
                                     helper_pid = HelperPid}};
         ER ->
             {reply, ER, State}
-    end.
-
-deduce_wire_version_from_proto({_Proto,{CommonMajor,CMinor},{CommonMajor,HMinor}}) ->
-    %% if common protocols are both >= 1.1, then we know the new binary wire protocol
-    case CommonMajor >= 1 andalso CMinor >= 1 andalso HMinor >= 1 of
-        true ->
-            %% new sink. yay! new wire protocol supported.
-            w1;
-        _False ->
-            %% old sink mandates old wire protocol only.
-            w0
     end.
 
 %% Connection manager failed to make connection

--- a/src/riak_repl2_rtsource_helper.erl
+++ b/src/riak_repl2_rtsource_helper.erl
@@ -8,7 +8,7 @@
 
 -behaviour(gen_server).
 %% API
--export([start_link/3,
+-export([start_link/4,
          stop/1,
          status/1, status/2]).
 
@@ -27,8 +27,8 @@
                 sent_seq,   % last sequence sent
                 objects = 0}).   % number of objects sent - really number of pulls as could be multiobj
 
-start_link(Remote, Transport, Socket) ->
-    gen_server:start_link(?MODULE, [Remote, Transport, Socket], []).
+start_link(Remote, Transport, Socket, Ver) ->
+    gen_server:start_link(?MODULE, [Remote, Transport, Socket, Ver], []).
 
 stop(Pid) ->
     gen_server:call(Pid, stop).
@@ -39,12 +39,12 @@ status(Pid) ->
 status(Pid, Timeout) ->
     gen_server:call(Pid, status, Timeout).
 
-init([Remote, Transport, Socket]) ->
+init([Remote, Transport, Socket, Ver]) ->
     riak_repl2_rtq:register(Remote), % re-register to reset stale deliverfun
     Me = self(),
     Deliver = fun(Result) -> gen_server:call(Me, {pull, Result}) end,
     State = #state{remote = Remote, transport = Transport, 
-                   socket = Socket, deliver_fun = Deliver},
+                   socket = Socket, deliver_fun = Deliver, ver = Ver},
     async_pull(State),
     {ok, State}.
 

--- a/src/riak_repl_fullsync_helper.erl
+++ b/src/riak_repl_fullsync_helper.erl
@@ -364,7 +364,9 @@ unpack_key(K) ->
 %% Hash an object, making sure the vclock is in sorted order
 %% as it varies depending on whether it has been pruned or not
 hash_object(RObjBin) ->
-    RObj = binary_to_term(RObjBin),
+    %% Cindy: Why Santa? Why don't we just use term_to_binary() any more?
+    %% Santa: Remember, Cindy, that we support multiple object formats now.
+    RObj = riak_object:from_binary(RObjBin), % converts from all r_object versions
     Vclock = riak_object:vclock(RObj),
     UpdObj = riak_object:set_vclock(RObj, lists:sort(Vclock)),
     erlang:phash2(term_to_binary(UpdObj)).

--- a/src/riak_repl_fullsync_helper.erl
+++ b/src/riak_repl_fullsync_helper.erl
@@ -365,7 +365,7 @@ unpack_key(K) ->
 %% as it varies depending on whether it has been pruned or not
 hash_object(RObjBin) ->
     %% Cindy: Why Santa? Why don't we just use term_to_binary() any more?
-    %% Santa: Remember, Cindy, that we support multiple object formats now.
+    %% Santa: Because we support multiple object formats now.
     RObj = riak_object:from_binary(RObjBin), % converts from all r_object versions
     Vclock = riak_object:vclock(RObj),
     UpdObj = riak_object:set_vclock(RObj, lists:sort(Vclock)),

--- a/src/riak_repl_fullsync_worker.erl
+++ b/src/riak_repl_fullsync_worker.erl
@@ -34,15 +34,6 @@ do_get(Pid, Bucket, Key, Transport, Socket, Pool, Partition, Ver) ->
 init([]) ->
     {ok, #state{}}.
 
-encode_obj_msg(V, {fs_diff_obj, RObj}) ->
-    case V of
-        w0 ->
-            term_to_binary({fs_diff_obj, RObj});
-        w1 ->
-            BObj = riak_repl_util:to_wire(w1,RObj),
-            term_to_binary({fs_diff_obj, BObj})
-    end.
-
 handle_call({get, B, K, Transport, Socket, Pool, Ver}, From, State) ->
     %% unblock the caller
     gen_server:reply(From, ok),
@@ -60,10 +51,12 @@ handle_call({get, B, K, Transport, Socket, Pool, Ver}, From, State) ->
                     %% Santa: Because the send() function will convert our tuple
                     %%        to a binary
                     [riak_repl_tcp_server:send(Transport, Socket,
-                                               encode_obj_msg(Ver,{fs_diff_obj,O}))
+                                               riak_repl_util:encode_obj_msg(
+                                                 Ver,{fs_diff_obj,O}))
                      || O <- Objects],
                     riak_repl_tcp_server:send(Transport, Socket,
-                                              encode_obj_msg(Ver,{fs_diff_obj,RObj}))
+                                              riak_repl_util:encode_obj_msg(
+                                                Ver,{fs_diff_obj,RObj}))
             end,
             ok;
         {error, notfound} ->
@@ -110,10 +103,12 @@ handle_call({get, B, K, Transport, Socket, Pool, Partition, Ver}, From, State) -
                             %% Santa: Because, Cindy, the send() function accepts
                             %%        either a binary or a term.
                             [riak_repl_tcp_server:send(Transport, Socket,
-                                                       encode_obj_msg(Ver,{fs_diff_obj,O}))
+                                                       riak_repl_util:encode_obj_msg(
+                                                         Ver,{fs_diff_obj,O}))
                              || O <- Objects],
                             riak_repl_tcp_server:send(Transport, Socket,
-                                                      encode_obj_msg(Ver,{fs_diff_obj,RObj}))
+                                                      riak_repl_util:encode_obj_msg(
+                                                        Ver,{fs_diff_obj,RObj}))
                     end,
                     ok;
                 {r, {error, notfound}, _, ReqID} ->

--- a/src/riak_repl_keylist_server.erl
+++ b/src/riak_repl_keylist_server.erl
@@ -497,15 +497,6 @@ diff_bloom({Ref,diff_exchanged},  #state{diff_ref=Ref} = State) ->
 %% end of bloom states
 %% --------------------------------------------------------------------------
 
-encode_obj_msg(V, {fs_diff_obj, RObj}) ->
-    case V of
-        w0 ->
-            term_to_binary({fs_diff_obj, RObj});
-        _W ->
-            BObj = riak_repl_util:to_wire(w1,RObj),
-            term_to_binary({fs_diff_obj, BObj})
-    end.
-
 %% server <- bloom_fold : diff_obj 'recv a diff object from bloom folder
 diff_bloom({diff_obj, RObj}, _From, #state{client=Client, transport=Transport,
                                            socket=Socket} = State) ->
@@ -518,10 +509,10 @@ diff_bloom({diff_obj, RObj}, _From, #state{client=Client, transport=Transport,
             %% binarize here instead of in the send() so that our wire
             %% format for the riak_object is more compact.
             [riak_repl_tcp_server:send(Transport, Socket,
-                                       encode_obj_msg(V,{fs_diff_obj,O}))
+                                       riak_repl_util:encode_obj_msg(V,{fs_diff_obj,O}))
              || O <- Objects],
             riak_repl_tcp_server:send(Transport, Socket,
-                                      encode_obj_msg(V,{fs_diff_obj,RObj}))
+                                      riak_repl_util:encode_obj_msg(V,{fs_diff_obj,RObj}))
     end,
     {reply, ok, diff_bloom, State}.
 

--- a/src/riak_repl_keylist_server.erl
+++ b/src/riak_repl_keylist_server.erl
@@ -88,7 +88,7 @@
         num_diffs,
         generator_paused = false,
         pending_acks = 0,
-        ver = v0
+        ver = w0
     }).
 
 %% -define(TRACE(Stmt),Stmt).
@@ -498,9 +498,9 @@ diff_bloom({Ref,diff_exchanged},  #state{diff_ref=Ref} = State) ->
 
 encode_obj_msg(V, {fs_diff_obj, RObj}) ->
     case V of
-        v0 ->
+        w0 ->
             term_to_binary({fs_diff_obj, RObj});
-        v1 ->
+        _W ->
             BObj = riak_repl_util:to_wire(w1,RObj),
             term_to_binary({fs_diff_obj, BObj})
     end.

--- a/src/riak_repl_keylist_server.erl
+++ b/src/riak_repl_keylist_server.erl
@@ -322,16 +322,17 @@ diff_keylist(Command, #state{diff_pid=Pid} = State)
     {next_state, wait_for_partition, State};
 %% @plu server <-- diff_stream : merkle_diff
 diff_keylist({Ref, {merkle_diff, {{B, K}, _VClock}}}, #state{
-        transport=Transport, socket=Socket, diff_ref=Ref, pool=Pool} = State) ->
+        transport=Transport, socket=Socket, diff_ref=Ref, pool=Pool, ver=Ver} = State) ->
     Worker = poolboy:checkout(Pool, true, infinity),
     case State#state.vnode_gets of
         true ->
             %% do a direct get against the vnode, not a regular riak client
             %% get().
             ok = riak_repl_fullsync_worker:do_get(Worker, B, K, Transport, Socket, Pool,
-                State#state.partition);
+                                                  State#state.partition, Ver);
         _ ->
-            ok = riak_repl_fullsync_worker:do_get(Worker, B, K, Transport, Socket, Pool)
+            ok = riak_repl_fullsync_worker:do_get(Worker, B, K, Transport, Socket, Pool,
+                                                  Ver)
     end,
     {next_state, diff_keylist, State};
 %% @plu server <-- key-lister: diff_paused

--- a/src/riak_repl_keylist_server.erl
+++ b/src/riak_repl_keylist_server.erl
@@ -503,8 +503,16 @@ diff_bloom({diff_obj, RObj}, _From, #state{client=Client, transport=Transport,
             skipped;
         Objects when is_list(Objects) ->
             %% server -> client : fs_diff_obj
-            [riak_repl_tcp_server:send(Transport, Socket, {fs_diff_obj, O}) || O <- Objects],
-            riak_repl_tcp_server:send(Transport, Socket, {fs_diff_obj, RObj})
+            Ver = v0,
+            %% binarize here instead of in the send() so that our wire
+            %% format for the riak_object is more compact.
+            [riak_repl_tcp_server:send(Transport, Socket,
+                                       {fs_diff_obj,
+                                        riak_object:to_binary(Ver, O)})
+             || O <- Objects],
+            riak_repl_tcp_server:send(Transport, Socket,
+                                      {fs_diff_obj,
+                                       riak_object:to_binary(Ver, RObj)})
     end,
     {reply, ok, diff_bloom, State}.
 

--- a/src/riak_repl_tcp_client.erl
+++ b/src/riak_repl_tcp_client.erl
@@ -288,7 +288,7 @@ code_change(_OldVsn, State, _Extra) ->
 %% Internal functions
 %% ====================================================================
 
-do_diff_obj_and_reply(Obj, State) ->
+do_diff_obj_and_reply(Msg, State) ->
     case Msg of
         {diff_obj, RObj} ->
             %% realtime diff object, or a fullsync diff object from legacy

--- a/src/riak_repl_tcp_client.erl
+++ b/src/riak_repl_tcp_client.erl
@@ -195,9 +195,8 @@ handle_info({ssl_error, Socket, Reason}, #state{socket = Socket} = State) ->
 handle_info({Proto, Socket, Data},
         State=#state{transport=Transport,socket=Socket}) when Proto==tcp; Proto==ssl ->
     Transport:setopts(Socket, [{active, once}]),
-    Msg = binary_to_term(Data),
     riak_repl_stats:client_bytes_recv(size(Data)),
-    Reply = case decode_obj_msg(Msg) of
+    Reply = case decode_obj_msg(Data) of
         {diff_obj, RObj} ->
             do_diff_obj_and_reply({diff_obj, RObj}, State);
         {fs_diff_obj, RObj} ->
@@ -281,7 +280,7 @@ decode_obj_msg(Data) ->
     %% Santa: Because, Cindy, with new riak object formats, we don't always encode
     %%        the message as term_to_binary({diff_obj, r_object()}). We can also
     %%        receive a message that was encoded as term_to_binary({diff_obj,
-    %%        riak_object:to_binary(Version, r_object()}).
+    %%        riak_object: to_binary(Version, r_object()}).
     case Msg of
         {diff_obj, BObj} when is_binary(BObj) ->
             RObj = riak_repl_util:from_wire(BObj),

--- a/src/riak_repl_tcp_server.erl
+++ b/src/riak_repl_tcp_server.erl
@@ -50,7 +50,7 @@
         fullsync_strategy :: atom(),
         election_timeout :: undefined | reference(), % reference for the election timeout
         keepalive_time :: undefined | integer(),
-        ver = v0
+        ver = w0
     }).
 
 make_state(Sitename, Transport, Socket, MyPI, WorkDir, Client) ->
@@ -126,9 +126,9 @@ handle_cast(_Event, State) ->
 
 encode_obj_msg(V, {diff_obj, RObj}) ->
     case V of
-        v0 ->
+        w0 ->
             term_to_binary({diff_obj, RObj});
-        v1 ->
+        _W ->
             BObj = riak_repl_util:to_wire(w1,RObj),
             term_to_binary({diff_obj, BObj})
     end.

--- a/src/riak_repl_tcp_server.erl
+++ b/src/riak_repl_tcp_server.erl
@@ -129,9 +129,7 @@ encode_obj_msg(V, {diff_obj, RObj}) ->
         v0 ->
             term_to_binary({diff_obj, RObj});
         v1 ->
-            K = riak_object:key(RObj),
-            B = riak_object:bucket(RObj),
-            BObj = riak_repl_util:to_wire(w1,B,K,RObj),
+            BObj = riak_repl_util:to_wire(w1,RObj),
             term_to_binary({diff_obj, BObj})
     end.
 

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -774,7 +774,8 @@ from_wire(<<?MAGIC:8/integer, ?W1_VER:8/integer,
             BLen:32/integer, B:BLen/binary,
             KLen:32/integer, K:KLen/binary, BinObj/binary>>) ->
     riak_object:from_binary(B, K, BinObj);
-from_wire(_) ->
+from_wire(X) ->
+    lager:error("unknown wire format: ~p", [X]),
     {error, unknown_wire_format}.
 
 %% Some eunit tests

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -53,6 +53,7 @@
 
 -export([wire_version/1,
          to_wire/1,
+         to_wire/2,
          to_wire/4,
          from_wire/1,
          from_wire/2
@@ -732,10 +733,12 @@ wire_version(<<?MAGIC:8/integer, N:8/integer, _Rest/binary>>) ->
 %%      binary format is supplied (because it doesn't contain them).
 to_wire(w0, Objects) when is_list(Objects) ->
     term_to_binary(Objects);
+to_wire(w0, Object) ->
+    term_to_binary(Object);
 to_wire(w1, Objects) when is_list(Objects) ->
     BObjs = [to_wire(w1,O) || O <- Objects],
     term_to_binary(BObjs);
-to_wire(w1, Object) ->
+to_wire(w1, Object) when not is_binary(Object) ->
     B = riak_object:bucket(Object),
     K = riak_object:key(Object),
     to_wire(w1, B, K, Object).
@@ -750,7 +753,7 @@ from_wire(w1, BinObjList) ->
 to_wire(w0, _B, _K, <<131,_/binary>>=Bin) ->
     Bin;
 to_wire(w0, _B, _K, RObj) when not is_binary(RObj) ->
-    term_to_binary(RObj);
+    to_wire(w0, RObj);
 to_wire(w1, B, K, <<131,_/binary>>=Bin) ->
     %% no need to wrap a full old object. just use w0 format
     to_wire(w0, B, K, Bin);

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -64,9 +64,6 @@
 %% Defines for Wire format encode/decode
 -define(MAGIC, 42). %% as opposed to 131 for Erlang term_to_binary or 51 for riak_object
 -define(W1_VER, 1). %% first non-just-term-to-binary wire format
--type wire_version() :: w0 | w1.
-
--export_type([wire_version/0]).
 
 make_peer_info() ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
@@ -748,8 +745,7 @@ wire_version(<<131, _Rest/binary>>) ->
 wire_version(<<?MAGIC:8/integer, ?W1_VER:8/integer, _Rest/binary>>) ->
     w1;
 wire_version(<<?MAGIC:8/integer, N:8/integer, _Rest/binary>>) ->
-    %% TODO: convert to an atom like atom_of('w' + N)
-    N.
+    list_to_atom(lists:flatten(io_lib:format("w~p", [N]))).
 
 %% @doc Convert a plain or binary riak object to repl wire format.
 %%      Bucket and Key will only be added if the new riak_object


### PR DESCRIPTION
The new binary object support has been added to riak_kv via the branch jrw-pdx-binary-robj-rebased2.

To summarize, it changes how we store objects in KV such that we now store a binary form that no longer includes the bucket, key, or a bloated dictionary. This new format can also be used as a wire format in handoff, etc in core.

Replication can take advantage of the new format as well, by passing the binary object over socket connections. To do this, we needed to add a wrapper that includes the bucket and key since they no longer appear in the object. Thus, I've added a "wire" format. This format is denoted either w0 or w1. w0 is the old way and is binary compatible with older versions of replication (pre 1.4). w1 can be used when both connected nodes (source and sink) exchange a negotiated protocol of 1.1 or greater. I think Micah is currently upping our protocol to 2.0. This could be a problem, but I'll get to that separately.

Of note is that we now write the new w1 format into the RT queue because it's only the RT sources that know what protocol is supported with their connected sinks. If the sink is older, then the source will down-convert the binary format to w0 before sending.

We take care to maintain the same hashing method for the keylist differences. That will not be needed when we move to AAE full sync (except for connecting to old clusters). We also take care to fold over binary objects now. So, there has been a lot of plumbing changes to support passing K,B around as needed.

That's about it. All riak_tests for replication pass, but you'll need that riak_kv branch mentioned above.
