### PR TITLE
Mw 1.2.5 1.3.0 upg fix

### DIFF
--- a/src/riak_repl2_fscoordinator_serv.erl
+++ b/src/riak_repl2_fscoordinator_serv.erl
@@ -219,6 +219,15 @@ get_matching_address(Node, NormIP, Masked) when Node =:= node() ->
 
 get_matching_address(Node, NormIP, Masked) ->
     case rpc:call(Node, riak_repl2_ip, get_matching_address, [NormIP, Masked]) of
+        % this is a clause that will be removed/useless once all nodes on a 
+        % cluster are >= 1.3
+        {badrpc, {'EXIT', {undef, _StackTrace}}} ->
+            case rpc:call(Node, riak_repl_app, get_matching_address, [NormIP, Masked]) of
+                {badrpc, Err} ->
+                    {error, Err};
+                OkRes ->
+                    {ok, OkRes}
+            end;
         {badrpc, Err} ->
             {error, Err};
         Res ->

--- a/src/riak_repl_app.erl
+++ b/src/riak_repl_app.erl
@@ -4,6 +4,9 @@
 -author('Andy Gross <andy@basho.com>').
 -behaviour(application).
 -export([start/2,prep_stop/1,stop/1]).
+% deprecated: used only when on a mixed version cluster where some
+% versions < 1.3
+-export([get_matching_address/2]).
 
 -include("riak_core_connection.hrl").
 
@@ -145,10 +148,24 @@ cluster_mgr_member_fun({IP, Port}) ->
             %AddressMask = mask_address(NormIP, MyMask),
             %?TRACE(lager:notice("address mask is ~p", [AddressMask])),
             Nodes = riak_core_node_watcher:nodes(riak_kv),
-            {Results, _BadNodes} = rpc:multicall(Nodes, riak_repl2_ip,
+            {Results, BadNodes} = rpc:multicall(Nodes, riak_repl2_ip,
                 get_matching_address, [NormIP, CIDR]),
-            lists_shuffle(Results)
+            % when this code was written, a multicall will list the results
+            % in the same order as the nodes where tried.
+            Results2 = maybe_retry_ip_rpc(Results, Nodes, BadNodes, [NormIP, CIDR]),
+            lists_shuffle(Results2)
     end.
+
+maybe_retry_ip_rpc(Results, Nodes, BadNodes, Args) ->
+    Nodes2 = Nodes -- BadNodes,
+    Zipped = lists:zip(Results, Nodes2),
+    MaybeRetry = fun
+        ({{badrpc, {'EXIT', {undef, _StrackTrace}}}, Node}) ->
+            rpc:call(Node, riak_repl_app, get_matching_address, Args);
+        ({Result, _Node}) ->
+            Result
+    end,
+    lists:map(MaybeRetry, Zipped).
 
 lists_shuffle([]) ->
     [];
@@ -257,6 +274,10 @@ prep_stop(_State) ->
                   [SinkErrors]),
     stopping.
 
+%% This function is only here for nodes using a version < 1.3. Remove it in
+%% future version
+get_matching_address(IP, CIDR) ->
+    riak_repl2_ip:get_matching_address(IP, CIDR).
 
 %%%%%%%%%%%%%%%%
 %% Unit Tests %%


### PR DESCRIPTION
Fixes Error when upgrading a cluster from 1.2.5 to 1.3 which would break ip matching due to function/module refactoring.
