### PR TITLE
Fix dependency version of riak_repl_pb_api to 0.2.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,5 +10,5 @@
                                  {branch, "master"}}},
         {meck, ".*", {git, "git://github.com/eproxus/meck.git", "HEAD"}},
         {ranch, "0.4.0", {git, "git://github.com/extend/ranch.git", {tag, "0.4.0"}}},
-        {riak_repl_pb_api, "0.2.0", {git, "git@github.com:basho/riak_repl_pb_api", {tag, "0.2.0"}}}
+        {riak_repl_pb_api, "0.2.1", {git, "git@github.com:basho/riak_repl_pb_api", {tag, "0.2.1"}}}
        ]}.


### PR DESCRIPTION
Without this building riak_ee will fail. 

Dependency: riak_ee -> riak_repl -> riak_repl_pb_api.

Log excerpt while get-deps:

<pre>
==> riak_repl (get-deps)
Pulling ranch from {git,"git://github.com/extend/ranch.git",{tag,"0.4.0"}}
Cloning into 'ranch'...
Pulling riak_repl_pb_api from {git,"git@github.com:basho/riak_repl_pb_api",
                                   {tag,"0.2.0"}}
Cloning into 'riak_repl_pb_api'...
==> ranch (get-deps)
==> riak_repl_pb_api (get-deps)
ERROR: Dependency dir /home/kenji/src/riak_ee/deps/riak_pb failed application validation with reason:
{version_mismatch,{"/home/kenji/src/riak_ee/deps/riak_pb/src/riak_pb.app.src",
                   {expected,"1.3.0"},
                   {has,"1.3.3"}}}.
ERROR: 'get-deps' failed while processing /home/kenji/src/riak_ee/deps/riak_repl_pb_api: rebar_abort
gmake: *** [deps] Error 1
</pre>
