### PR TITLE
Race between riak_repl_pb_get and riak_repl_ring_handler

### DIFF
--- a/src/riak_repl_pb_get.erl
+++ b/src/riak_repl_pb_get.erl
@@ -117,8 +117,7 @@ process(#rpbreplgetreq{bucket=B, key=K, r=R0, pr=PR0, notfound_ok=NFOk,
                     {Value, notconnected} -> Value;
                     {_, Value} ->
                         lager:warning("proxy_get received a result from multiple versions of replication for cluster ~p", [CName]),
-                        Value; %% default to 1.3 if both are valid
-                    _ -> notconnected
+                        Value %% default to 1.3 if both are valid
                 end,
             case Result of
                 notconnected ->

--- a/src/riak_repl_pb_get.erl
+++ b/src/riak_repl_pb_get.erl
@@ -35,9 +35,9 @@ init() ->
     % get the current repl modes and stash them in the state
     % I suppose riak_repl_pb_get would need to be restarted if these values
     % changed
-    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+    {ok, Ring0} = riak_core_ring_manager:get_my_ring(),
+    Ring = riak_repl_ring:ensure_config(Ring0),
     ClusterID = riak_core_ring:cluster_name(Ring),
-    riak_repl_ring:ensure_config(Ring),
     Modes = riak_repl_ring:get_modes(Ring),
     #state{client=C, repl_modes=Modes, cluster_id=ClusterID}.
 

--- a/src/riak_repl_ring.erl
+++ b/src/riak_repl_ring.erl
@@ -64,7 +64,7 @@ ensure_config(Ring) ->
 get_repl_config(Ring) ->
     case riak_core_ring:get_meta(?MODULE, Ring) of
         {ok, RC} -> RC;
-        undefined -> undefined
+        undefined -> initial_config()
     end.
 
 -spec(set_repl_config/2 :: (ring(), dict()) -> ring()).


### PR DESCRIPTION
As of 1.4, riak_repl_pb_get checks the ring as part of init():

https://github.com/basho/riak_repl/blob/master/src/riak_repl_pb_get.erl#L41

Problem is, that init is done before the riak_repl_ring handler is installed:

https://github.com/basho/riak_repl/blob/master/src/riak_repl_app.erl#L58

https://github.com/basho/riak_repl/blob/master/src/riak_repl_app.erl#L82

So, on a clean node, bad things like this happpen:

```
2013-06-04 18:42:52.206 [error] <0.639.0> gen_server <0.639.0> terminated with reason: bad record di
ct in dict:get_slot/2 line 395
2013-06-04 18:42:52.207 [error] <0.639.0> CRASH REPORT Process <0.639.0> with 0 neighbours exited wi
th reason: bad record dict in dict:get_slot/2 line 395 in gen_server:terminate/6 line 747
2013-06-04 18:42:52.207 [error] <0.324.0> Supervisor riak_api_pb_sup had child undefined started wit
h {riak_api_pb_server,start_link,undefined} at <0.639.0> exit with reason bad record dict in dict:ge
t_slot/2 line 395 in context child_terminated
```

This happens because riak_repl_ring:get_repl_config, if there's no repl config in the ring, returns undefined:

https://github.com/basho/riak_repl/blob/master/src/riak_repl_ring.erl#L67

And everywhere we call get_repl_config, we assume that a valid dict is returned.

For most usages this turns out fine (by accident, I guess), but the change to riak_repl_pb_get introduces a race which can make node startup fail on new nodes.
