### PR TITLE
Add default registration functions to cluster manager supervisor

### DIFF
--- a/src/riak_core_cluster_mgr_sup.erl
+++ b/src/riak_core_cluster_mgr_sup.erl
@@ -18,6 +18,9 @@ start_link() ->
 %% @spec init([]) -> SupervisorTree
 %% @doc supervisor callback.
 init([]) ->
+    ClusterMgrDefaults = [fun riak_repl_app:cluster_mgr_member_fun/1,
+                          fun riak_repl_app:cluster_mgr_write_cluster_members_to_ring/2,
+                          fun riak_repl_app:cluster_mgr_read_cluster_targets_from_ring/0],
     Processes =
         [%% TODO: move these to riak core
          %% Service Manager (inbound connections)
@@ -33,7 +36,7 @@ init([]) ->
          {riak_core_cluster_conn_sup, {riak_core_cluster_conn_sup, start_link, []},
           permanent, infinity, supervisor, [riak_core_cluster_conn_sup]},
          %% Cluster Manager
-         {riak_repl_cluster_mgr, {riak_core_cluster_mgr, start_link, []},
+         {riak_repl_cluster_mgr, {riak_core_cluster_mgr, start_link, ClusterMgrDefaults},
           permanent, 5000, worker, [riak_core_cluster_mgr]},
          {riak_core_tcp_mon, {riak_core_tcp_mon, start_link, []},
           permanent, 5000, worker, [riak_core_tcp_mon]}

--- a/src/riak_repl_app.erl
+++ b/src/riak_repl_app.erl
@@ -6,7 +6,10 @@
 -export([start/2,prep_stop/1,stop/1]).
 % deprecated: used only when on a mixed version cluster where some
 % versions < 1.3
--export([get_matching_address/2]).
+-export([get_matching_address/2,
+         cluster_mgr_member_fun/1,
+         cluster_mgr_write_cluster_members_to_ring/2,
+         cluster_mgr_read_cluster_targets_from_ring/0]).
 
 -include("riak_core_connection.hrl").
 


### PR DESCRIPTION
Ports PR #257 to 1.3 branch

Test with Andrew's scripts documented here:

https://github.com/basho/riak_repl/pull/257
