### PR TITLE
Fix repl deps for 1.3.1 release

### DIFF
--- a/ebin/riak_repl.app
+++ b/ebin/riak_repl.app
@@ -3,7 +3,7 @@
  riak_repl,
  [{description,  "Enterprise replication for Riak"},
   {id,           "riak_repl"},
-  {vsn,          "1.3.0"},
+  {vsn,          "1.3.1"},
   {modules,      ['bounded_queue',
                   'couch_btree',
                   'couch_file',

--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 {erl_first_files, ["src/gen_leader.erl"]}.
 {lib_dirs, [".."]}.
 {deps, [
-        {riak_kv, "1.3.0", {git, "git://github.com/basho/riak_kv", {tag, "1.3.0"}}},
+        {riak_kv, "1.3.1", {git, "git://github.com/basho/riak_kv", {tag, "1.3.1"}}},
         {riak_search, "1.3.0", {git, "git://github.com/basho/riak_search",
                                  {tag, "1.3.0"}}},
         {meck, "0.7.2", {git, "git://github.com/eproxus/meck.git", {tag, "0.7.2-2-gd6230ae"}}},


### PR DESCRIPTION
Fix repl so that it points to riak_kv version 1.3.1
and update version in app file.
