### PR TITLE
Fix bogus call to MODULE:stop in riak_repl_keylist_server.erl

### DIFF
--- a/src/riak_repl_keylist_server.erl
+++ b/src/riak_repl_keylist_server.erl
@@ -382,7 +382,6 @@ diff_keylist({Ref, diff_done}, #state{diff_ref=Ref} = State) ->
 %% Pause or Cancel
 diff_bloom(Command, #state{diff_pid=Pid} = State)
         when Command == pause_fullsync; Command == cancel_fullsync ->
-    ?MODULE:stop(Pid),
     riak_repl_tcp_server:send(State#state.transport, State#state.socket, Command),
     log_stop(Command, State),
     {next_state, wait_for_partition, State};


### PR DESCRIPTION
The call to ?MODULE:stop(Pid) crashes because stop() is not defined. This occurs as a result of pausing or canceling full sync on the 1.2.1 release (at least). We also need to investigate if this is a problem for 1.3 and beyond; I think it is, at least when using old "default" replication mode and not BNW "advanced" mode.

in riak_repl_keylist_server.erl, near line 368,

```
%% Pause or Cancel
diff_bloom(Command, #state{diff_pid=Pid} = State)
        when Command == pause_fullsync; Command == cancel_fullsync ->
    ?MODULE:stop(Pid),
```

We currently get this:

```
2013-03-01 18:30:08.991 UTC [error] <0.13814.1729> gen_server <0.13814.1729> terminated with reason: {{undef,[{riak_repl_keylist_server,stop,[<0.28925.5075>],[]},{riak_repl_keylist_server,diff_bloom,2,[{file,"src/riak_repl_keylist_server.erl"},{line,368}]},{gen_fsm,handle_msg,7,[{file,"gen_fsm.erl"},{line,494}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,227}]}]},{gen_fsm,sync_send_event,[<0.11827.5075>,{diff_obj,{r_object,<<48,98,58,151,53,226,97,20,82,163,213,247,17,16,140,144,218,20,141>>,<;<99,29,250,23,252,98,74,239,180,227,221,216,181,166,77,242,0,0,0,74>>,[{r_content,{dict,...},...}],...}},...]}}
```
