### PR TITLE
Add AAE fullsync strategy (technology release)

### DIFF
--- a/ebin/riak_repl.app
+++ b/ebin/riak_repl.app
@@ -10,6 +10,8 @@
                   'couch_merkle',
                   'gen_leader',
                   'riak_repl',
+                  'riak_repl_aae_sink',
+                  'riak_repl_aae_source',
                   'riak_repl_app',
                   'riak_repl_bq',
                   'riak_repl_cinfo',

--- a/include/riak_repl.hrl
+++ b/include/riak_repl.hrl
@@ -30,6 +30,7 @@
 -define(RETRY_WHEREIS_INTERVAL, 1000).
 -define(CONSOLE_RPC_TIMEOUT, 5000).
 -define(RETRY_AAE_LOCKED_INTERVAL, 1000).
+-define(DEFAULT_FULLSYNC_STRATEGY, keylist). %% keylist | aae
 
 -type(ip_addr_str() :: string()).
 -type(ip_portnum() :: non_neg_integer()).

--- a/include/riak_repl.hrl
+++ b/include/riak_repl.hrl
@@ -29,6 +29,7 @@
 -define(DEFAULT_MAX_FS_BUSIES_TOLERATED, 10).
 -define(RETRY_WHEREIS_INTERVAL, 1000).
 -define(CONSOLE_RPC_TIMEOUT, 5000).
+-define(RETRY_AAE_LOCKED_INTERVAL, 1000).
 
 -type(ip_addr_str() :: string()).
 -type(ip_portnum() :: non_neg_integer()).

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -209,7 +209,7 @@ handle_call(status, _From, State = #state{socket=Socket}) ->
     StartTime =
         case State#state.fullsync_start_time of
             undefined -> undefined;
-            N -> calendar:gregorian_seconds_to_datetime(State#state.fullsync_start_time)
+            _N -> calendar:gregorian_seconds_to_datetime(State#state.fullsync_start_time)
         end,
     SelfStats = [
         {cluster, State#state.other_cluster},
@@ -336,7 +336,7 @@ handle_cast(_Msg, State) ->
 
 %% @hidden
 handle_info({'EXIT', Pid, Cause}, State) when Cause =:= normal; Cause =:= shutdown ->
-    lager:info("fssource ~p exited normally", [Pid]),
+    lager:debug("fssource ~p exited normally", [Pid]),
     PartitionEntry = lists:keytake(Pid, 1, State#state.running_sources),
     case PartitionEntry of
         false ->
@@ -384,7 +384,7 @@ handle_info({'EXIT', Pid, Cause}, State) when Cause =:= normal; Cause =:= shutdo
     end;
 
 handle_info({'EXIT', Pid, _Cause}, State) ->
-    lager:info("fssource ~p exited abnormally", [Pid]),
+    lager:warning("fssource ~p exited abnormally", [Pid]),
     PartitionEntry = lists:keytake(Pid, 1, State#state.running_sources),
     case PartitionEntry of
         false ->

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -336,6 +336,7 @@ handle_cast(_Msg, State) ->
 
 %% @hidden
 handle_info({'EXIT', Pid, Cause}, State) when Cause =:= normal; Cause =:= shutdown ->
+    lager:info("fssource ~p exited normally", [Pid]),
     PartitionEntry = lists:keytake(Pid, 1, State#state.running_sources),
     case PartitionEntry of
         false ->
@@ -383,7 +384,7 @@ handle_info({'EXIT', Pid, Cause}, State) when Cause =:= normal; Cause =:= shutdo
     end;
 
 handle_info({'EXIT', Pid, _Cause}, State) ->
-    lager:warning("fssource ~p exited abnormally", [Pid]),
+    lager:info("fssource ~p exited abnormally", [Pid]),
     PartitionEntry = lists:keytake(Pid, 1, State#state.running_sources),
     case PartitionEntry of
         false ->

--- a/src/riak_repl2_fssink.erl
+++ b/src/riak_repl2_fssink.erl
@@ -1,9 +1,41 @@
 -module(riak_repl2_fssink).
 -include("riak_repl.hrl").
 
+%% @doc fssink
+%%
+%% This module is responsible, at a high level, for accomplishing the full sync
+%% of a single partition. The partition to synchronize is transmitted from the
+%% connected fssource on the source cluster. The strategy for fullsync is determined
+%% dynamically as well:
+%%   keylist - used if the protocol version is < 2.0
+%%   aae     - used if the protocol version is >= 2.0 and AAE is enabled and repl_strategy=aae
+%%
+%% Protocol Support Summary:
+%% -------------------------
+%% 1,0 and up supports keylist strategy
+%% 1,1 and up supports binary object
+%% 2,0 and up supports AAE strategy
+%%
+%% For keylist, the "old" tcp_server is used. That module is capable of handling multiple
+%% sequential partitions, but we only use it to sync a single partition and then we stop it.
+%% For aae, the repl_aae_sink is desinged to process a single partition and be stopped.
+%%
+%% If the protocol version >= 2.0, and the cluster has aae enabled and the replication
+%% configuration stanza enables the aae strategy (the default is keylist), then aae strategy
+%% will be selected. It is negotiated as follows: if the version is >= 2.0, then upon
+%% accepting a connection from the soruce, we send our capabilities to the the source. The
+%% source then sends it's caps to us. This is all done by the fssource and fssink modules
+%% in order to decide which strategy will be used. Once caps are exchanged, both sides can
+%% mutually agree on the strategy (aae if both sides announced it in their caps). If the
+%% node does not have aae enabled in riak_kv or aae strategy is not enabled in riak_repl,
+%% then the caps will not include the "aae" strategy.
+%%
+%% Once the strategy is settled, the sockets are handled to the appropriate spawned
+%% fullssync worker processes.
+
 -behaviour(gen_server).
 %% API
--export([start_link/4, register_service/0, start_service/5, legacy_status/2]).
+-export([start_link/4, register_service/0, start_service/5, legacy_status/2, fullsync_complete/1]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -14,22 +46,30 @@
         socket,
         cluster,
         fullsync_worker,
-        work_dir,
+        work_dir = undefined,
+        strategy :: keylist | aae,
+        proto,
         ver              % highest common wire protocol in common with fs source
     }).
 
 start_link(Socket, Transport, Proto, Props) ->
     gen_server:start_link(?MODULE, [Socket, Transport, Proto, Props], []).
 
+fullsync_complete(Pid) ->
+    %% cast to avoid deadlock in terminate
+    gen_server:cast(Pid, fullsync_complete).
+
 %% Register with service manager
 register_service() ->
-    %% use 1,1 proto for new binary object
-    ProtoPrefs = {fullsync,[{1,1}]},
+    %% 1,0 and up supports keylist strategy
+    %% 1,1 and up supports binary object
+    %% 2,0 and up supports AAE strategy
+    ProtoPrefs = {fullsync,[{1,1}, {2,0}]},
     TcpOptions = [{keepalive, true}, % find out if connection is dead, this end doesn't send
                   {packet, 4},
                   {active, false},
                   {nodelay, true}],
-    HostSpec = {ProtoPrefs, {TcpOptions, ?MODULE, start_service, undefined}},
+    HostSpec     = {ProtoPrefs, {TcpOptions, ?MODULE, start_service, undefined}},
     riak_core_service_mgr:register_service(HostSpec, {round_robin, undefined}).
 
 %% Callback from service manager
@@ -50,25 +90,27 @@ init([Socket, Transport, OKProto, Props]) ->
     {ok, Proto} = OKProto,
     Ver = riak_repl_util:deduce_wire_version_from_proto(Proto),
     SocketTag = riak_repl_util:generate_socket_tag("fs_sink", Transport, Socket),
+    lager:info("Negotiated ~p with ver ~p", [Proto, Ver]),
     lager:debug("Keeping stats for " ++ SocketTag),
     riak_core_tcp_mon:monitor(Socket, {?TCP_MON_FULLSYNC_APP, sink,
                                        SocketTag}, Transport),
 
     Cluster = proplists:get_value(clustername, Props),
-    lager:info("fullsync connection"),
-    {ok, WorkDir} = riak_repl_fsm_common:work_dir(Transport, Socket, Cluster),
-    %% strategy is hardcoded
-    {ok, FullsyncWorker} = riak_repl_keylist_client:start_link(Cluster,
-        Transport, Socket, WorkDir),
-    {ok, #state{cluster=Cluster, transport=Transport, socket=Socket,
-            fullsync_worker=FullsyncWorker, work_dir=WorkDir, ver=Ver}}.
+    lager:info("fullsync connection (ver ~p) from cluster ~p", [Ver, Cluster]),
+    {ok, #state{proto=Proto, socket=Socket, transport=Transport, cluster=Cluster, ver=Ver}}.
 
 handle_call(legacy_status, _From, State=#state{fullsync_worker=FSW,
-                                               socket=Socket}) ->
-    Res = case is_pid(FSW) of
-        true -> gen_fsm:sync_send_all_state_event(FSW, status, infinity);
-        false -> []
-    end,
+                                               socket=Socket, strategy=Strategy}) ->
+    Res = case is_pid(FSW) andalso is_process_alive(FSW) of
+              true ->
+                  case Strategy of
+                      keylist ->
+                          gen_fsm:sync_send_all_state_event(FSW, status);
+                      aae ->
+                          gen_server:call(FSW, status, 5000)
+                  end;
+              false -> []
+          end,
     SocketStats = riak_core_tcp_mon:socket_status(Socket),
     Desc =
         [
@@ -83,6 +125,10 @@ handle_call(legacy_status, _From, State=#state{fullsync_worker=FSW,
 handle_call(_Msg, _From, State) ->
     {reply, ok, State}.
 
+handle_cast(fullsync_complete, State) ->
+    %% sent from AAE fullsync worker
+    lager:info("Fullsync of partition complete."),
+    {stop, normal, State};
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
@@ -97,6 +143,7 @@ handle_info({Error, _Socket, Reason}, State)
     {stop, normal, State};
 handle_info({Proto, Socket, Data},
         State=#state{socket=Socket,transport=Transport}) when Proto==tcp; Proto==ssl ->
+    %% aae strategy will not receive messages here
     Transport:setopts(Socket, [{active, once}]),
     case decode_obj_msg(Data) of
         {fs_diff_obj, RObj} ->
@@ -105,9 +152,35 @@ handle_info({Proto, Socket, Data},
             gen_fsm:send_event(State#state.fullsync_worker, Other)
     end,
     {noreply, State};
-handle_info(init_ack, State=#state{socket=Socket, transport=Transport}) ->
-    Transport:setopts(Socket, [{active, once}]),
-    {noreply, State};
+handle_info(init_ack, State=#state{socket=Socket,
+                                   transport=Transport,
+                                   proto=Proto,
+                                   cluster=Cluster}) ->
+    {_Proto,{CommonMajor,_CMinor},{CommonMajor,_HMinor}} = Proto,
+
+    %% possibly exchange fullsync capabilities with the remote
+    OurCaps = decide_our_caps(CommonMajor),
+    TheirCaps = maybe_exchange_caps(CommonMajor, OurCaps, Socket, Transport),
+    lager:info("Got caps: ~p", [TheirCaps]),
+    Strategy = decide_common_strategy(OurCaps, TheirCaps),
+    lager:info("Common strategy: ~p", [Strategy]),
+
+    case Strategy of
+        keylist ->
+            %% Keylist server strategy
+            Transport:setopts(Socket, [{active, once}]),
+            {ok, WorkDir} = riak_repl_fsm_common:work_dir(Transport, Socket, Cluster),
+            {ok, FullsyncWorker} = riak_repl_keylist_client:start_link(Cluster, Transport,
+                                                                       Socket, WorkDir),
+            {noreply, State#state{cluster=Cluster, fullsync_worker=FullsyncWorker, work_dir=WorkDir,
+                                  strategy=keylist}};
+        aae ->
+            %% AAE strategy
+            {ok, FullsyncWorker} = riak_repl_aae_sink:start_link(Cluster, Transport, Socket, self()),
+            ok = Transport:controlling_process(Socket, FullsyncWorker),
+            riak_repl_aae_sink:init_sync(FullsyncWorker),
+            {noreply, State#state{cluster=Cluster, fullsync_worker=FullsyncWorker, strategy=aae}}
+    end;
 handle_info(_Msg, State) ->
     {noreply, State}.
 
@@ -123,16 +196,65 @@ decode_obj_msg(Data) ->
             Other
     end.
 
-terminate(_Reason, #state{fullsync_worker=FSW, work_dir=WorkDir}) ->
-    case is_pid(FSW) of
+terminate(_Reason, #state{fullsync_worker=FSW, work_dir=WorkDir, strategy=Strategy}) ->
+    case is_pid(FSW) andalso is_process_alive(FSW) of
         true ->
-            gen_fsm:sync_send_all_state_event(FSW, stop);
+            case Strategy of
+                keylist ->
+                    gen_fsm:sync_send_all_state_event(FSW, stop);
+                aae ->
+                    gen_server:call(FSW, stop)
+            end;
         _ ->
             ok
     end,
     %% clean up work dir
-    Cmd = lists:flatten(io_lib:format("rm -rf ~s", [WorkDir])),
-    os:cmd(Cmd).
+    case WorkDir of
+        undefined ->
+            ok;
+        _Other ->
+            Cmd = lists:flatten(io_lib:format("rm -rf ~s", [WorkDir])),
+            os:cmd(Cmd)
+    end.
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
+
+%% decide what strategy to use, given our own capabilties and those
+%% of the remote source.
+decide_common_strategy(_OurCaps, []) -> keylist;
+decide_common_strategy(OurCaps, TheirCaps) ->
+    OurStrategy = proplists:get_value(strategy, OurCaps, keylist),
+    TheirStrategy = proplists:get_value(strategy, TheirCaps, keylist),
+    case {OurStrategy,TheirStrategy} of
+        {aae,aae} -> aae;
+        {_,_}     -> keylist
+    end.
+
+%% Based on the agreed common protocol level and the supported
+%% mode of AAE, decide what strategy we are capable of offering.
+decide_our_caps(CommonMajor) ->
+    SupportedStrategy =
+        case {riak_kv_entropy_manager:enabled(), CommonMajor} of
+            {_,1} -> keylist;
+            {false,_} -> keylist;
+            {true,_} -> aae
+        end,
+    [{strategy, SupportedStrategy}].
+
+%% Depending on the protocol version number, send our capabilities
+%% as a list of properties, in binary.
+maybe_exchange_caps(1, _Caps, _Socket, _Transport) ->
+    [];
+maybe_exchange_caps(_, Caps, Socket, Transport) ->
+    Transport:send(Socket, term_to_binary(Caps)),
+    case Transport:recv(Socket, 0, ?PEERINFO_TIMEOUT) of
+        {ok, Data} ->
+            binary_to_term(Data);
+        {Error, Socket} ->
+            throw(Error);
+        {Error, Socket, Reason} ->
+            throw({Error, Reason})
+    end.
+
+

--- a/src/riak_repl2_fssink.erl
+++ b/src/riak_repl2_fssink.erl
@@ -197,6 +197,7 @@ decode_obj_msg(Data) ->
     end.
 
 terminate(_Reason, #state{fullsync_worker=FSW, work_dir=WorkDir, strategy=Strategy}) ->
+    %% TODO: define a fullsync worker behavior and call it's stop function
     case is_pid(FSW) andalso is_process_alive(FSW) of
         true ->
             case Strategy of

--- a/src/riak_repl2_fssource.erl
+++ b/src/riak_repl2_fssource.erl
@@ -4,7 +4,7 @@
 -behaviour(gen_server).
 %% API
 -export([start_link/2, connected/6, connect_failed/3, start_fullsync/1,
-         stop_fullsync/1, cluster_name/1, legacy_status/2]).
+         stop_fullsync/1, cluster_name/1, legacy_status/2, fullsync_complete/1]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -19,7 +19,8 @@
         connection_ref,
         fullsync_worker,
         work_dir,
-        ver
+        ver,
+        strategy
     }).
 
 start_link(Partition, IP) ->
@@ -40,6 +41,10 @@ start_fullsync(Pid) ->
 stop_fullsync(Pid) ->
     gen_server:call(Pid, stop_fullsync).
 
+fullsync_complete(Pid) ->
+    %% cast to avoid deadlock in terminate
+    gen_server:cast(Pid, fullsync_complete).
+
 %% get the cluster name
 cluster_name(Pid) ->
     gen_server:call(Pid, cluster_name).
@@ -54,23 +59,41 @@ init([Partition, IP]) ->
                   {nodelay, true},
                   {packet, 4},
                   {active, false}],
-    ClientSpec = {{fullsync,[{1,1}]}, {TcpOptions, ?MODULE, self()}},
+
+    DefaultStrategy = keylist,
+
+    %% Determine what kind of fullsync worker strategy we want to start with,
+    %% which could change if we talk to the sink and it can't speak AAE. If
+    %% AAE is not enabled in KV, then we can't use aae strategy.
+    OurCaps = decide_our_caps(DefaultStrategy),
+    SupportedStrategy = proplists:get_value(strategy, OurCaps, DefaultStrategy),
+
+    %% use 1,1 proto for new binary object
+    %% use 2,0 for AAE fullsync + binary objects
+    {Major,Minor} = case SupportedStrategy of
+                        keylist -> {1,1};
+                        aae -> {2,0}
+                    end,
+    ClientSpec = {{fullsync,[{Major,Minor}]}, {TcpOptions, ?MODULE, self()}},
 
     %% TODO: check for bad remote name
     lager:info("connecting to remote ~p", [IP]),
     case riak_core_connection_mgr:connect({identity, IP}, ClientSpec) of
         {ok, Ref} ->
             lager:info("connection ref ~p", [Ref]),
-            {ok, #state{ip = IP, connection_ref = Ref, partition=Partition}};
+            {ok, #state{strategy = SupportedStrategy, ip = IP,
+                        connection_ref = Ref, partition=Partition}};
         {error, Reason}->
             lager:warning("Error connecting to remote"),
             {stop, Reason}
     end.
 
-handle_call({connected, Socket, Transport, _Endpoint, Proto, Props}, _From,
-        State=#state{ip=IP, partition=Partition}) ->
+
+
+handle_call({connected, Socket, Transport, _Endpoint, Proto, Props},
+            _From, State=#state{ip=IP, partition=Partition, strategy=DefaultStrategy}) ->
     Ver = riak_repl_util:deduce_wire_version_from_proto(Proto),
-    lager:debug("Negotiated ~p wire format", [Ver]),
+    lager:info("Negotiated ~p with ver ~p", [Proto, Ver]),
     Cluster = proplists:get_value(clustername, Props),
     lager:info("fullsync connection to ~p for ~p",[IP, Partition]),
 
@@ -79,25 +102,64 @@ handle_call({connected, Socket, Transport, _Endpoint, Proto, Props}, _From,
     riak_core_tcp_mon:monitor(Socket, {?TCP_MON_FULLSYNC_APP, source,
                                        SocketTag}, Transport),
 
+    %% Strategy still depends on what the sink is capable of.
+    {_Proto,{CommonMajor,_CMinor},{CommonMajor,_HMinor}} = Proto,
+
+    OurCaps = decide_our_caps(DefaultStrategy),
+    TheirCaps = maybe_exchange_caps(CommonMajor, OurCaps, Socket, Transport),
+    lager:info("Got caps: ~p", [TheirCaps]),
+    Strategy = decide_common_strategy(OurCaps, TheirCaps),
+    lager:info("Common strategy: ~p", [Strategy]),
+
     Transport:setopts(Socket, [{active, once}]),
-    {ok, WorkDir} = riak_repl_fsm_common:work_dir(Transport, Socket, Cluster),
-    {ok, Client} = riak:local_client(),
-    %% strategy is hardcoded
-    {ok, FullsyncWorker} = riak_repl_keylist_server:start_link(Cluster,
-        Transport, Socket, WorkDir, Client),
-    riak_repl_keylist_server:start_fullsync(FullsyncWorker, [Partition]),
-    {reply, ok, State#state{transport=Transport, socket=Socket,
-            cluster=Cluster,
-            fullsync_worker=FullsyncWorker, work_dir=WorkDir, ver=Ver}};
-handle_call(start_fullsync, _From, State=#state{fullsync_worker=FSW}) ->
-    riak_repl_keylist_server:start_fullsync(FSW),
+
+    case Strategy of
+        keylist ->
+            %% Keylist server strategy
+            {ok, WorkDir} = riak_repl_fsm_common:work_dir(Transport, Socket, Cluster),
+            {ok, Client} = riak:local_client(),
+            {ok, FullsyncWorker} = riak_repl_keylist_server:start_link(Cluster,
+                                                                       Transport, Socket, WorkDir, Client),
+            riak_repl_keylist_server:start_fullsync(FullsyncWorker, [Partition]),
+            {reply, ok, State#state{transport=Transport, socket=Socket, cluster=Cluster,
+                                    fullsync_worker=FullsyncWorker, work_dir=WorkDir, ver=Ver,
+                                    strategy=keylist}};
+        aae ->
+            %% AAE strategy
+            {ok, Client} = riak:local_client(),
+            {ok, FullsyncWorker} = riak_repl_aae_source:start_link(Cluster, Client,
+                                                                   Transport, Socket,
+                                                                   Partition,
+                                                                   self()),
+            ok = Transport:controlling_process(Socket, FullsyncWorker),
+            riak_repl_aae_source:start_exchange(FullsyncWorker),
+            {reply, ok,
+             State#state{transport=Transport, socket=Socket, cluster=Cluster,
+                         fullsync_worker=FullsyncWorker, work_dir="/dev/null",
+                         ver=Ver, strategy=aae}}
+    end;
+            
+handle_call(start_fullsync, _From, State=#state{fullsync_worker=FSW,
+                                                strategy=Strategy}) ->
+    case Strategy of
+        keylist ->
+            riak_repl_keylist_server:start_fullsync(FSW);
+        aae ->
+            ok
+    end,
     {reply, ok, State};
-handle_call(stop_fullsync, _From, State=#state{fullsync_worker=FSW}) ->
-    riak_repl_keylist_server:cancel_fullsync(FSW),
+handle_call(stop_fullsync, _From, State=#state{fullsync_worker=FSW,
+                                               strategy=Strategy}) ->
+    case Strategy of
+        keylist ->
+            riak_repl_keylist_server:cancel_fullsync(FSW);
+        aae ->
+            riak_repl_aae_source:cancel_fullsync(FSW)
+    end,
     {reply, ok, State};
 handle_call(legacy_status, _From, State=#state{fullsync_worker=FSW,
                                                socket=Socket}) ->
-    Res = case is_pid(FSW) of
+    Res = case is_pid(FSW) andalso is_process_alive(FSW) of
         true -> gen_fsm:sync_send_all_state_event(FSW, status, infinity);
         false -> []
     end,
@@ -123,6 +185,10 @@ handle_call(cluster_name, _From, State) ->
 handle_call(_Msg, _From, State) ->
     {reply, ok, State}.
 
+handle_cast(fullsync_complete, State=#state{partition=Partition}) ->
+    %% sent from AAE fullsync worker
+    lager:info("Fullsync for partition ~p complete.", [Partition]),
+    {stop, normal, State};
 handle_cast({connect_failed, _Pid, Reason},
      State = #state{cluster = Cluster}) ->
      lager:info("fullsync replication connection to cluster ~p failed ~p",
@@ -146,7 +212,9 @@ handle_info({Proto, Socket, Data},
     Msg = binary_to_term(Data),
     case Msg == fullsync_complete of
         true ->
-            %% stop on fullsync completion
+            %% sent from the keylist_client when it's done.
+            %% stop on fullsync completion, which will call
+            %% our terminate function and stop the keylist_server.
             {stop, normal, State};
         _ ->
             gen_fsm:send_event(State#state.fullsync_worker, Msg),
@@ -156,11 +224,12 @@ handle_info(_Msg, State) ->
     {noreply, State}.
 
 terminate(_Reason, #state{fullsync_worker=FSW, work_dir=WorkDir}) ->
-    case is_pid(FSW) of
+    %% check if process alive only if it's defined
+    case is_pid(FSW) andalso is_process_alive(FSW) of
+        false ->
+            ok;
         true ->
-            gen_fsm:sync_send_all_state_event(FSW, stop);
-        _ ->
-            ok
+            gen_fsm:sync_send_all_state_event(FSW, stop)
     end,
     %% clean up work dir
     Cmd = lists:flatten(io_lib:format("rm -rf ~s", [WorkDir])),
@@ -170,3 +239,46 @@ code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
 
+%% Based on the agreed common protocol level and the supported
+%% mode of AAE, decide what strategy we are capable of offering.
+decide_our_caps(DefaultStrategy) ->
+    SupportedStrategy =
+        case {riak_kv_entropy_manager:enabled(),
+              app_helper:get_env(riak_repl, fullsync_strategy, DefaultStrategy)} of
+            {false,_} -> keylist;
+            {true,aae} -> aae;
+            {true,keylist} -> keylist;
+            {true,UnSupportedStrategy} ->
+                lager:warning("App config for riak_repl/fullsync_strategy ~p is unsupported. Using ~p",
+                              [UnSupportedStrategy, DefaultStrategy]),
+                DefaultStrategy
+        end,
+    [{strategy, SupportedStrategy}].
+
+%% decide what strategy to use, given our own capabilties and those
+%% of the remote source.
+decide_common_strategy(_OurCaps, []) -> keylist;
+decide_common_strategy(OurCaps, TheirCaps) ->
+    OurStrategy = proplists:get_value(strategy, OurCaps, keylist),
+    TheirStrategy = proplists:get_value(strategy, TheirCaps, keylist),
+    case {OurStrategy,TheirStrategy} of
+        {aae,aae} -> aae;
+        {_,_}     -> keylist
+    end.
+
+%% Depending on the protocol version number, send our capabilities
+%% as a list of properties, in binary.
+maybe_exchange_caps(1, _Caps, _Socket, _Transport) ->
+    [];
+maybe_exchange_caps(_, Caps, Socket, Transport) ->
+    TheirCaps =
+        case Transport:recv(Socket, 0, ?PEERINFO_TIMEOUT) of
+            {ok, Data} ->
+                binary_to_term(Data);
+            {Error, Socket} ->
+                throw(Error);
+            {Error, Socket, Reason} ->
+                throw({Error, Reason})
+        end,
+    Transport:send(Socket, term_to_binary(Caps)),
+    TheirCaps.

--- a/src/riak_repl2_fssource.erl
+++ b/src/riak_repl2_fssource.erl
@@ -91,11 +91,6 @@ init([Partition, IP]) ->
 
 handle_call({connected, Socket, Transport, _Endpoint, Proto, Props},
             _From, State=#state{ip=IP, partition=Partition, strategy=DefaultStrategy}) ->
-<<<<<<< HEAD
-=======
-    Ver = riak_repl_util:deduce_wire_version_from_proto(Proto),
-    lager:info("Negotiated ~p with ver ~p", [Proto, Ver]),
->>>>>>> d044370ce20c58892ea8607455c09d0d4fa811c0
     Cluster = proplists:get_value(clustername, Props),
     lager:info("fullsync connection to ~p for ~p",[IP, Partition]),
 

--- a/src/riak_repl2_fssource.erl
+++ b/src/riak_repl2_fssource.erl
@@ -19,7 +19,6 @@
         connection_ref,
         fullsync_worker,
         work_dir,
-        ver,
         strategy
     }).
 
@@ -92,8 +91,6 @@ init([Partition, IP]) ->
 
 handle_call({connected, Socket, Transport, _Endpoint, Proto, Props},
             _From, State=#state{ip=IP, partition=Partition, strategy=DefaultStrategy}) ->
-    Ver = riak_repl_util:deduce_wire_version_from_proto(Proto),
-    lager:info("Negotiated ~p with ver ~p", [Proto, Ver]),
     Cluster = proplists:get_value(clustername, Props),
     lager:info("fullsync connection to ~p for ~p",[IP, Partition]),
 
@@ -122,7 +119,7 @@ handle_call({connected, Socket, Transport, _Endpoint, Proto, Props},
                                                                        Transport, Socket, WorkDir, Client),
             riak_repl_keylist_server:start_fullsync(FullsyncWorker, [Partition]),
             {reply, ok, State#state{transport=Transport, socket=Socket, cluster=Cluster,
-                                    fullsync_worker=FullsyncWorker, work_dir=WorkDir, ver=Ver,
+                                    fullsync_worker=FullsyncWorker, work_dir=WorkDir,
                                     strategy=keylist}};
         aae ->
             %% AAE strategy
@@ -137,7 +134,7 @@ handle_call({connected, Socket, Transport, _Endpoint, Proto, Props},
             {reply, ok,
              State#state{transport=Transport, socket=Socket, cluster=Cluster,
                          fullsync_worker=FullsyncWorker, work_dir=undefined,
-                         ver=Ver, strategy=aae}}
+                         strategy=aae}}
     end;
             
 handle_call(start_fullsync, _From, State=#state{fullsync_worker=FSW,

--- a/src/riak_repl2_rtsource_helper.erl
+++ b/src/riak_repl2_rtsource_helper.erl
@@ -60,17 +60,6 @@ init([Remote, Transport, Socket, Version]) ->
     async_pull(State),
     {ok, State}.
 
-%% @doc BinObjs are in new riak binary object format. If the remote sink
-%%      is storing older non-binary objects, then we need to downconvert
-%%      the objects before sending. V is the format expected by the sink.
-maybe_downconvert_binary_objs(BinObjs, w0) ->
-    %% old sink. downconvert
-    Objs = riak_repl_util:from_wire(w1, BinObjs),
-    riak_repl_util:to_wire(w0, Objs);
-maybe_downconvert_binary_objs(BinObjs, w1) ->
-    %% great! nothing to do.
-    BinObjs.
-
 handle_call({pull, {error, Reason}}, _From, State) ->
     riak_repl_stats:rt_source_errors(),
     {stop, {queue_error, Reason}, ok, State};

--- a/src/riak_repl2_rtsource_helper.erl
+++ b/src/riak_repl2_rtsource_helper.erl
@@ -53,20 +53,6 @@ init([Remote, Transport, Socket, Ver]) ->
     async_pull(State),
     {ok, State}.
 
-%% @doc BinObjs are in new riak binary object format. If the remote sink
-%%      is storing older non-binary objects, then we need to downconvert
-%%      the objects before sending. V is the format expected by the sink.
-maybe_downconvert_binary_objs(BinObjs, V) ->
-    case V of
-        w1 ->
-            %% great! nothing to do.
-            BinObjs;
-        w0 ->
-            %% old sink. downconvert
-            Objs = riak_repl_util:from_wire(w1, BinObjs),
-            riak_repl_util:to_wire(w0, Objs)
-    end.
-
 handle_call({pull, {error, Reason}}, _From, State) ->
     riak_repl_stats:rt_source_errors(),
     {stop, {queue_error, Reason}, State};

--- a/src/riak_repl2_rtsource_helper.erl
+++ b/src/riak_repl2_rtsource_helper.erl
@@ -92,7 +92,7 @@ handle_cast({v1_ack, Seq}, State = #state{v1_seq_map = Map}) ->
     Map2 = orddict:erase(Seq, Map),
     {noreply, State#state{v1_seq_map = Map2}};
 
-handle_cast(Msg, State) ->
+handle_cast(Msg, _State) ->
     lager:info("Realtime source helper received unexpected cast - ~p\n", [Msg]).
 
 
@@ -132,7 +132,7 @@ encode({Seq, _NumObjs, BinObjs, Meta}, State = #state{proto = Ver}) when Ver < {
     Offset = State#state.v1_offset + Skips,
     Seq2 = Seq - Offset,
     V1Map = orddict:store(Seq2, Seq, State#state.v1_seq_map),
-    BinObjs2 = maybe_downconvert_binary_objs(BinObjs, w0),
+    BinObjs2 = riak_repl_util:maybe_downconvert_binary_objs(BinObjs, w0),
     Encoded = riak_repl2_rtframe:encode(objects, {Seq2, BinObjs2}),
     State2 = State#state{v1_offset = Offset, v1_seq_map = V1Map},
     {Encoded, State2};

--- a/src/riak_repl_aae_fullsync.hrl
+++ b/src/riak_repl_aae_fullsync.hrl
@@ -7,3 +7,4 @@
 -define(MSG_PUT_OBJ, 7).
 -define(MSG_GET_OBJ, 8).
 -define(MSG_COMPLETE, 9).
+-define(AAE_FULLSYNC_REPLY_TIMEOUT, 60000). %% 1 minute to hear from remote sink

--- a/src/riak_repl_aae_fullsync.hrl
+++ b/src/riak_repl_aae_fullsync.hrl
@@ -1,0 +1,9 @@
+-define(MSG_INIT, 1).
+-define(MSG_LOCK_TREE, 2).
+-define(MSG_UPDATE_TREE, 3).
+-define(MSG_GET_AAE_BUCKET, 4).
+-define(MSG_GET_AAE_SEGMENT, 5).
+-define(MSG_REPLY, 6).
+-define(MSG_PUT_OBJ, 7).
+-define(MSG_GET_OBJ, 8).
+-define(MSG_COMPLETE, 9).

--- a/src/riak_repl_aae_sink.erl
+++ b/src/riak_repl_aae_sink.erl
@@ -76,13 +76,10 @@ handle_info({Proto, _Socket, Data}, State=#state{transport=Transport,
     ok = Transport:setopts(Socket, TcpOptions),
     case Data of
         [MsgType] ->
-            trace(MsgType),
             process_msg(MsgType, State);
         [MsgType|<<>>] ->
-            trace(MsgType),
             process_msg(MsgType, State);
         [MsgType|MsgData] ->
-            trace(MsgType),
             process_msg(MsgType, binary_to_term(MsgData), State)
     end;
 
@@ -143,9 +140,6 @@ process_msg(?MSG_GET_AAE_SEGMENT, {SegmentNum,IndexN}, State=#state{tree_pid=Tre
 %% no reply
 process_msg(?MSG_PUT_OBJ, {fs_diff_obj, BObj}, State) ->
     RObj = riak_repl_util:from_wire(BObj),
-    %% B = riak_object:bucket(RObj),
-    %% K = riak_object:key(RObj),
-    %% lager:info("PUT ~p:~p", [B, K]),
     %% do the put
     riak_repl_util:do_repl_put(RObj),
     {noreply, State};
@@ -167,15 +161,10 @@ process_msg(?MSG_COMPLETE, State=#state{owner=Owner}) ->
     riak_repl2_fssink:fullsync_complete(Owner),
     {stop, normal, State}.
 
-trace(_Msg) ->
-%%    lager:info("Sink <-------- ~p", [_Msg]),
-    ok.
-
 %% Send a response back to the aae_source worker
 
 send_reply(Msg, State=#state{socket=Socket, transport=Transport}) ->
     Data = term_to_binary(Msg),
     ok = Transport:send(Socket, <<?MSG_REPLY:8, Data/binary>>),
-%%    lager:info("Sink --------> ~p", [Msg]),
     {noreply, State}.
 

--- a/src/riak_repl_aae_sink.erl
+++ b/src/riak_repl_aae_sink.erl
@@ -1,0 +1,181 @@
+%% @doc
+%% This module implements a fullsync "sink" strategy that uses Active Anti-Entropy (AAE).
+%% It takes full control of the socket to the source side and implements the entire protocol
+%% here. 
+%%
+-module(riak_repl_aae_sink).
+-include("riak_repl.hrl").
+-include("riak_repl_aae_fullsync.hrl").
+
+-behaviour(gen_server).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+%% API
+-export([start_link/4, init_sync/1]).
+
+-record(state, {
+          clustername,
+          socket,
+          transport,
+          tree_pid      :: pid(),  %% pid of the AAE tree
+          partition,
+          owner         :: pid()   %% our fssource owner
+         }).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+start_link(ClusterName, Transport, Socket, OwnerPid) ->
+    gen_server:start_link(?MODULE, [ClusterName, Transport, Socket, OwnerPid], []).
+
+%% Called after ownership of socket has been given to AAE sink worker
+init_sync(AAEWorker) ->
+    gen_server:call(AAEWorker, init_sync, infinity).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+init([ClusterName, Transport, Socket, OwnerPid]) ->
+    lager:info("Starting AAE fullsync sink worker"),
+    {ok, #state{clustername=ClusterName, socket=Socket, transport=Transport, owner=OwnerPid}}.
+
+handle_call(init_sync, _From, State=#state{transport=Transport, socket=Socket}) ->
+    TcpOptions = [{keepalive, true}, % find out if connection is dead, this end doesn't send
+                  {packet, 4},
+                  {active, once},
+                  {nodelay, true},
+                  {header, 1}],
+    ok = Transport:setopts(Socket, TcpOptions),
+    {reply, ok, State};
+
+handle_call(status, _From, State) ->
+    Reply = [{partition_syncing, State#state.partition}],
+    {reply, Reply, State};
+
+handle_call(stop, _From, State) ->
+    {stop, normal, ok, State};
+
+handle_call(_Request, _From, State) ->
+    Reply = ok,
+    {reply, Reply, State}.
+
+handle_cast(stop, State) ->
+    {stop, normal, State};
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info({Proto, _Socket, Data}, State=#state{transport=Transport,
+                                                 socket=Socket}) when Proto==tcp; Proto==ssl ->
+    TcpOptions = [{active, once}], %% reset to receive next tcp message
+    ok = Transport:setopts(Socket, TcpOptions),
+    case Data of
+        [MsgType] ->
+            trace(MsgType),
+            process_msg(MsgType, State);
+        [MsgType|<<>>] ->
+            trace(MsgType),
+            process_msg(MsgType, State);
+        [MsgType|MsgData] ->
+            trace(MsgType),
+            process_msg(MsgType, binary_to_term(MsgData), State)
+    end;
+
+handle_info({'DOWN', _, _, _, _}, State) ->
+    {stop, tree_down, State};
+
+handle_info({tcp_closed, Socket}, State=#state{socket=Socket}) ->
+    lager:info("AAE sink connection to ~p closed", [State#state.clustername]),
+    {stop, normal, State};
+handle_info({tcp_error, _Socket, Reason}, State) ->
+    lager:error("AAE sink connection to ~p closed unexpectedly: ~p",
+                [State#state.clustername, Reason]),
+    {stop, normal, State};
+handle_info({ssl_closed, Socket}, State=#state{socket=Socket}) ->
+    lager:info("AAE sink ssl connection to ~p closed", [State#state.clustername]),
+    {stop, normal, State};
+handle_info({ssl_error, _Socket, Reason}, State) ->
+    lager:error("AAE sink ssl connection to ~p closed unexpectedly with: ~p",
+                [State#state.clustername, Reason]),
+    {stop, normal, State};
+handle_info({Error, Socket, Reason},
+            State=#state{socket=MySocket}) when Socket == MySocket ->
+    lager:info("AAE sink connection to ~p closed unexpectedly: ~p",
+               [State#state.clustername, {Socket, Error, Reason}]),
+    {stop, {Socket, Error, Reason}, State};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    lager:info("Terminating."),
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+%% replies: ok
+process_msg(?MSG_INIT, Partition, State) ->
+    lager:info("MSG_INIT for partition ~p", [Partition]),
+    {ok, TreePid} = riak_kv_vnode:hashtree_pid(Partition),
+    %% monitor the tree and crash if the tree goes away
+    monitor(process, TreePid),
+    %% tell the reservation coordinator that we are taking this partition.
+    riak_repl2_fs_node_reserver:claim_reservation(Partition),
+    send_reply(ok, State#state{partition=Partition, tree_pid=TreePid});
+
+process_msg(?MSG_GET_AAE_BUCKET, {Level,BucketNum,IndexN}, State=#state{tree_pid=TreePid}) ->
+    ResponseMsg = riak_kv_index_hashtree:exchange_bucket(IndexN, Level, BucketNum, TreePid),
+    send_reply(ResponseMsg, State);
+
+process_msg(?MSG_GET_AAE_SEGMENT, {SegmentNum,IndexN}, State=#state{tree_pid=TreePid}) ->
+    ResponseMsg = riak_kv_index_hashtree:exchange_segment(IndexN, SegmentNum, TreePid),
+    send_reply(ResponseMsg, State);
+
+%% no reply
+process_msg(?MSG_PUT_OBJ, {fs_diff_obj, BObj}, State) ->
+    RObj = riak_repl_util:from_wire(BObj),
+    %% B = riak_object:bucket(RObj),
+    %% K = riak_object:key(RObj),
+    %% lager:info("PUT ~p:~p", [B, K]),
+    %% do the put
+    riak_repl_util:do_repl_put(RObj),
+    {noreply, State};
+
+%% replies: ok | not_responsible
+process_msg(?MSG_UPDATE_TREE, IndexN, State=#state{tree_pid=TreePid}) ->
+    ResponseMsg = riak_kv_index_hashtree:update(IndexN, TreePid),
+    send_reply(ResponseMsg, State).
+
+%% replies: ok | not_built | already_locked
+process_msg(?MSG_LOCK_TREE, State=#state{tree_pid=TreePid}) ->
+    %% NOTE: be sure to die if tcp connection dies, to give back lock
+    ResponseMsg = riak_kv_index_hashtree:get_lock(TreePid, fullsync_sink),
+    send_reply(ResponseMsg, State);
+
+%% no reply
+process_msg(?MSG_COMPLETE, State=#state{owner=Owner}) ->
+    lager:info("got complete"),
+    riak_repl2_fssink:fullsync_complete(Owner),
+    {stop, normal, State}.
+
+trace(_Msg) ->
+%%    lager:info("Sink <-------- ~p", [_Msg]),
+    ok.
+
+%% Send a response back to the aae_source worker
+
+send_reply(Msg, State=#state{socket=Socket, transport=Transport}) ->
+    Data = term_to_binary(Msg),
+    ok = Transport:send(Socket, <<?MSG_REPLY:8, Data/binary>>),
+%%    lager:info("Sink --------> ~p", [Msg]),
+    {noreply, State}.
+

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -1,0 +1,657 @@
+%% Riak EnterpriseDS
+%% Copyright 2013 Basho Technologies, Inc. All Rights Reserved.
+
+-module(riak_repl_aae_source).
+-behaviour(gen_fsm).
+
+-include("riak_repl.hrl").
+-include("riak_repl_aae_fullsync.hrl").
+
+%% API
+-export([start_link/6, start_exchange/1]).
+
+%% FSM states
+-export([prepare_exchange/2,
+         update_trees/2,
+         cancel_fullsync/1,
+         key_exchange/2,
+         send_diffs/2,
+         send_diffs/3,
+         send_missing/3,
+         bloom_fold/3]).
+
+%% gen_fsm callbacks
+-export([init/1, handle_event/3, handle_sync_event/4, handle_info/3,
+         terminate/3, code_change/4]).
+
+-export([replicate_diff/3]).
+
+-type index() :: non_neg_integer().
+-type index_n() :: {index(), pos_integer()}.
+
+-record(state, {cluster,
+                client,     %% riak:local_client()
+                transport,
+                socket,
+                index       :: index(),
+                indexns     :: [index_n()],
+                tree_pid    :: pid(),
+                built       :: non_neg_integer(),
+                timeout     :: pos_integer(),
+                wire_ver    :: atom(),
+                diff_batch_size = 1000 :: non_neg_integer(),
+                local_lock = false :: boolean(),
+                owner       :: pid()
+               }).
+
+%% Per state transition timeout used by certain transitions
+-define(DEFAULT_ACTION_TIMEOUT, 300000). %% 5 minutes
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec start_link(term(), term(), term(), term(), index(), pid())
+                -> {ok,pid()} | ignore | {error, term()}.
+start_link(Cluster, Client, Transport, Socket, Partition, OwnerPid) ->
+    gen_fsm:start(?MODULE, [Cluster, Client, Transport, Socket, Partition, OwnerPid], []).
+
+start_exchange(AAESource) ->
+    lager:debug("Send start_exchange to AAE fullsync sink worker"),
+    gen_fsm:send_event(AAESource, start_exchange).
+
+cancel_fullsync(Pid) ->
+    gen_fsm:send_event(Pid, cancel_fullsync).
+
+%%%===================================================================
+%%% gen_fsm callbacks
+%%%===================================================================
+
+init([Cluster, Client, Transport, Socket, Partition, OwnerPid]) ->
+    %% Get the list of IndexNs for this partition. We'll lock the tree just once
+    %% for all combined IndexNs and iterate over them. When finished, send
+    %% COMPLETE msg to signal sink to die and unlock tree.
+
+    lager:info("AAE fullsync source worker started for partition ~p", [Partition]),
+
+    Timeout = app_helper:get_env(riak_kv,
+                                 anti_entropy_timeout,
+                                 ?DEFAULT_ACTION_TIMEOUT),
+
+    {ok, TreePid} = riak_kv_vnode:hashtree_pid(Partition),
+
+    %% monitor(process, Manager),
+    monitor(process, TreePid),
+
+    %% List of IndexNs to iterate over.
+    IndexNs = riak_kv_util:responsible_preflists(Partition),
+
+    lager:debug("AAE fullsync source partition ~p has Indexes ~p", [Partition, IndexNs]),
+
+    State = #state{cluster=Cluster,
+                   client=Client,
+                   transport=Transport,
+                   socket=Socket,
+                   index=Partition,
+                   indexns=IndexNs,
+                   tree_pid=TreePid,
+                   timeout=Timeout,
+                   built=0,
+                   owner=OwnerPid,
+                   wire_ver=w1}, %% can't be w0 because they don't do AAE
+    {ok, prepare_exchange, State}.
+
+handle_event(_Event, StateName, State) ->
+    {next_state, StateName, State}.
+
+handle_sync_event(stop,_F,_StateName,State) ->
+    {stop, normal, ok, State};
+
+handle_sync_event(status, _From, StateName, State) ->
+    Res = [{state, StateName},
+           {partition_syncing, State#state.index},
+           {wire_ver, State#state.wire_ver},
+           {trees_built, State#state.built}
+          ],
+    {reply, Res, StateName, State};
+
+handle_sync_event(_Event, _From, StateName, State) ->
+    {reply, ok, StateName, State}.
+
+handle_info(Error={'DOWN', _, _, _, _}, _StateName, State) ->
+    %% Either the entropy manager, local hashtree, or remote hashtree has
+    %% exited. Stop exchange.
+    lager:info("Something went down ~p", [Error]),
+    send_complete(State),
+    {stop, something_went_down, State};
+handle_info(_Info, StateName, State) ->
+    {next_state, StateName, State}.
+
+terminate(_Reason, _StateName, _State) ->
+    lager:info("Terminating."),
+    ok.
+
+code_change(_OldVsn, StateName, State, _Extra) ->
+    {ok, StateName, State}.
+
+%%%===================================================================
+%%% gen_fsm states
+%%%===================================================================
+
+%% @doc Initial state. Attempt to acquire all necessary exchange locks.
+%%      In order, acquire local concurrency lock, local tree lock,
+%%      remote concurrency lock, and remote tree lock. Exchange will
+%%      timeout if locks cannot be acquired in a timely manner.
+prepare_exchange(cancel_fullsync, State) ->
+    larger:info("AAE fullsync source cancelled for partition ~p", [State#state.index]),
+    send_complete(State),
+    {stop, normal, State};
+prepare_exchange(start_exchange, State=#state{transport=Transport,
+                                              socket=Socket,
+                                              index=Partition,
+                                              local_lock=Lock}) when Lock == false ->
+    TcpOptions = [{keepalive, true},
+                  {packet, 4},
+                  {active, once},
+                  {nodelay, true},
+                  {header, 1}],
+    %% try to get local lock of the tree
+    lager:debug("Prepare exchange for partition ~p", [Partition]),
+    ok = Transport:setopts(Socket, TcpOptions),
+    trace("Send MSG_INIT for part", Partition),
+    ok = send_synchronous_msg(?MSG_INIT, Partition, State),
+    case riak_kv_index_hashtree:get_lock(State#state.tree_pid, fullsync_source) of
+        ok ->
+            prepare_exchange(start_exchange, State#state{local_lock=true});
+        Error ->
+            lager:info("AAE source failed get_lock for partition ~p, got ~p",
+                       [Partition, Error]),
+            send_complete(State),
+            send_exchange_status(Error, State),
+            {stop, Error, State}
+    end;
+prepare_exchange(start_exchange, State=#state{index=Partition}) ->
+    %% try to get the remote lock
+    trace("Send MSG_LOCK_TREE for part", Partition),
+    case send_synchronous_msg(?MSG_LOCK_TREE, State) of
+        ok ->
+            update_trees(start_exchange, State);
+        already_locked ->
+            %% This partition is already locked, probably by a vnode doing a handoff.
+            %% ideally, we would put this back on the queue, but we'll just need to
+            %% wait for a while and try again since we can't unclaim it yet.
+            lager:info("AAE tree for partition ~p is already_locked. Trying again in ~p seconds.",
+                       [?RETRY_AAE_LOCKED_INTERVAL]),
+            gen_fsm:send_event_after(?RETRY_AAE_LOCKED_INTERVAL, start_exchange),
+            {next_state, prepare_exchange, State};
+        Error ->
+            lager:warning("lock tree for partition ~p failed, got ~p",
+                          [Partition, Error]),
+            send_complete(State),
+            send_exchange_status({remote, Error}, State),
+            {stop, {remote, Error}, State}
+    end.
+
+%% @doc Now that locks have been acquired, ask both the local and remote
+%%      hashtrees to perform a tree update. If updates do not occur within
+%%      a timely manner, the exchange will timeout. Since the trees will
+%%      continue to finish the update even after the exchange times out,
+%%      a future exchange should eventually make progress.
+update_trees(cancel_fullsync, State) ->
+    larger:info("AAE fullsync source cancelled for partition ~p", [State#state.index]),
+    send_complete(State),
+    {stop, normal, State};
+update_trees(start_exchange, State=#state{indexns=IndexN, owner=Owner}) when IndexN == [] ->
+    send_complete(State),
+    lager:info("AAE fullsync source completed partition ~p. Stopping.",
+               [State#state.index]),
+    riak_repl2_fssource:fullsync_complete(Owner),
+%%    {stop, normal, State};
+    {next_state, update_trees, State};
+update_trees(start_exchange, State=#state{tree_pid=TreePid,
+                                          index=Partition,
+                                          indexns=[IndexN|_IndexNs]}) ->
+    lager:debug("Start exchange for partition,IndexN ~p,~p", [Partition, IndexN]),
+    update_request(TreePid, {Partition, undefined}, IndexN),
+    trace("Send MSG_UPDATE_TREE for partition", Partition),
+    case send_synchronous_msg(?MSG_UPDATE_TREE, IndexN, State) of
+        ok ->
+            update_trees({tree_built, Partition, IndexN}, State);
+        not_responsible ->
+            update_trees({not_responsible, Partition, IndexN}, State)
+    end;
+
+update_trees({not_responsible, Partition, IndexN}, State) ->
+    lager:info("VNode ~p does not cover preflist ~p", [Partition, IndexN]),
+    send_complete(State),
+    send_exchange_status({not_responsible, Partition, IndexN}, State),
+    {stop, not_responsible, State};
+update_trees({tree_built, _, _}, State) ->
+    Built = State#state.built + 1,
+    case Built of
+        2 ->
+            lager:debug("Moving to key exchange state"),
+            gen_fsm:send_event(self(), start_key_exchange),
+            {next_state, key_exchange, State};
+        _ ->
+            {next_state, update_trees, State#state{built=Built}}
+    end.
+
+%% @doc Now that locks have been acquired and both hashtrees have been updated,
+%%      perform a key exchange and trigger replication for any divergent keys.
+key_exchange(cancel_fullsync, State) ->
+    larger:info("AAE fullsync source cancelled for partition ~p", [State#state.index]),
+    send_complete(State),
+    {stop, normal, State};
+key_exchange(start_key_exchange, State=#state{cluster=Cluster,
+                                              transport=Transport,
+                                              socket=Socket,
+                                              index=Partition,
+                                              tree_pid=TreePid,
+                                              indexns=[IndexN|_IndexNs]}) ->
+    lager:debug("Starting fullsync key exchange with ~p for ~p/~p",
+               [Cluster, Partition, IndexN]),
+
+    SourcePid = self(),
+
+    %% A function that receives callbacks from the hashtree:compare engine.
+    %% This will send messages to ourself, handled in compare_loop(), that
+    %% allow us to pass control of the TCP socket around. This is needed so
+    %% that the process needing to send/receive on that socket has ownership
+    %% of it.
+    Remote = fun(init, _) ->
+                     %% cause control of the socket to be given to AAE so that
+                     %% the get_bucket and key_hashes can send messages via the
+                     %% socket (with correct ownership). We'll send a 'ready'
+                     %% back here once the socket ownership is transfered and
+                     %% we are ready to proceed with the compare.
+                     trace("Init worker_pid", [Partition]),
+                     SourcePid ! {'$aae_src', worker_pid, self()},
+                     receive
+                         {'$aae_src', ready, SourcePid} ->
+                             ok
+                     end;
+                (get_bucket, {L, B}) ->
+                     trace("Send MSG_GET_AAE_BUCKET for bucket", B),
+                     send_synchronous_msg(?MSG_GET_AAE_BUCKET, {L,B,IndexN}, State);
+                (key_hashes, Segment) ->
+                     trace("Send MSG_GET_AAE_SEGMENT for segment", Segment),
+                     send_synchronous_msg(?MSG_GET_AAE_SEGMENT, {Segment,IndexN}, State);
+                (final, _) ->
+                     %% give ourself control of the socket again
+                     trace("Final"),
+                     ok = Transport:controlling_process(Socket, SourcePid)
+             end,
+
+    %% Unclear if we should allow exchange to run indefinitely or enforce
+    %% a timeout. The problem is that depending on the number of keys and
+    %% key differences, exchange can take arbitrarily long. For now, go with
+    %% unbounded exchange, with the ability to cancel exchanges through the
+    %% entropy manager if needed.
+
+    %% accumulates a list of one element that is the count of
+    %% keys that differed. We can't prime the accumulator. It
+    %% always starts as the empty list. KeyDiffs is a list of hashtree::keydiff()
+    NumKeys = 10000000,
+    {ok, Bloom} = ebloom:new(NumKeys, 0.01, random:uniform(1000)),
+    AccFun = fun(KeyDiffs, Acc0) ->
+                     %% Gather diff keys into a bloom filter
+                     lists:foldl(fun(KeyDiff, AccIn) ->
+                                         accumulate_diff(KeyDiff, Bloom, AccIn, State) end,
+                                 Acc0,
+                                 KeyDiffs)
+             end,
+
+    %% TODO: Add stats for AAE
+    lager:debug("Starting compare for partition ~p", [Partition]),
+    spawn_link(fun() ->
+                       StageStart=os:timestamp(),
+                       Acc = riak_kv_index_hashtree:compare(IndexN, Remote, AccFun, TreePid),
+                       %% Maybe you wish you could move this send up to the compare function,
+                       %% but we need it to send the Accumulated results back to our SourcePid.
+                       Count = case Acc of
+                                   [] -> 0;
+                                   [N] -> N
+                               end,
+                       lager:info("Full-sync with site ~p; fullsync difference generator for ~p complete (completed in ~p secs)",
+                                  [State#state.cluster, Partition, riak_repl_util:elapsed_secs(StageStart)]),
+                       SourcePid ! {'$aae_src', done, Acc}
+               end),
+
+    {_Acc, State2} = compare_loop(State),
+
+    %% send differences
+    NDiff = ebloom:elements(Bloom),
+    lager:info("Found ~p differences", [NDiff]),
+
+    %% case Acc of
+    %%     [] ->
+    %%         %% exchange_complete(LocalVN, RemoteVN, IndexN, 0),
+    %%         lager:info("Repl'd 0 keys"),
+    %%         ok;
+    %%     [Count] ->
+    %%         %% exchange_complete(LocalVN, RemoteVN, IndexN, Count),
+    %%         lager:info("Found ~b differences during AAE exchange on ~p of ~p/~p ",
+    %%                    [Count, Cluster, Partition, IndexN])
+    %% end,
+
+    %% if we have anything in our bloom filter, start sending them now.
+    %% this will start a worker process, which will tell us it's done with
+    %% diffs_done once all differences are sent.
+    finish_sending_differences(Bloom, State),
+
+    %% wait for differences from bloom_folder or to be done
+    {next_state, send_diffs, State2}.
+
+%% state send_diffs is where we wait for diff_obj messages from the bloom folder
+%% and send them to the sink for each diff_obj. We eventually finish upon receipt
+%% of the diff_done event. Note: recv'd from a sync send event.
+send_diffs({diff_obj, RObj}, _From, State) ->
+    %% send missing object to remote sink
+    send_missing(RObj, State),
+    {reply, ok, send_diffs, State}.
+
+%% All indexes in this Partition are done.
+%% Note: recv'd from an async send event
+send_diffs(diff_done, State=#state{indexns=[]}) ->
+    gen_fsm:send_event(self(), start_exchange),
+    {next_state, update_trees, State#state{built=0, indexns=[]}};
+%% IndexN is done, restart for remaining
+send_diffs(diff_done, State=#state{indexns=[_IndexN|IndexNs]}) ->
+    %% re-start for next indexN
+    gen_fsm:send_event(self(), start_exchange),
+    {next_state, update_trees, State#state{built=0, indexns=IndexNs}}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+compare_loop(State=#state{transport=Transport,
+                          socket=Socket}) ->
+    receive
+        {'$aae_src', worker_pid, WorkerPid} ->
+            trace_recv("worker_pid", [WorkerPid]),
+            ok = Transport:controlling_process(Socket, WorkerPid),
+            WorkerPid ! {'$aae_src', ready, self()},
+            compare_loop(State);
+        {'$aae_src', done, Acc} ->
+            {Acc, State}
+    end.
+
+finish_sending_differences(Bloom, #state{index=Partition}) ->
+    case ebloom:elements(Bloom) == 0 of
+        true ->
+            lager:info("No differences, skipping bloom fold"),
+            gen_fsm:send_event(self(), diff_done);
+        false ->
+            {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+            OwnerNode = riak_core_ring:index_owner(Ring, Partition),
+            Count = ebloom:elements(Bloom),
+
+            trace("Folding over bloom"),
+
+            Self = self(),
+            Worker = fun() ->
+                             StartTime = erlang:now(),
+                             riak_kv_vnode:fold({Partition,OwnerNode},
+                                                fun ?MODULE:bloom_fold/3,
+                                                {Self,
+                                                 {serialized, ebloom:serialize(Bloom)}}),
+                             trace_time(StartTime,"bloom_fold diffs/partition", Count, Partition),
+                             gen_fsm:send_event(Self, diff_done),
+                             ok
+                     end,
+            spawn_link(Worker) %% this isn't the Pid we need because it's just the vnode:fold
+    end.
+
+bloom_fold(BK, V, {MPid, {serialized, SBloom}}) ->
+    {ok, Bloom} = ebloom:deserialize(SBloom),
+    trace("deserialized bloom count is", ebloom:elements(Bloom)),
+    bloom_fold(BK, V, {MPid, Bloom});
+bloom_fold({B, K}, V, {MPid, Bloom}) ->
+    case ebloom:contains(Bloom, <<B/binary, K/binary>>) of
+        true ->
+            trace("bloom contains:", K),
+            RObj = riak_object:from_binary(B,K,V),
+            gen_fsm:sync_send_event(MPid, {diff_obj, RObj}, infinity);
+        false ->
+            trace("bloom !contains:", K),
+            ok
+    end,
+    {MPid, Bloom}.
+
+%% @private
+%% Returns accumulator as a list of one element that is the count of
+%% keys that differed. Initial value of Acc is always [].
+replicate_diff(KeyDiff, Acc, State=#state{index=Partition}) ->
+    NumObjects =
+        case KeyDiff of
+            {remote_missing, Bin} ->
+                %% send object and related objects to remote
+                {Bucket,Key} = binary_to_term(Bin),
+                lager:debug("Keydiff: remote partition ~p remote missing: ~p:~p",
+                            [Partition, Bucket, Key]),
+                send_missing(Bucket, Key, State);
+            {different, Bin} ->
+                %% send object and related objects to remote
+                {Bucket,Key} = binary_to_term(Bin),
+                lager:debug("Keydiff: remote partition ~p different: ~p:~p",
+                            [Partition, Bucket, Key]),
+                send_missing(Bucket, Key, State);
+            {missing, Bin} ->
+                %% remote has a key we don't have. Ignore it.
+                {Bucket,Key} = binary_to_term(Bin),
+                lager:debug("Keydiff: remote partition ~p local missing: ~p:~p (ignored)",
+                            [Partition, Bucket, Key]),
+                0;
+            Other ->
+                lager:info("Keydiff: ~p (ignored)", [Other]),
+                0
+        end,
+
+    case Acc of
+        [] ->
+            [1];
+        [Count] ->
+            %% accrue number of differences sent from this segment
+            [Count+NumObjects];
+        _Other ->
+            Acc
+    end.
+
+accumulate_diff(KeyDiff, Bloom, [], State) ->
+    accumulate_diff(KeyDiff, Bloom, [0], State);
+accumulate_diff(KeyDiff, Bloom, [Count], #state{index=Partition}) ->
+    NumObjects =
+        case KeyDiff of
+            {remote_missing, Bin} ->
+                %% send object and related objects to remote
+                {Bucket,Key} = binary_to_term(Bin),
+                lager:debug("Keydiff: remote partition ~p remote missing: ~p:~p",
+                            [Partition, Bucket, Key]),
+                ebloom:insert(Bloom, <<Bucket/binary, Key/binary>>),
+                %%ebloom:insert(Bloom, Bin),
+                1;
+            {different, Bin} ->
+                %% send object and related objects to remote
+                {Bucket,Key} = binary_to_term(Bin),
+                lager:debug("Keydiff: remote partition ~p different: ~p:~p",
+                            [Partition, Bucket, Key]),
+                %% ebloom:insert(Bloom, Bin),
+                1;
+            {missing, Bin} ->
+                %% remote has a key we don't have. Ignore it.
+                {Bucket,Key} = binary_to_term(Bin),
+                lager:debug("Keydiff: remote partition ~p local missing: ~p:~p (ignored)",
+                            [Partition, Bucket, Key]),
+                0;
+            Other ->
+                lager:info("Keydiff: ~p (ignored)", [Other]),
+                0
+        end,
+    [Count+NumObjects].
+
+send_missing(RObj, State=#state{client=Client, wire_ver=Ver}) ->
+    %% we don't actually have the vclock to compare, so just send the
+    %% key and let the other side sort things out.
+    case riak_repl_util:repl_helper_send(RObj, Client) of
+        cancel ->
+            0;
+        Objects when is_list(Objects) ->
+            %% source -> sink : fs_diff_obj
+            %% binarize here instead of in the send() so that our wire
+            %% format for the riak_object is more compact.
+            trace("Send missing object"),
+            [begin
+                 Data = riak_repl_util:encode_obj_msg(Ver, {fs_diff_obj,O}),
+                 send_asynchronous_msg(?MSG_PUT_OBJ, Data, State)
+             end || O <- Objects],
+            Data2 = riak_repl_util:encode_obj_msg(Ver, {fs_diff_obj,RObj}),
+            send_asynchronous_msg(?MSG_PUT_OBJ, Data2, State),
+            1 + length(Objects)
+    end.
+
+send_missing(Bucket, Key, State=#state{client=Client, wire_ver=Ver}) ->
+    case Client:get(Bucket, Key, 1, ?REPL_FSM_TIMEOUT) of
+        {ok, RObj} ->
+            %% we don't actually have the vclock to compare, so just send the
+            %% key and let the other side sort things out.
+            case riak_repl_util:repl_helper_send(RObj, Client) of
+                cancel ->
+                    0;
+                Objects when is_list(Objects) ->
+                    %% source -> sink : fs_diff_obj
+                    %% binarize here instead of in the send() so that our wire
+                    %% format for the riak_object is more compact.
+                    trace("Send missing B,K"),
+                    [begin
+                         Data = riak_repl_util:encode_obj_msg(Ver, {fs_diff_obj,O}),
+                         send_asynchronous_msg(?MSG_PUT_OBJ, Data, State)
+                     end || O <- Objects],
+                    Data2 = riak_repl_util:encode_obj_msg(Ver, {fs_diff_obj,RObj}),
+                    send_asynchronous_msg(?MSG_PUT_OBJ, Data2, State),
+                    1 + length(Objects)
+            end;
+        {error, notfound} ->
+            %% can't find the key!
+            lager:warning("Can't get a key that was know to be a difference: ~p:~p", [Bucket,Key]),
+            0;
+        _ ->
+            0
+    end.
+
+%% @private
+update_request(Tree, {Index, _}, IndexN) ->
+    as_event(fun() ->
+                     case riak_kv_index_hashtree:update(IndexN, Tree) of
+                         ok ->
+                             {tree_built, Index, IndexN};
+                         not_responsible ->
+                             {not_responsible, Index, IndexN}
+                     end
+             end).
+
+%% @private
+as_event(F) ->
+    Self = self(),
+    spawn_link(fun() ->
+                       Result = F(),
+                       gen_fsm:send_event(Self, Result)
+               end),
+    ok.
+
+%% @private
+%% do_timeout(State=#state{local=LocalVN,
+%%                         remote=RemoteVN,
+%%                         index_n=IndexN}) ->
+%%     lager:info("Timeout during exchange between (local) ~p and (remote) ~p, "
+%%                "(preflist) ~p", [LocalVN, RemoteVN, IndexN]),
+%%     send_exchange_status({timeout, RemoteVN, IndexN}, State),
+%%     {stop, normal, State}.
+
+%% @private
+send_exchange_status(Status, State) ->
+    throw(Status),
+    State.
+
+%% @private
+%% next_state_with_timeout(StateName, State) ->
+%%     next_state_with_timeout(StateName, State, State#state.timeout).
+%% next_state_with_timeout(StateName, State, Timeout) ->
+%%     {next_state, StateName, State, Timeout}.
+
+%% exchange_complete({LocalIdx, _}, {RemoteIdx, RemoteNode}, IndexN, Repaired) ->
+%%     riak_kv_entropy_info:exchange_complete(LocalIdx, RemoteIdx, IndexN, Repaired),
+%%     rpc:call(RemoteNode, riak_kv_entropy_info, exchange_complete,
+%%              [RemoteIdx, LocalIdx, IndexN, Repaired]).
+
+send_complete(State=#state{index=Partition}) ->
+    trace("Send MSG_COMPLETE for partition", Partition),
+    send_asynchronous_msg(?MSG_COMPLETE, State).
+
+%%------------
+%% Synchronous messaging with the AAE fullsync "sink" on the remote cluster
+%%------------
+%% send a tagged message with type and binary data. return the reply
+send_synchronous_msg(MsgType, Data, State=#state{transport=Transport,
+                                                 socket=Socket}) when is_binary(Data) ->
+    lager:debug("sending message type ~p", [MsgType]),
+    ok = Transport:send(Socket, <<MsgType:8, Data/binary>>),
+    Response = get_reply(State),
+    lager:debug("got reply ~p", [Response]),
+    Response;
+%% send a tagged message with type and msg. return the reply
+send_synchronous_msg(MsgType, Msg, State) ->
+    Data = term_to_binary(Msg),
+    send_synchronous_msg(MsgType, Data, State).
+
+%% send a message with type tag only, no data
+send_synchronous_msg(MsgType, State=#state{transport=Transport,
+                                           socket=Socket}) ->
+    ok = Transport:send(Socket, <<MsgType:8>>),
+    get_reply(State).
+
+%% Async message send with tag and (binary or term data).
+send_asynchronous_msg(MsgType, Data, #state{transport=Transport,
+                                            socket=Socket}) when is_binary(Data) ->
+    ok = Transport:send(Socket, <<MsgType:8, Data/binary>>);
+%% send a tagged message with type and msg. return the reply
+send_asynchronous_msg(MsgType, Msg, State) ->
+    Data = term_to_binary(Msg),
+    send_asynchronous_msg(MsgType, Data, State).
+
+%% send a message with type tag only, no data
+send_asynchronous_msg(MsgType, #state{transport=Transport,
+                                      socket=Socket}) ->
+    ok = Transport:send(Socket, <<MsgType:8>>).
+
+get_reply(#state{transport=Transport, socket=Socket}) ->
+    ok = Transport:setopts(Socket, [{active, once}]),
+    receive
+        {_, Socket, [?MSG_REPLY|Data]} ->
+            trace_recv("MSG_REPLY"),
+            binary_to_term(Data);
+        {Error, Socket} ->
+            throw(Error);
+        {Error, Socket, Reason} ->
+            throw({Error, Reason})
+    end.
+
+trace(_Msg) ->
+%%    lager:info("Source ---------> ~p", [_Msg]),
+    ok.
+trace(_Msg, _Param) ->
+%%    lager:info("Source ---------> ~p : ~p", [_Msg, _Param]),
+    ok.
+
+trace_recv(_Msg) ->
+%%    lager:info("Source <--------- ~p", [_Msg]),
+    ok.
+trace_recv(_Msg,_Param) ->
+%%    lager:info("Source <--------- ~p : ~p", [_Msg, _Param]),
+    ok.
+
+trace_time(StartTime, Msg, P1, P2) ->
+    DiffTime = timer:now_diff(erlang:now(), StartTime),
+    DiffSecs = DiffTime / 1000,
+    lager:info("~p:~s:~p:~p", [DiffSecs, Msg, P1, P2]).

--- a/src/riak_repl_app.erl
+++ b/src/riak_repl_app.erl
@@ -11,10 +11,6 @@
          cluster_mgr_write_cluster_members_to_ring/2,
          cluster_mgr_read_cluster_targets_from_ring/0]).
 
--export([cluster_mgr_member_fun/1,
-         cluster_mgr_write_cluster_members_to_ring/2,
-         cluster_mgr_read_cluster_targets_from_ring/0]).
-
 -include("riak_core_cluster.hrl").
 -include_lib("riak_core/include/riak_core_connection.hrl").
 

--- a/src/riak_repl_console.erl
+++ b/src/riak_repl_console.erl
@@ -134,9 +134,9 @@ status2(Verbose) ->
     PGStats = riak_repl2_pg:status(),
 
     Most =
-          RTRemotesStatus ++ FSRemotesStatus ++ Config++Stats1++
-          LeaderStats++ClientStats++ServerStats++
-          CoordStats++CoordSrvStats++CMgrStats++RTQStats++PGStats,
+        RTRemotesStatus++FSRemotesStatus++PGRemotesStatus++Config++
+        Stats1++LeaderStats++ClientStats++ServerStats++
+        CoordStats++CoordSrvStats++CMgrStats++RTQStats++PGStats,
     SendRecvKbps = extract_rt_fs_send_recv_kbps(Most),
     All = Most ++ SendRecvKbps,
     if Verbose ->

--- a/src/riak_repl_console.erl
+++ b/src/riak_repl_console.erl
@@ -140,9 +140,9 @@ status2(Verbose) ->
     PGStats = riak_repl2_pg:status(),
 
     Most =
-          RTRemotesStatus ++ FSRemotesStatus ++ Config++Stats1++
-          LeaderStats++ClientStats++ServerStats++
-          CoordStats++CoordSrvStats++CMgrStats++RTQStats++PGStats,
+        RTRemotesStatus++FSRemotesStatus++PGRemotesStatus++Config++
+        Stats1++LeaderStats++ClientStats++ServerStats++
+        CoordStats++CoordSrvStats++CMgrStats++RTQStats++PGStats,
     SendRecvKbps = extract_rt_fs_send_recv_kbps(Most),
     All = Most ++ SendRecvKbps,
     if Verbose ->

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -767,7 +767,7 @@ make_pg_name(Remote) ->
 
 deduce_wire_version_from_proto({_Proto,{CommonMajor,CMinor},{CommonMajor,HMinor}}) ->
     %% if common protocols are both >= 1.1, then we know the new binary wire protocol
-    case CommonMajor >= 1 andalso CMinor >= 1 andalso HMinor >= 1 of
+    case ((CommonMajor >= 2) or (CommonMajor == 1 andalso CMinor >= 1 andalso HMinor >= 1)) of
         true ->
             %% new sink. yay! new wire protocol supported.
             w1;

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -765,7 +765,7 @@ make_pg_proxy_name(Remote) ->
 make_pg_name(Remote) ->
     list_to_atom("pg_requester_" ++ Remote).
 
-% everything from version 1.1 and up should use the new binary objects
+% everything from version 1.5 and up should use the new binary objects
 deduce_wire_version_from_proto({_Proto, {CommonMajor, _CMinor}, {CommonMajor, _HMinor}}) when CommonMajor > 1 ->
     w1;
 deduce_wire_version_from_proto({_Proto, {_CommonMajor, CMinor}, {_CommonMajor, HMinor}}) when CMinor >= 5 andalso HMinor >= 5 ->

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -765,9 +765,9 @@ make_pg_proxy_name(Remote) ->
 make_pg_name(Remote) ->
     list_to_atom("pg_requester_" ++ Remote).
 
-deduce_wire_version_from_proto({_Proto,{CommonMajor,CMinor},{CommonMajor,HMinor}}) ->
+deduce_wire_version_from_proto({_Proto,ClientVer,HostVer}) ->
     %% if common protocols are both >= 1.1, then we know the new binary wire protocol
-    case ((CommonMajor >= 2) or (CommonMajor == 1 andalso CMinor >= 1 andalso HMinor >= 1)) of
+    case ClientVer >= {1,1} andalso HostVer >= {1,1} of
         true ->
             %% new sink. yay! new wire protocol supported.
             w1;


### PR DESCRIPTION
This is a squash of branch pdx-aae-fullsync that owes much debt to @jtuple . Thanks, Joe!

The fullsync coordinator is unchanged, while fssource and fssink  get a new capability.
- Source and Sink exchange caps if protocol is >= 2.0.
- If awe is enabled on both sides, they will negotiate the use of AAE strategy
- aae strategy now guarded on existence of cluster aae enabled.
- strategy dynamically determined as each partition is sync'd, so a long sync's strategy can be changed while it's running. If only we had a nice command to do that. For now, you can only change the strategy by changing the app env value in riak_repl of {fullsync_strategy, aee | keylist}.

If a partition is locked by the anti entropy manager, it will be retried periodically until the lock is released, which should only be a few seconds. The 'whereis', 'busy', and reservation mechanisms all still work the same.

For the most part, the new riak_repl_aae_sink and source work identical in their usage to the keylist workers (client and server, respectively).

A PR from riak_kv is required for this PR to complle.
https://github.com/basho/riak_kv/pull/555

And a riak test...
https://github.com/basho/riak_test/pull/282
