### PR TITLE
fix broken test includes

### DIFF
--- a/test/riak_core_cluster_mgr_sup_tests.erl
+++ b/test/riak_core_cluster_mgr_sup_tests.erl
@@ -1,6 +1,6 @@
 -module(riak_core_cluster_mgr_sup_tests).
 -compile(export_all).
--include("riak_core_connection.hrl").
+-include_lib("riak_core/include/riak_core_connection.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 murdering_test_() ->

--- a/test/riak_core_cluster_mgr_tests.erl
+++ b/test/riak_core_cluster_mgr_tests.erl
@@ -4,8 +4,8 @@
 -module(riak_core_cluster_mgr_tests).
 -compile(export_all).
 
--include("riak_core_connection.hrl").
-
+-include("riak_core_cluster.hrl").
+-include_lib("riak_core/include/riak_core_connection.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 -define(TRACE(Stmt),Stmt).


### PR DESCRIPTION
from a riak_ee tree:

```
(cd deps/riak_repl && ../../rebar eunit deps_dir=.. skip_deps=true)
```
