### PR TITLE
Fix dependancy version of riak_repl_pb_api to 0.2.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,5 +10,5 @@
                                  {branch, "master"}}},
         {meck, ".*", {git, "git://github.com/eproxus/meck.git", "HEAD"}},
         {ranch, "0.4.0", {git, "git://github.com/extend/ranch.git", {tag, "0.4.0"}}},
-        {riak_repl_pb_api, "0.2.1", {git, "git@github.com:basho/riak_repl_pb_api", {tag, "0.2.1"}}}
+        {riak_repl_pb_api, "0.2.2", {git, "git@github.com:basho/riak_repl_pb_api", {tag, "0.2.2"}}}
        ]}.


### PR DESCRIPTION
Before:

```
rebar get-ups
[snip]
==> riak_repl_pb_api (get-deps)
ERROR: Dependency dir /Users/micahw/src/riak_repl/deps/riak_pb failed application validation with reason:
{version_mismatch,{"/Users/micahw/src/riak_repl/deps/riak_pb/src/riak_pb.app.src",
               {expected,"1.3.3"},
               {has,"1.3.0"}}}.
ERROR: 'get-deps' failed while processing /Users/micahw/src/riak_repl/deps/riak_repl_pb_api: rebar_abort
```

Now it all is happy, pointing at 1.3.0 of riak_pb.
