### PR TITLE
Fixed function clause error when migrating queue

### DIFF
--- a/src/riak_repl2_rtq.erl
+++ b/src/riak_repl2_rtq.erl
@@ -222,9 +222,11 @@ handle_call(shutting_down, _From, State = #state{shutting_down=false}) ->
     %% this will allow the realtime repl hook to determine if it should send
     %% to another host
     riak_repl2_rtq_proxy:start(),
+    lager:info("Shutting down"),
     {reply, ok, State#state{shutting_down = true}};
 
 handle_call(stop, _From, State) ->
+    lager:info("Stopping"),
     {stop, normal, ok, State};
 
 handle_call(is_running, _From,

--- a/src/riak_repl2_rtq.erl
+++ b/src/riak_repl2_rtq.erl
@@ -222,11 +222,9 @@ handle_call(shutting_down, _From, State = #state{shutting_down=false}) ->
     %% this will allow the realtime repl hook to determine if it should send
     %% to another host
     riak_repl2_rtq_proxy:start(),
-    lager:info("Shutting down"),
     {reply, ok, State#state{shutting_down = true}};
 
 handle_call(stop, _From, State) ->
-    lager:info("Stopping"),
     {stop, normal, ok, State};
 
 handle_call(is_running, _From,

--- a/src/riak_repl_migration.erl
+++ b/src/riak_repl_migration.erl
@@ -72,7 +72,7 @@ drain_queue(false, Peer, PeerWireVer) ->
              fun ({Seq, NumItem, W1BinObjs, Meta}) ->
                 try
                     BinObjs = riak_repl_util:maybe_downconvert_binary_objs(W1BinObjs, PeerWireVer),
-                    CastObj = case W1BinObjs of
+                    CastObj = case PeerWireVer of
                         w0 ->
                             {push, NumItem, BinObjs};
                         w1 ->


### PR DESCRIPTION
Discovered during a riak test, where shutting down a node would hang
forever chewing up a significant amount of cpu.

The queue migration delivery fun expected a tuple of size 3, but was given
a tuple of size 4 (due to the meta data). Fixed the clause and added a down
cast to push a size 3 to the remote rtq in case it's an older version.
