### PR TITLE
Fixes issue 222, cluster manager can't reconnect after disconnect

### DIFF
--- a/src/riak_repl_ring.erl
+++ b/src/riak_repl_ring.erl
@@ -259,7 +259,12 @@ set_clusterIpAddrs(Ring, {ClusterName, Addrs}) ->
     Cluster = {ClusterName, Addrs},
     Clusters = case lists:keymember(ClusterName, 1, OldClusters) of
                    true ->
-                       lists:keyreplace(ClusterName, 1, OldClusters, Cluster);
+                       case Addrs of
+                           [] ->
+                               lists:keydelete(ClusterName, 1, OldClusters);
+                           _Addrs ->
+                               lists:keyreplace(ClusterName, 1, OldClusters, Cluster)
+                       end;
                    _ ->
                        [Cluster | OldClusters]
                end,


### PR DESCRIPTION
This PR is against 1.3 and will later be applied to 1.4

Resolves issue 222: https://github.com/basho/riak_repl/issues/222

Previously, the cluster manager wasn't removing a connection when disconnect was called. It was dropping the connection, but it wasn't removing the entry from the ring; rather, it was writing the connection name with an empty list of IP addresses. It would never drop the name from the list of connections and it could never re-connect to a new IP addresses. Removing the name from the dictionary fixes the problem and finally makes the list of connections correct after a disconnect! Yay.
