### PR TITLE
Replace fullsync complete stat on server.

### DIFF
--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -362,6 +362,8 @@ handle_info({'EXIT', Pid, Cause}, State) when Cause =:= normal; Cause =:= shutdo
                     % clear the "rt dirty" stat if it's set,
                     % otherwise, don't do anything
                     State3 = notify_rt_dirty_nodes(State),
+                    %% update legacy stats too! some riak_tests depend on them.
+                    riak_repl_stats:server_fullsyncs(),
                     TotalFullsyncs = State#state.fullsyncs_completed + 1,
                     Finish = riak_core_util:moment(),
                     ElapsedSeconds = Finish - State#state.fullsync_start_time,


### PR DESCRIPTION
- Replace the line of code that increments the global fullsync completed stat on the server.
- Needed by the riak_test/src/repl_util.erl to detect when fullsyncs have completed.
- Maybe needed for other customers who may watch this stat.
