### PR TITLE
Add heartbeat to the realtime replication protocol to 1.4

### DIFF
--- a/src/riak_repl2_rtsink_conn.erl
+++ b/src/riak_repl2_rtsink_conn.erl
@@ -32,6 +32,7 @@
                 deactivated = 0,  %% Count of times deactivated
                 source_drops = 0, %% Count of upstream drops
                 helper,           %% Helper PID
+                hb_last,          %% os:timestamp last heartbeat message received
                 seq_ref,          %% Sequence reference for completed/acked
                 expect_seq = undefined,%% Next expected sequence number
                 acked_seq = undefined, %% Last sequence number acknowledged
@@ -41,7 +42,7 @@
 
 %% Register with service manager
 register_service() ->
-    ProtoPrefs = {realtime,[{1,0}]},
+    ProtoPrefs = {realtime,[{1,1}]},
     TcpOptions = [{keepalive, true}, % find out if connection is dead, this end doesn't send
                   {packet, 0},
                   {nodelay, true}],
@@ -91,6 +92,7 @@ init([Proto, Remote]) ->
 
 handle_call(status, _From, State = #state{remote = Remote,
                                           transport = T, socket = _S, helper = Helper,
+                                          hb_last = HBLast,
                                           active = Active, deactivated = Deactivated,
                                           source_drops = SourceDrops,
                                           expect_seq = ExpSeq, acked_seq = AckedSeq}) ->
@@ -103,6 +105,7 @@ handle_call(status, _From, State = #state{remote = Remote,
               %%{socket_raw, S},
               {socket,
                riak_core_tcp_mon:format_socket_stats(SocketStats,[])},
+              {hb_last, HBLast},
               %%{peer, peername(State)},
               {helper, riak_repl_util:safe_pid_to_list(Helper)},
               {active, Active},
@@ -200,12 +203,15 @@ code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
 %% Receive TCP data - decode framing and dispatch
-recv(TcpBin, State) ->
+recv(TcpBin, State = #state{transport = T, socket = S}) ->
     case riak_repl2_rtframe:decode(TcpBin) of
         {ok, undefined, Cont} ->
             {noreply, State#state{cont = Cont}};
         {ok, {objects, {Seq, BinObjs}}, Cont} ->
             recv(Cont, do_write_objects(Seq, BinObjs, State));
+        {ok, heartbeat, Cont} ->
+            T:send(S, riak_repl2_rtframe:encode(heartbeat, undefined)),
+            recv(Cont, State#state{hb_last = os:timestamp()});
         {error, Reason} ->
             %% TODO: Log Something bad happened
             riak_repl_stats:rt_sink_errors(),

--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -4,8 +4,34 @@
 
 %% @doc Realtime replication source connection module
 %%
-%% High level responsibility...
+%% Works in tandem with rtsource_helper.  The helper interacts with
+%% the RTQ to send queued traffic over the socket.  This rtsource_conn
+%% process accepts the remote Acks and clears the RTQ.
 %%
+%% If both sides support heartbeat message, it is sent from the RT source
+%% every {riak_repl, rt_heartbeat_interval} which default to 15s.  If
+%% a response is not received in {riak_repl, rt_heartbeat_timeout}, also
+%% default to 15s then the source connection exits and will be re-established
+%% by the supervisor.
+%%
+%% 1. On startup/interval timer - rtsource_conn casts to rtsource_helper
+%%    to send over the socket.  If TCP buffer is full or rtsource_helper
+%%    is otherwise hung the rtsource_conn process will still continue.
+%%    rtsource_conn sets up a heartbeat timeout.
+%%
+%% 2. At rtsink, on receipt of a heartbeat message it sends back
+%%    a heartbeat message and stores the timestamp it last received one.
+%%    The rtsink does not worry about detecting broken connections
+%%    as new ones can be established harmlessly.  Keep it simple.
+%%
+%% 3. If rtsource receives the heartbeat back, it cancels the timer
+%%    and updates the hearbeat round trip time (hb_rtt) then sets
+%%    a new heartbeat_interval timer.
+%%
+%%    If the heartbeat_timeout fires, the rtsource connection terminates.
+%%    The rtsource_helper:stop call is now wrapped in a timeout in
+%%    case it is hung so we don't get nasty messages about rtsource_conn
+%%    crashing when it's the helper that is causing the problems.
 
 -behaviour(gen_server).
 -include("riak_repl.hrl").
@@ -24,6 +50,9 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
+-define(DEFAULT_HBINTERVAL, timer:seconds(15)).
+-define(DEFAULT_HBTIMEOUT, timer:seconds(15)).
+
 -record(state, {remote,    % remote name
                 address,   % {IP, Port}
                 connection_ref, % reference handed out by connection manager
@@ -31,6 +60,11 @@
                 socket,    % socket to use with transport 
                 proto,     % protocol version negotiated
                 helper_pid,% riak_repl2_rtsource_helper pid
+                hb_interval,% milliseconds to send new heartbeat after last
+                hb_timeout,% milliseconds to wait for heartbeat after send
+                hb_timeout_tref,% heartbeat timeout timer reference
+                hb_sent,   % now() last heartbeat was sent
+                hb_rtt,    % RTT in milliseconds for last completed heartbeat
                 cont = <<>>}). % continuation from previous TCP buffer
 
 %% API - start trying to send realtime repl to remote site
@@ -72,7 +106,7 @@ init([Remote]) ->
                   {nodelay, true},
                   {packet, 0},
                   {active, false}],
-    ClientSpec = {{realtime,[{1,0}]}, {TcpOptions, ?MODULE, self()}},
+    ClientSpec = {{realtime,[{1,1}]}, {TcpOptions, ?MODULE, self()}},
 
     %% Todo: check for bad remote name
     lager:debug("connecting to remote ~p", [Remote]),
@@ -89,12 +123,20 @@ handle_call(stop, _From, State) ->
     {stop, normal, ok, State};
 handle_call(status, _From, State =
                 #state{remote = R, address = _A, transport = T, socket = S,
-                       helper_pid = H}) ->
+                       helper_pid = H,
+                       hb_interval = HBInterval, hb_rtt = HBRTT}) ->
     Props = case T of
                 undefined ->
                     [{connected, false}];
                 _ ->
+                    HBStats = case HBInterval of
+                                  undefined ->
+                                      [];
+                                  _ ->
+                                      [{hb_rtt, HBRTT}]
+                              end,
                     SocketStats = riak_core_tcp_mon:socket_status(S),
+
                     [{connected, true},
                      %%{address, riak_repl_util:format_ip_and_port(A)},
                      {transport, T},
@@ -102,7 +144,8 @@ handle_call(status, _From, State =
                      {socket,
                       riak_core_tcp_mon:format_socket_stats(SocketStats, [])},
                      %%{peername, peername(State)},
-                     {helper_pid, riak_repl_util:safe_pid_to_list(H)}]
+                     {helper_pid, riak_repl_util:safe_pid_to_list(H)}] ++
+                        HBStats
             end,
     HelperProps = case H of
                       undefined ->
@@ -156,11 +199,26 @@ handle_call({connected, Socket, Transport, EndPoint, Proto}, _From,
             lager:debug("Keeping stats for " ++ SocketTag),
             riak_core_tcp_mon:monitor(Socket, {?TCP_MON_RT_APP, source,
                                                SocketTag}, Transport),
-            {reply, ok, State#state{transport = Transport, 
-                                    socket = Socket,
-                                    address = EndPoint,
-                                    proto = Proto,
-                                    helper_pid = HelperPid}};
+            State2 = State#state{transport = Transport, 
+                                 socket = Socket,
+                                 address = EndPoint,
+                                 proto = Proto,
+                                 helper_pid = HelperPid},
+            lager:info("Established realtime connection to site ~p address ~s",
+                      [Remote, peername(State2)]),
+            case Proto of
+                {realtime, _OurVer, {1, 0}} ->
+                    {reply, ok, State2};
+                _ ->
+                    %% 1.1 and above, start with a heartbeat
+                    HBInterval = app_helper:get_env(riak_repl, rt_hearbeat_interval,
+                                                    ?DEFAULT_HBINTERVAL),
+                    HBTimeout = app_helper:get_env(riak_repl, rt_hearbeat_timeout,
+                                                   ?DEFAULT_HBTIMEOUT),
+                    State3 = State2#state{hb_interval = HBInterval,
+                                          hb_timeout = HBTimeout},
+                    {reply, ok, send_heartbeat(State3)}
+            end;
         ER ->
             {reply, ER, State}
     end.
@@ -183,7 +241,7 @@ handle_info({tcp_closed, _S},
             ok;
         NumBytes ->
             riak_repl_stats:rt_source_errors(),
-            lager:warning("Realtime connection ~p to ~p closed with partial receive of ~b bytes\n",
+            lager:warning("Realtime connection ~s to ~p closed with partial receive of ~b bytes\n",
                           [peername(State), Remote, NumBytes])
     end,
     %% go to sleep for 1s so a sink that opens the connection ok but then 
@@ -193,9 +251,24 @@ handle_info({tcp_closed, _S},
 handle_info({tcp_error, _S, Reason}, 
             State = #state{remote = Remote, cont = Cont}) ->
     riak_repl_stats:rt_source_errors(),
-    lager:warning("Realtime connection ~p to ~p network error ~p - ~b bytes pending\n",
+    lager:warning("Realtime connection ~s to ~p network error ~p - ~b bytes pending\n",
                   [peername(State), Remote, Reason, size(Cont)]),
     {stop, normal, State};
+handle_info(send_heartbeat, State) ->
+    {noreply, send_heartbeat(State)};
+handle_info({heartbeat_timeout, HBSent}, State = #state{hb_sent = HBSent,
+                                                        remote = Remote}) ->
+    Duration = timer:now_diff(now(), HBSent) div 1000,
+    lager:warning("Realtime connection ~s to ~p heartbeat timeout "
+                  "after ~p milliseconds\n",
+                  [peername(State), Remote, Duration]),
+    {stop, normal, State};
+handle_info({heartbeat_timeout, _HBSent}, State = #state{remote = Remote}) ->
+    %% Timeout message was in the queue when we received the heartbeat
+    %% already handled, ignore.
+    lager:info("Realtime connection ~s to ~p received stale timeout\n",
+               [peername(State), Remote]),
+    {noreply, State};
 handle_info(Msg, State) ->
     lager:warning("Unhandled info:  ~p", [Msg]),
     {noreply, State}.
@@ -207,13 +280,21 @@ terminate(_Reason, #state{helper_pid = HelperPid}) ->
         undefined ->
             ok;
         _ ->
-            riak_repl2_rtsource_helper:stop(HelperPid)
+            try
+                riak_repl2_rtsource_helper:stop(HelperPid)
+            catch
+                _:Err ->
+                    lager:info("Realtime source did not cleanly stop ~p - ~p\n",
+                               [HelperPid, Err])
+            end
     end.
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
-recv(TcpBin, State = #state{remote = Name}) ->
+recv(TcpBin, State = #state{remote = Name,
+                            hb_sent = HBSent,
+                            hb_timeout_tref = HBTRef}) ->
     case riak_repl2_rtframe:decode(TcpBin) of
         {ok, undefined, Cont} ->
             {noreply, State#state{cont = Cont}};
@@ -222,6 +303,15 @@ recv(TcpBin, State = #state{remote = Name}) ->
             riak_repl_stats:objects_sent(),
             ok = riak_repl2_rtq:ack(Name, Seq),
             recv(Cont, State);
+        {ok, heartbeat, Cont} ->
+            %% Compute last heartbeat roundtrip in msecs and
+            %% reschedule next
+            HBRTT = timer:now_diff(now(), HBSent) div 1000,
+            erlang:cancel_timer(HBTRef),
+            State2 = State#state{hb_sent = undefined,
+                                 hb_timeout_tref = undefined,
+                                 hb_rtt = HBRTT},
+            recv(Cont, schedule_heartbeat(State2));
         {error, Reason} ->
             %% Something bad happened
             riak_repl_stats:rt_source_errors(),
@@ -229,10 +319,24 @@ recv(TcpBin, State = #state{remote = Name}) ->
     end.
 
 peername(#state{transport = T, socket = S}) ->
-    case T:peername(S) of
-        {ok, Res} ->
-            Res;
-        {error, Reason} ->
-            riak_repl_stats:rt_source_errors(),
-            {lists:flatten(io_lib:format("error:~p", [Reason])), 0}
-    end.
+    riak_repl_util:peername(S, T).
+
+%% Heartbeat is disabled, do nothing
+send_heartbeat(State = #state{hb_interval = undefined}) ->
+    State;
+%% Heartbeat supported and enabled, tell helper to send the message,
+%% and start the timeout.  Managing heartbeat from this process
+%% will catch any bug that causes the helper process to hang as
+%% well as connection issues - either way we want to re-establish.
+send_heartbeat(State = #state{hb_timeout = HBTimeout,
+                              helper_pid = HelperPid}) ->
+    Now = now(), % using now as need a unique reference for this heartbeat
+                 % to spot late heartbeat timeout messages
+    riak_repl2_rtsource_helper:send_heartbeat(HelperPid),
+    TRef = erlang:send_after(HBTimeout, self(), {heartbeat_timeout, Now}),
+    State#state{hb_sent = Now, hb_timeout_tref = TRef}.
+
+%% Schedule the next heartbeat
+schedule_heartbeat(State = #state{hb_interval = HBInterval}) ->
+    erlang:send_after(HBInterval, self(), send_heartbeat),
+    State.

--- a/src/riak_repl2_rtsource_helper.erl
+++ b/src/riak_repl2_rtsource_helper.erl
@@ -10,7 +10,7 @@
 %% API
 -export([start_link/3,
          stop/1,
-         status/1, status/2]).
+         status/1, status/2, send_heartbeat/1]).
 
 -define(SERVER, ?MODULE).
 
@@ -37,6 +37,11 @@ status(Pid) ->
 
 status(Pid, Timeout) ->
     gen_server:call(Pid, status, Timeout).
+
+send_heartbeat(Pid) ->
+    %% Cast the heartbeat, do not want to block the rtsource process
+    %% as it is responsible for checking heartbeat
+    gen_server:cast(Pid, send_heartbeat).
 
 init([Remote, Transport, Socket]) ->
     riak_repl2_rtq:register(Remote), % re-register to reset stale deliverfun
@@ -65,12 +70,16 @@ handle_call(status, _From, State =
     {reply, [{sent_seq, SentSeq},
              {objects, Objects}], State}.
 
-handle_cast(_Msg, State) ->
-    %% TODO: Log unhandled message
+handle_cast(send_heartbeat, State = #state{transport = T, socket = S}) ->
+    HBIOL = riak_repl2_rtframe:encode(heartbeat, undefined),
+    T:send(S, HBIOL),
+    {noreply, State};
+handle_cast(Msg, State) ->
+    lager:info("Realtime source helper received unexpected cast - ~p\n", [Msg]),
     {noreply, State}.
 
-handle_info(_Msg, State) ->
-    %% TODO: Log unknown msg
+handle_info(Msg, State) ->
+    lager:info("Realtime source helper received unexpected message - ~p\n", [Msg]),
     {noreply, State}.
 
 terminate(_Reason, _State) ->

--- a/src/riak_repl_wm_stats.erl
+++ b/src/riak_repl_wm_stats.erl
@@ -161,9 +161,19 @@ jsonify_stats([{K,V}|T], Acc) when is_atom(K)
         [] ->
             jsonify_stats(T, Acc)
     end;
+jsonify_stats([{S,IP,Port}|T], Acc) when is_atom(S) andalso is_list(IP) andalso is_integer(Port) ->
+    jsonify_stats(T, [{S,
+                       list_to_binary(IP++":"++integer_to_list(Port))}|Acc]);
+jsonify_stats([{S,{A,B,C,D},Port}|T], Acc) when is_atom(S) andalso is_integer(Port) ->
+    jsonify_stats(T, [{S,
+                       iolist_to_binary(io_lib:format("~b.~b.~b.~b:~b",[A,B,C,D,Port]))}|Acc]);
+jsonify_stats([{K,{Mega,Secs,Micro}=Now}|T], Acc) when is_integer(Mega),
+                                                   is_integer(Secs),
+                                                   is_integer(Micro) ->
+    StrDate = httpd_util:rfc1123_date(calendar:now_to_local_time(Now)),
+    jsonify_stats(T, [{K, list_to_binary(StrDate)} | Acc]);
 jsonify_stats([{K,V}|T], Acc) when is_list(V) ->
     jsonify_stats(T, [{K,list_to_binary(V)}|Acc]);
-
 jsonify_stats([{K,V}|T], Acc) ->
     jsonify_stats(T, [{K,V}|Acc]).
 


### PR DESCRIPTION
This change bumps the RT proto to {1, 1}. We may need to resolve
this with the binary object work and cascaded realtime work.

If both sides are using the updated protocol, a heartbeat message is
sent from the RT source every {riak_repl, rt_heartbeat_interval} which
default to 15s.  If a response is not received in
{riak_repl, rt_heartbeat_timeout}, also default to 15s then the source
connection exits and will be re-established
by the supervisor.
1. On startup/interval timer - rtsource_conn casts to rtsource_helper
   to send over the socket.  If TCP buffer is full or rtsource_helper
   is otherwise hung the rtsource_conn process will still continue.
   rtsource_conn sets up a heartbeat timeout.
2. At rtsink, on receipt of a heartbeat message it sends back
   a heartbeat message and stores the timestamp it last received one.
   The rtsink does not worry about detecting broken connections
   as new ones can be established harmlessly.  Keep it simple.
3. If rtsource receives the heartbeat back, it cancels the timer
   and updates the hearbeat round trip time (hb_rtt) then sets
   a new heartbeat_interval timer.
   
   If the heartbeat_timeout fires, the rtsource connection terminates.
   The rtsource_helper:stop call is now wrapped in a timeout in
   case it is hung so we don't get nasty messages about rtsource_conn
   crashing when it's the helper that is causing the problems.
