### PR TITLE
race conds with cross-node calls and node shutdown

### DIFF
--- a/src/riak_core_cluster_mgr.erl
+++ b/src/riak_core_cluster_mgr.erl
@@ -77,8 +77,7 @@
                 restore_targets_fun = fun() -> [] end,         % returns persisted cluster targets
                 save_members_fun = fun(_C,_M) -> ok end,       % persists remote cluster members
                 balancer_fun = fun(Addrs) -> Addrs end,        % registered balancer function
-                clusters = orddict:new() :: orddict:orddict(),  % resolved clusters by name
-                cluster_id :: term()
+                clusters = orddict:new() :: orddict:orddict()  % resolved clusters by name
                }).
 
 -export([start_link/0,
@@ -95,8 +94,7 @@
          get_connections/0,
          get_ipaddrs_of_cluster/1,
          set_gc_interval/1,
-         stop/0,
-         get_cluster_id/0
+         stop/0
          ]).
 
 %% gen_server callbacks
@@ -198,13 +196,6 @@ set_gc_interval(Interval) ->
     gen_server:cast(?SERVER, {set_gc_interval, Interval}).
 
 
-%% @doc gets the cached cluster_id. This value is different than the
-%% bravenewworld clustername. It's a unique identifier generated when
-%% the ring is created.
--spec get_cluster_id() -> term().
-get_cluster_id() ->
-    gen_server:call(?SERVER, get_cluster_id).
-
 %%%===================================================================
 %%% gen_server callbacks
 %%%===================================================================
@@ -223,11 +214,12 @@ init(Defaults) ->
     erlang:send_after(?CLUSTER_POLLING_INTERVAL, self(), poll_clusters_timer),
     BalancerFun = fun(Addr) -> round_robin_balancer(Addr) end,
     MeNode = node(),
-    State = register_defaults(Defaults, #state{is_leader = false, balancer_fun = BalancerFun}),
+    State = register_defaults(Defaults, #state{
+                is_leader = false,
+                balancer_fun = BalancerFun}),
 
     %% Schedule a delayed connection to know clusters
     schedule_cluster_connections(),
-
     case riak_repl2_leader:leader_node() of
         undefined ->
             % there's an election in progress, so we can just hang on until
@@ -243,9 +235,6 @@ init(Defaults) ->
 
 handle_call(get_is_leader, _From, State) ->
     {reply, State#state.is_leader, State};
-
-handle_call(get_cluster_id, _From, State) ->
-    {reply, State#state.cluster_id, State};
 
 handle_call({get_my_members, MyAddr}, _From, State) ->
     %% This doesn't need to call the leader.

--- a/src/riak_repl2_pg_block_provider.erl
+++ b/src/riak_repl2_pg_block_provider.erl
@@ -138,7 +138,8 @@ handle_info(_Msg, State) ->
 
 handle_msg(get_cluster_info, State=#state{transport=Transport, socket=Socket}) ->
     ThisClusterName = riak_core_connection:symbolic_clustername(),
-    ClusterID = riak_core_cluster_mgr:get_cluster_id(),
+    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+    ClusterID = riak_core_ring:cluster_name(Ring),
     lager:debug("Cluster ID=~p, Cluster Name = ~p",[ClusterID, ThisClusterName]),
     Data = term_to_binary({get_cluster_info_resp, ClusterID, ThisClusterName}),
     Transport:send(Socket, Data),

--- a/src/riak_repl2_pg_proxy.erl
+++ b/src/riak_repl2_pg_proxy.erl
@@ -16,13 +16,13 @@
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-        terminate/2, code_change/3, proxy_get/4, register_pg_node/2]).
+        terminate/2, code_change/3, proxy_get/4]).
 
 -define(SERVER, ?MODULE).
 
 -record(state, {
         source_cluster = undefined,
-        pg_node = undefined
+        pg_nodes = []
         }).
 
 %%%===================================================================
@@ -30,9 +30,6 @@
 %%%===================================================================
 proxy_get(Pid, Bucket, Key, Options) ->
     gen_server:call(Pid, {proxy_get, Bucket, Key, Options}).
-
-register_pg_node(Pid, Node) ->
-    gen_server:call(Pid, {register, Node}).
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -53,26 +50,47 @@ init(ProxyName) ->
     erlang:register(ProxyName, self()),
     {ok, #state{}}.
 
-handle_call({proxy_get, Bucket, Key, GetOptions}, _From, #state{pg_node=Node} = State) ->
-    case Node of
-        undefined ->
+handle_call({proxy_get, Bucket, Key, GetOptions}, _From,
+            #state{pg_nodes=RequesterNodes} = State) ->
+    case RequesterNodes of
+        [] ->
             lager:warning("No proxy_get node registered"),
-            {reply, ok, State};
-        N ->
-            RegName = riak_repl_util:make_pg_name(State#state.source_cluster),
-            Result = gen_server:call({RegName, N}, {proxy_get, Bucket, Key, GetOptions}),
-            {reply, Result, State}
+            {reply, {error, no_proxy_get_node}, State};
+        [{_RNode, RPid, _} | T] ->
+            try gen_server:call(RPid, {proxy_get, Bucket, Key, GetOptions}) of
+                Result ->
+                    {reply, Result, State}
+            catch
+                %% remove this bad pid from the list and try another
+                exit:{noproc, _} ->
+                    handle_call({proxy_get, Bucket, Key, GetOptions}, _From,
+                        State#state{pg_nodes=T});
+                exit:{{nodedown, _}, _} ->
+                    handle_call({proxy_get, Bucket, Key, GetOptions}, _From,
+                        State#state{pg_nodes=T})
+            end
     end;
 
-handle_call({register, ClusterName, Node}, _From, State) ->
-    lager:debug("registered node for cluster name ~p", [ClusterName]),
-    NewState = State#state{pg_node = Node, source_cluster=ClusterName},
+handle_call({register, ClusterName, RequesterNode, RequesterPid},
+            _From, State = #state{pg_nodes = PGNodes}) ->
+    lager:info("registered node for cluster name ~p ~p ~p", [ClusterName,
+                                                             RequesterNode,
+                                                             RequesterPid]),
+    Monitor = erlang:monitor(process, RequesterPid),
+    NewState = State#state{pg_nodes = [{RequesterNode, RequesterPid, Monitor} | PGNodes],
+                           source_cluster=ClusterName},
     {reply, ok, NewState}.
 
-handle_cast(_Msg, State) ->
+handle_info({'DOWN', MRef, process, _Pid, _Reason}, State =
+            #state{pg_nodes=RequesterNodes}) ->
+    NewRequesterNodes = [ {RNode, RPid, RMon} ||
+            {RNode,RPid,RMon} <- RequesterNodes,
+            RMon /= MRef],
+    {noreply, State#state{pg_nodes=NewRequesterNodes}};
+handle_info(_Info, State) ->
     {noreply, State}.
 
-handle_info(_Info, State) ->
+handle_cast(_Msg, State) ->
     {noreply, State}.
 
 terminate(_Reason, _State) ->


### PR DESCRIPTION
don't cache cluster_id in cluster_mgr

squashed version of https://github.com/basho/riak_repl/pull/285
