### PR TITLE
Mw ensure cluster mgr leadered

### DIFF
--- a/src/riak_repl_sup.erl
+++ b/src/riak_repl_sup.erl
@@ -24,14 +24,14 @@ init([]) ->
                  {riak_repl_server_sup, {riak_repl_server_sup, start_link, []},
                   permanent, infinity, supervisor, [riak_repl_server_sup]},
 
-                 {riak_core_cluster_mgr_sup, {riak_core_cluster_mgr_sup, start_link, []},
-                  permanent, infinity, supervisor, [riak_cluster_mgr_sup]},
-
                  {riak_repl_leader, {riak_repl_leader, start_link, []},
                   permanent, 5000, worker, [riak_repl_leader]},
 
                  {riak_repl2_leader, {riak_repl2_leader, start_link, []},
                   permanent, 5000, worker, [riak_repl2_leader]},
+
+                 {riak_core_cluster_mgr_sup, {riak_core_cluster_mgr_sup, start_link, []},
+                  permanent, infinity, supervisor, [riak_cluster_mgr_sup]},
 
                  {riak_repl2_fs_node_reserver, {riak_repl2_fs_node_reserver, start_link, []},
                   permanent, infinity, worker, [riak_repl2_fs_node_reserver]},

--- a/test/riak_core_cluster_mgr_sup_tests.erl
+++ b/test/riak_core_cluster_mgr_sup_tests.erl
@@ -1,0 +1,105 @@
+-module(riak_core_cluster_mgr_sup_tests).
+-compile(export_all).
+-include("riak_core_connection.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+murdering_test_() ->
+    {setup, fun() ->
+    % if the cluster_mgr is restarted after the leader process is running,
+    % it should ask about who the current leader is.
+        Kids = [
+            {riak_repl_leader, {riak_repl_leader, start_link, []},
+                  permanent, 5000, worker, [riak_repl_leader]},
+            {riak_repl2_leader, {riak_repl2_leader, start_link, []},
+                  permanent, 5000, worker, [riak_repl2_leader]},
+            {riak_core_cluster_mgr_sup, {riak_core_cluster_mgr_sup, start_link, []},
+                  permanent, infinity, supervisor, [riak_cluster_mgr_sup]}
+        ],
+        meck:new(riak_repl_sup, [passthrough]),
+        meck:expect(riak_repl_sup, init, fun(_Args) ->
+            {ok, {{one_for_one, 9, 10}, Kids}}
+        end),
+        meck:new(riak_core_node_watcher_events),
+        meck:expect(riak_core_node_watcher_events, add_sup_callback, fun(_fn) ->
+            ok
+        end),
+        meck:new(riak_core_node_watcher),
+        meck:expect(riak_core_node_watcher, nodes, fun(_) ->
+            [node()]
+        end),
+        application:start(ranch),
+        application:set_env(riak_repl, data_root, "."),
+        {ok, _Eventer} = riak_core_ring_events:start_link(),
+        {ok, _RingMgr} = riak_core_ring_manager:start_link(test),
+        {ok, _ClientSup} = riak_repl_client_sup:start_link(),
+        {ok, TopSup} = riak_repl_sup:start_link(),
+        riak_repl2_leader:register_notify_fun(
+            fun riak_core_cluster_mgr:set_leader/2),
+        riak_repl_leader:set_candidates([node()], []),
+        riak_repl2_leader:set_candidates([node()], []),
+        wait_for_leader(),
+        TopSup
+    end,
+    fun(_) ->
+        Mecks = [riak_repl_sup, riak_core_node_watcher_events, riak_core_node_watcher],
+        [meck:unload(Meck) || Meck <- Mecks],
+        riak_core_ring_manager:stop()
+    end,
+    fun(_) -> [
+
+        {"Cluster Mgr knows of a leader", fun() ->
+            ?assertNotEqual(undefined, riak_core_cluster_mgr:get_leader())
+        end},
+
+        {"Kill off the cluster manager, it can still find a leader", fun() ->
+            OldPid = whereis(riak_core_cluster_manager),
+            exit(OldPid, kill),
+            WaitFun = fun() ->
+                case whereis(riak_core_cluster_manager) of
+                    OP when OP == OldPid ->
+                    false;
+                    undefined ->
+                        false;
+                    _Pid ->
+                        Leader = riak_core_cluster_mgr:get_leader(),
+                        Leader =/= undefined
+                end
+            end,
+            WaitRes = wait(WaitFun, 10, 400),
+            ?assertEqual(ok, WaitRes)
+        end}
+
+    ] end}.
+
+pester(Fun) ->
+    pester(Fun, 10, 100).
+
+pester(Fun, Wait, Times) ->
+    pester(Fun, Wait, Times, []).
+
+pester(_Fun, _Wait, Times, Acc) when Times =< 0 ->
+    lists:reverse(Acc);
+pester(Fun, Wait, Times, Acc) ->
+    Res = Fun(),
+    timer:sleep(Wait),
+    pester(Fun, Wait, Times - 1, [Res | Acc]).
+
+wait_for_leader() ->
+    WaitFun = fun() ->
+        riak_repl2_leader:leader_node() =/= undefined
+    end,
+    wait(WaitFun).
+
+wait(WaitFun) ->
+    wait(WaitFun, 10, 100).
+
+wait(_WaitFun, _Wait, Itor) when Itor =< 0 ->
+    timeout;
+wait(WaitFun, Wait, Itor) ->
+    case WaitFun() of
+        true ->
+            ok;
+        _ ->
+            timer:sleep(Wait),
+            wait(WaitFun, Wait, Itor - 1)
+    end.

--- a/test/riak_core_cluster_mgr_tests.erl
+++ b/test/riak_core_cluster_mgr_tests.erl
@@ -360,12 +360,12 @@ cleanup() ->
         Leader -> exit(Leader, kill)
     end,
     riak_core_ring_manager:stop(),
-    case whereis(riak_core_ring_event) of
+    case whereis(riak_core_ring_events) of
         undefined -> ok;
         RingEvents -> exit(RingEvents, kill)
     end,
     meck:unload(riak_core_node_watcher),
-    meck:unlaod(riak_core_node_watcher_events).
+    meck:unload(riak_core_node_watcher_events).
 
 maybe_start_master() ->
     case node() of

--- a/test/riak_repl_sup_tests.erl
+++ b/test/riak_repl_sup_tests.erl
@@ -1,0 +1,41 @@
+-module(riak_repl_sup_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+% Why? Because it's nice to know that system can start.
+
+can_start_test() ->
+    {timeout, 60000, {setup, fun() ->
+        % core features that are needed
+        {ok, _Eventer} = riak_core_ring_events:start_link(),
+        {ok, _RingMgr} = riak_core_ring_manager:start_link(test),
+
+        % needed by the leaders
+        meck:new(riak_core_node_watcher_events),
+        meck:expect(riak_core_node_watcher_events, add_sup_callback, fun(_fn) ->
+            ok
+        end),
+        meck:new(riak_core_node_watcher),
+        meck:expect(riak_core_node_watcher, nodes, fun(_) ->
+            [node()]
+        end),
+
+        % needed by repl itself
+        application:start(ranch),
+        application:set_env(riak_repl, data_root, ".")
+    end,
+    fun(_) ->
+        riak_core_ring_events:stop(),
+        riak_core_ring_manager:stop(),
+        meck:unload(riak_core_node_watcher),
+        meck:unload(riak_core_node_watcher_events)
+    end,
+    fun(_) -> [
+
+        fun() ->
+            {ok, Pid} = riak_repl_sup:start_link(),
+            timer:sleep(5000),
+            ?assert(is_process_alive(Pid))
+        end
+
+    ] end}}.

--- a/test/riak_repl_sup_tests.erl
+++ b/test/riak_repl_sup_tests.erl
@@ -25,6 +25,7 @@ can_start_test() ->
         application:set_env(riak_repl, data_root, ".")
     end,
     fun(_) ->
+        application:stop(ranch),
         riak_core_ring_events:stop(),
         riak_core_ring_manager:stop(),
         meck:unload(riak_core_node_watcher),


### PR DESCRIPTION
A bandage (better than a band-aid) to the cluster manager losing it's leader. The root cause seemed to be the cluster manager being restarted due to a crash. This patch has the cluster_manager check if it's leader is defined later on in it's life, and attempt to rectify that.
