### PR TITLE
Add default registration functions to cluster manager supervisor

### DIFF
--- a/src/riak_core_cluster_mgr_sup.erl
+++ b/src/riak_core_cluster_mgr_sup.erl
@@ -18,6 +18,9 @@ start_link() ->
 %% @spec init([]) -> SupervisorTree
 %% @doc supervisor callback.
 init([]) ->
+    ClusterMgrDefaults = [fun riak_repl_app:cluster_mgr_member_fun/1,
+                          fun riak_repl_app:cluster_mgr_write_cluster_members_to_ring/2,
+                          fun riak_repl_app:cluster_mgr_read_cluster_targets_from_ring/0],
     Processes =
         [%% TODO: move these to riak core
          %% Service Manager (inbound connections)
@@ -33,7 +36,7 @@ init([]) ->
          {riak_core_cluster_conn_sup, {riak_core_cluster_conn_sup, start_link, []},
           permanent, infinity, supervisor, [riak_core_cluster_conn_sup]},
          %% Cluster Manager
-         {riak_repl_cluster_mgr, {riak_core_cluster_mgr, start_link, []},
+         {riak_repl_cluster_mgr, {riak_core_cluster_mgr, start_link, ClusterMgrDefaults},
           permanent, 5000, worker, [riak_core_cluster_mgr]},
          {riak_core_tcp_mon, {riak_core_tcp_mon, start_link, []},
           permanent, 5000, worker, [riak_core_tcp_mon]}

--- a/src/riak_repl_app.erl
+++ b/src/riak_repl_app.erl
@@ -8,6 +8,10 @@
 % versions < 1.3
 -export([get_matching_address/2]).
 
+-export([cluster_mgr_member_fun/1,
+         cluster_mgr_write_cluster_members_to_ring/2,
+         cluster_mgr_read_cluster_targets_from_ring/0]).
+
 -include("riak_core_cluster.hrl").
 -include_lib("riak_core/include/riak_core_connection.hrl").
 


### PR DESCRIPTION
See issue https://github.com/basho/riak_repl/issues/255

This solution exports the member, save, and restore functions from riak_repl_app.erl and uses them as defaults in the cluster manager supervisor. They are also registered, as before, by riak_repl_app. If the cluster manager is terminated, the supervisor will not start it up with defaults that will allow connections to already known clusters. This solution allows the cluster manager to remain pluggable with a different supervision strategy or no supervisor.

An additional change was made to cause reconnections to be attempted after various intervals up to one minute in case the ring takes longer than 5 seconds to converge.

Tested by connecting two clusters and sequentially terminating all cluster managers on the source side, twice each, to ensure that restart is idempotent.
