### PR TITLE
gen_server:call timeout review & fixes

### DIFF
--- a/include/riak_repl.hrl
+++ b/include/riak_repl.hrl
@@ -99,3 +99,5 @@
 -define(REPL_MODES, [{mode_repl12,?REPL_HOOK12}, {mode_repl13,?REPL_HOOK_BNW}]).
 
 
+-define(LONG_TIMEOUT, 120*1000).
+

--- a/include/riak_repl.hrl
+++ b/include/riak_repl.hrl
@@ -26,6 +26,8 @@
 -define(DEFAULT_MAX_SINKS_NODE, 1).
 %% 20 seconds. sources should claim within 5 seconds, but give them a little more time
 -define(RESERVATION_TIMEOUT, (20 * 1000)).
+%% allow 1 minute for reservation call to succeed before timeout and 'down' response.
+-define(RESERVE_TIMEOUT, (60 * 1000)).
 -define(DEFAULT_MAX_FS_BUSIES_TOLERATED, 10).
 -define(RETRY_WHEREIS_INTERVAL, 1000).
 -define(CONSOLE_RPC_TIMEOUT, 5000).
@@ -100,4 +102,3 @@
 
 
 -define(LONG_TIMEOUT, 120*1000).
-

--- a/src/riak_core_cluster_mgr.erl
+++ b/src/riak_core_cluster_mgr.erl
@@ -139,12 +139,12 @@ set_leader(LeaderNode, _LeaderPid) ->
 %% Reply with the current leader node.
 -spec get_leader() -> node().
 get_leader() ->
-    gen_server:call(?SERVER, leader_node).
+    gen_server:call(?SERVER, leader_node, infinity).
 
 %% @doc True if the local manager is the leader.
 -spec get_is_leader() -> boolean().
 get_is_leader() ->
-    gen_server:call(?SERVER, get_is_leader).
+    gen_server:call(?SERVER, get_is_leader, infinity).
 
 %% @doc Register a function that will get called to get out local riak node
 %% member's IP addrs. MemberFun(inet:addr()) -> [{IP,Port}] were IP is a string
@@ -172,24 +172,24 @@ remove_remote_cluster(Cluster) ->
 %% @doc Retrieve a list of known remote clusters that have been resolved (they responded).
 -spec(get_known_clusters() -> {ok,[clustername()]} | term()).
 get_known_clusters() ->
-    gen_server:call(?SERVER, get_known_clusters).
+    gen_server:call(?SERVER, get_known_clusters, infinity).
 
 %% @doc Retrieve a list of IP,Port tuples we are connected to or trying to connect to
 get_connections() ->
-    gen_server:call(?SERVER, get_connections).
+    gen_server:call(?SERVER, get_connections, infinity).
 
 get_my_members(MyAddr) ->
-    gen_server:call(?SERVER, {get_my_members, MyAddr}).
+    gen_server:call(?SERVER, {get_my_members, MyAddr}, infinity).
 
 %% @doc Return a list of the known IP addresses of all nodes in the remote cluster.
 -spec(get_ipaddrs_of_cluster(clustername()) -> [ip_addr()]).
 get_ipaddrs_of_cluster(ClusterName) ->
-        gen_server:call(?SERVER, {get_known_ipaddrs_of_cluster, {name,ClusterName}}).
+        gen_server:call(?SERVER, {get_known_ipaddrs_of_cluster, {name,ClusterName}}, infinity).
 
 %% @doc stops the local server.
 -spec stop() -> 'ok'.
 stop() ->
-    gen_server:call(?SERVER, stop).
+    gen_server:call(?SERVER, stop, infinity).
 
 -spec set_gc_interval(Interval :: timeout()) -> 'ok'.
 set_gc_interval(Interval) ->
@@ -783,7 +783,7 @@ ctrlServiceProcess(Socket, Transport, MyVer, RemoteVer, ClientAddr) ->
                 {error, closed} ->
                     {error, connection_closed};
                 {ok, MyAddr} ->
-                    BalancedMembers = gen_server:call(?SERVER, {get_my_members, MyAddr}),
+                    BalancedMembers = gen_server:call(?SERVER, {get_my_members, MyAddr}, infinity),
                     ok = Transport:send(Socket, term_to_binary(BalancedMembers)),
                     ctrlServiceProcess(Socket, Transport, MyVer, RemoteVer, ClientAddr);
                 Error ->

--- a/src/riak_repl2_fs_node_reserver.erl
+++ b/src/riak_repl2_fs_node_reserver.erl
@@ -40,6 +40,8 @@ start_link() ->
 reserve(Partition) ->
     Node = get_partition_node(Partition),
     % I don't want to crash the caller if the node is down
+    %% TODO: add explicit timeout to this call
+    %% TODO: add timeout handling to catch?
     try gen_server:call({?SERVER, Node}, {reserve, Partition}) of
         Out -> Out
     catch

--- a/src/riak_repl2_fssink.erl
+++ b/src/riak_repl2_fssink.erl
@@ -107,7 +107,7 @@ handle_call(legacy_status, _From, State=#state{fullsync_worker=FSW,
                       keylist ->
                           gen_fsm:sync_send_all_state_event(FSW, status);
                       aae ->
-                          gen_server:call(FSW, status, 5000)
+                          gen_server:call(FSW, status, ?LONG_TIMEOUT)
                   end;
               false -> []
           end,
@@ -204,7 +204,7 @@ terminate(_Reason, #state{fullsync_worker=FSW, work_dir=WorkDir, strategy=Strate
                 keylist ->
                     gen_fsm:sync_send_all_state_event(FSW, stop);
                 aae ->
-                    gen_server:call(FSW, stop)
+                    gen_server:call(FSW, stop, ?LONG_TIMEOUT)
             end;
         _ ->
             ok

--- a/src/riak_repl2_fssink.erl
+++ b/src/riak_repl2_fssink.erl
@@ -107,7 +107,8 @@ handle_call(legacy_status, _From, State=#state{fullsync_worker=FSW,
                       keylist ->
                           gen_fsm:sync_send_all_state_event(FSW, status);
                       aae ->
-                          gen_server:call(FSW, status, ?LONG_TIMEOUT)
+                          %% worker is on local node
+                          gen_server:call(FSW, status, infinity)
                   end;
               false -> []
           end,
@@ -204,7 +205,8 @@ terminate(_Reason, #state{fullsync_worker=FSW, work_dir=WorkDir, strategy=Strate
                 keylist ->
                     gen_fsm:sync_send_all_state_event(FSW, stop);
                 aae ->
-                    gen_server:call(FSW, stop, ?LONG_TIMEOUT)
+                    %% worker is on local node
+                    gen_server:call(FSW, stop, infinity)
             end;
         _ ->
             ok

--- a/src/riak_repl2_fssource.erl
+++ b/src/riak_repl2_fssource.erl
@@ -28,8 +28,9 @@ start_link(Partition, IP) ->
 %% connection manager callbacks
 connected(Socket, Transport, Endpoint, Proto, Pid, Props) ->
     Transport:controlling_process(Socket, Pid),
+    %% Pid is running local when connection manager calls us here.
     gen_server:call(Pid,
-        {connected, Socket, Transport, Endpoint, Proto, Props}, ?LONG_TIMEOUT).
+        {connected, Socket, Transport, Endpoint, Proto, Props}, infinity).
 
 connect_failed(_ClientProto, Reason, RtSourcePid) ->
     gen_server:cast(RtSourcePid, {connect_failed, self(), Reason}).

--- a/src/riak_repl2_fssource.erl
+++ b/src/riak_repl2_fssource.erl
@@ -29,16 +29,16 @@ start_link(Partition, IP) ->
 connected(Socket, Transport, Endpoint, Proto, Pid, Props) ->
     Transport:controlling_process(Socket, Pid),
     gen_server:call(Pid,
-        {connected, Socket, Transport, Endpoint, Proto, Props}).
+        {connected, Socket, Transport, Endpoint, Proto, Props}, ?LONG_TIMEOUT).
 
 connect_failed(_ClientProto, Reason, RtSourcePid) ->
     gen_server:cast(RtSourcePid, {connect_failed, self(), Reason}).
 
 start_fullsync(Pid) ->
-    gen_server:call(Pid, start_fullsync).
+    gen_server:call(Pid, start_fullsync, ?LONG_TIMEOUT).
 
 stop_fullsync(Pid) ->
-    gen_server:call(Pid, stop_fullsync).
+    gen_server:call(Pid, stop_fullsync, ?LONG_TIMEOUT).
 
 fullsync_complete(Pid) ->
     %% cast to avoid deadlock in terminate
@@ -46,7 +46,7 @@ fullsync_complete(Pid) ->
 
 %% get the cluster name
 cluster_name(Pid) ->
-    gen_server:call(Pid, cluster_name).
+    gen_server:call(Pid, cluster_name, ?LONG_TIMEOUT).
 
 legacy_status(Pid, Timeout) ->
     gen_server:call(Pid, legacy_status, Timeout).
@@ -172,7 +172,7 @@ handle_cast({connect_failed, _Pid, Reason},
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
-handle_info({'DOWN', Ref, process, Pid, not_responsible}, State=#state{partition=Partition}) ->
+handle_info({'DOWN', Ref, process, _Pid, not_responsible}, State=#state{partition=Partition}) ->
     erlang:demonitor(Ref),
     lager:info("Fullsync of partition ~p stopped because AAE trees can't be compared.", [Partition]),
     lager:info("Probable cause is one or more differing bucket n_val properties between source and sink clusters."),

--- a/src/riak_repl2_leader.erl
+++ b/src/riak_repl2_leader.erl
@@ -64,11 +64,11 @@ register_notify_fun(Fun) ->
 
 %% Return the current leader node
 leader_node() ->
-    gen_server:call(?SERVER, leader_node).
+    gen_server:call(?SERVER, leader_node, infinity).
 
 %% Are we the leader?
 is_leader() ->
-    gen_server:call(?SERVER, is_leader).
+    gen_server:call(?SERVER, is_leader, infinity).
 
 %%%===================================================================
 %%% Callback for riak_repl_leader_helper
@@ -77,14 +77,14 @@ is_leader() ->
 %% Called by riak_repl_leader_helper whenever a leadership election
 %% takes place.
 set_leader(LocalPid, LeaderNode, LeaderPid) ->
-    gen_server:call(LocalPid, {set_leader_node, LeaderNode, LeaderPid}).
+    gen_server:call(LocalPid, {set_leader_node, LeaderNode, LeaderPid}, infinity).
 
 %%%===================================================================
 %%% Unit test support for riak_repl_leader_helper
 %%%===================================================================
 
 helper_pid() ->
-    gen_server:call(?SERVER, helper_pid).
+    gen_server:call(?SERVER, helper_pid, infinity).
 
 %%%===================================================================
 %%% gen_server callbacks

--- a/src/riak_repl2_pg_block_provider.erl
+++ b/src/riak_repl2_pg_block_provider.erl
@@ -44,7 +44,8 @@ status(Pid, Timeout) ->
 connected(Socket, Transport, Endpoint, Proto, Pid, Props) ->
     Transport:controlling_process(Socket, Pid),
     gen_server:call(Pid,
-        {connected, Socket, Transport, Endpoint, Proto, Props}, ?LONG_TIMEOUT).
+                    %% Pid is running local when connection manager calls us here.
+                    {connected, Socket, Transport, Endpoint, Proto, Props}, infinity).
 
 connect_failed(_ClientProto, Reason, Pid) ->
     gen_server:cast(Pid, {connect_failed, self(), Reason}).

--- a/src/riak_repl2_pg_block_provider.erl
+++ b/src/riak_repl2_pg_block_provider.erl
@@ -44,7 +44,7 @@ status(Pid, Timeout) ->
 connected(Socket, Transport, Endpoint, Proto, Pid, Props) ->
     Transport:controlling_process(Socket, Pid),
     gen_server:call(Pid,
-        {connected, Socket, Transport, Endpoint, Proto, Props}).
+        {connected, Socket, Transport, Endpoint, Proto, Props}, ?LONG_TIMEOUT).
 
 connect_failed(_ClientProto, Reason, Pid) ->
     gen_server:cast(Pid, {connect_failed, self(), Reason}).

--- a/src/riak_repl2_pg_block_requester.erl
+++ b/src/riak_repl2_pg_block_requester.erl
@@ -53,7 +53,7 @@ start_service(Socket, Transport, Proto, _Args, Props) ->
 
 
 proxy_get(Pid, Bucket, Key, Options) ->
-    gen_server:call(Pid, {proxy_get, Bucket, Key, Options}).
+    gen_server:call(Pid, {proxy_get, Bucket, Key, Options}, ?LONG_TIMEOUT).
 
 status(Pid) ->
     gen_server:call(Pid, status, infinity).
@@ -62,7 +62,7 @@ status(Pid, Timeout) ->
     gen_server:call(Pid, status, Timeout).
 
 provider_cluster_info(Pid) ->
-    gen_server:call(Pid, provider_cluster_info).
+    gen_server:call(Pid, provider_cluster_info, ?LONG_TIMEOUT).
 
 %% gen server
 
@@ -207,8 +207,9 @@ register_with_leader(#state{leader_mref=MRef, cluster=Cluster}=State) ->
                             make_pg_proxy(Cluster)))
             end,
             %% this can fail if the leader node is shutting down
-            catch(gen_server:call({ProxyForCluster, Leader}, {register, Cluster, node(),
-                        self()}))
+            catch(gen_server:call({ProxyForCluster, Leader},
+                                  {register, Cluster, node(), self()},
+                                  ?LONG_TIMEOUT))
     catch
         _:_ ->
             %% the monitor below will take care of us...

--- a/src/riak_repl2_pg_proxy.erl
+++ b/src/riak_repl2_pg_proxy.erl
@@ -18,6 +18,8 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
         terminate/2, code_change/3, proxy_get/4]).
 
+-include("riak_repl.hrl").
+
 -define(SERVER, ?MODULE).
 
 -record(state, {
@@ -28,7 +30,7 @@
 %%% API
 %%%===================================================================
 proxy_get(Pid, Bucket, Key, Options) ->
-    gen_server:call(Pid, {proxy_get, Bucket, Key, Options}).
+    gen_server:call(Pid, {proxy_get, Bucket, Key, Options}, ?LONG_TIMEOUT).
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -56,7 +58,7 @@ handle_call({proxy_get, Bucket, Key, GetOptions}, _From,
             lager:warning("No proxy_get node registered"),
             {reply, {error, no_proxy_get_node}, State};
         [{_RNode, RPid, _} | T] ->
-            try gen_server:call(RPid, {proxy_get, Bucket, Key, GetOptions}) of
+            try gen_server:call(RPid, {proxy_get, Bucket, Key, GetOptions}, ?LONG_TIMEOUT) of
                 Result ->
                     {reply, Result, State}
             catch

--- a/src/riak_repl2_rt.erl
+++ b/src/riak_repl2_rt.erl
@@ -127,12 +127,12 @@ register_remote_locator() ->
 
 %% Register an active realtime sink (supervised under ranch)
 register_sink(Pid) ->
-    gen_server:call(?SERVER, {register_sink, Pid}).
+    gen_server:call(?SERVER, {register_sink, Pid}, infinity).
 
 %% Get list of sink pids 
 %% TODO: Remove this once rtsink_sup is working right
 get_sink_pids() ->
-    gen_server:call(?SERVER, get_sink_pids).
+    gen_server:call(?SERVER, get_sink_pids, infinity).
 
 %% Realtime replication post-commit hook
 postcommit(RObj) ->

--- a/src/riak_repl2_rtq.erl
+++ b/src/riak_repl2_rtq.erl
@@ -85,22 +85,22 @@ start_test() ->
 %% sequence number.
 -spec register(Name :: string()) -> {'ok', number()}.
 register(Name) ->
-    gen_server:call(?SERVER, {register, Name}).
+    gen_server:call(?SERVER, {register, Name}, infinity).
 
 %% @doc Removes a consumer.
 -spec unregister(Name :: string()) -> 'ok' | {'error', 'not_registered'}.
 unregister(Name) ->
-    gen_server:call(?SERVER, {unregister, Name}).
+    gen_server:call(?SERVER, {unregister, Name}, infinity).
 
 %% @doc True if the given consumer has no items to consume.
 -spec is_empty(Name :: string()) -> boolean().
 is_empty(Name) ->
-    gen_server:call(?SERVER, {is_empty, Name}).
+    gen_server:call(?SERVER, {is_empty, Name}, infinity).
 
 %% @doc True if no consumer has items to consume.
 -spec all_queues_empty() -> boolean().
 all_queues_empty() ->
-    gen_server:call(?SERVER, all_queues_empty).
+    gen_server:call(?SERVER, all_queues_empty, infinity).
 
 %% @doc Set the maximum number of bytes to use - could take a while to return
 %% on a big queue. The maximum is for the backend data structure used itself,
@@ -142,7 +142,7 @@ pull(Name, DeliverFun) ->
 %% @doc Block the caller while the pull is done.
 -spec pull_sync(Name :: string(), DeliverFun :: deliver_fun()) -> 'ok'.
 pull_sync(Name, DeliverFun) ->
-    gen_server:call(?SERVER, {pull_with_ack, Name, DeliverFun}).
+    gen_server:call(?SERVER, {pull_with_ack, Name, DeliverFun}, infinity).
 
 %% @doc Asynchronously acknowldge delivery of all objects with a sequence
 %% equal or lower to Seq for the consumer.
@@ -153,7 +153,7 @@ ack(Name, Seq) ->
 %% @doc Same as ack/2, but blocks the caller.
 -spec ack_sync(Name :: string(), Seq :: pos_integer()) ->'ok'.
 ack_sync(Name, Seq) ->
-    gen_server:call(?SERVER, {ack_sync, Name, Seq}).
+    gen_server:call(?SERVER, {ack_sync, Name, Seq}, infinity).
 
 %% @doc The status of the queue.
 %% <dl>
@@ -172,27 +172,27 @@ ack_sync(Name, Seq) ->
 %% </dl>
 -spec status() -> [any()].
 status() ->
-    gen_server:call(?SERVER, status).
+    gen_server:call(?SERVER, status, infinity).
 
 %% @doc return the data store as a list.
 -spec dumpq() -> [any()].
 dumpq() ->
-    gen_server:call(?SERVER, dumpq).
+    gen_server:call(?SERVER, dumpq, infinity).
 
 %% @doc Signal that this node is doing down, and so a proxy process needs to
 %% start to avoid dropping, or aborting unacked results.
 -spec shutdown() -> 'ok'.
 shutdown() ->
-    gen_server:call(?SERVER, shutting_down).
+    gen_server:call(?SERVER, shutting_down, infinity).
 
 stop() ->
-    gen_server:call(?SERVER, stop).
+    gen_server:call(?SERVER, stop, infinity).
 
 %% @doc Will explode if the server is not started, but will tell you if it's
 %% in shutdown.
 -spec is_running() -> boolean().
 is_running() ->
-    gen_server:call(?SERVER, is_running).
+    gen_server:call(?SERVER, is_running, infinity).
 
 
 %% Internals
@@ -477,16 +477,16 @@ set_skip_meta(QEntry, _Seq, _C = #c{delivered = false}) ->
 set_skip_meta(QEntry, _Seq, _C = #c{skips = S}) ->
     set_meta(QEntry, skip_count, S).
 
-% if the sequence we are testing is more than one above the last sequence
-% skipped, then there was at least one sequence sent to the sink side.
-count_skips(Seq, [SeqMin1 | Tail], N) when Seq - 1 == SeqMin1 ->
-    count_skips(SeqMin1, Tail, N + 1);
-% a skipped seq can happen when a source connects to a sink, and a seq was
-% marked as unroutable.
-count_skips(Seq, [SeqBig | Tail], N) when Seq < SeqBig ->
-    count_skips(Seq, Tail, N);
-count_skips(_Seq, _Count, N) ->
-    N.
+%% % if the sequence we are testing is more than one above the last sequence
+%% % skipped, then there was at least one sequence sent to the sink side.
+%% count_skips(Seq, [SeqMin1 | Tail], N) when Seq - 1 == SeqMin1 ->
+%%     count_skips(SeqMin1, Tail, N + 1);
+%% % a skipped seq can happen when a source connects to a sink, and a seq was
+%% % marked as unroutable.
+%% count_skips(Seq, [SeqBig | Tail], N) when Seq < SeqBig ->
+%%     count_skips(Seq, Tail, N);
+%% count_skips(_Seq, _Count, N) ->
+%%     N.
 
 set_local_forwards_meta(LocalForwards, QEntry) ->
     set_meta(QEntry, local_forwards, LocalForwards).

--- a/src/riak_repl2_rtsink_conn.erl
+++ b/src/riak_repl2_rtsink_conn.erl
@@ -73,13 +73,13 @@ set_socket(Pid, Socket, Transport) ->
     gen_server:call(Pid, {set_socket, Socket, Transport}, infinity).
 
 status(Pid) ->
-    status(Pid, 5000).
+    status(Pid, ?LONG_TIMEOUT).
 
 status(Pid, Timeout) ->
     gen_server:call(Pid, status, Timeout).
 
 legacy_status(Pid) ->
-    legacy_status(Pid, 5000).
+    legacy_status(Pid, ?LONG_TIMEOUT).
 
 legacy_status(Pid, Timeout) ->
     gen_server:call(Pid, legacy_status, Timeout).

--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -73,7 +73,7 @@ start_link(Remote) ->
     gen_server:start_link(?MODULE, [Remote], []).
 
 stop(Pid) ->
-    gen_server:call(Pid, stop).
+    gen_server:call(Pid, stop, ?LONG_TIMEOUT).
     
 status(Pid) ->
     status(Pid, infinity).
@@ -94,7 +94,8 @@ connected(Socket, Transport, Endpoint, Proto, RtSourcePid, Props) ->
     Transport:controlling_process(Socket, RtSourcePid),
     Transport:setopts(Socket, [{active, true}]),
     gen_server:call(RtSourcePid,
-                    {connected, Socket, Transport, Endpoint, Proto}).
+                    {connected, Socket, Transport, Endpoint, Proto},
+                    ?LONG_TIMEOUT).
 
 connect_failed(_ClientProto, Reason, RtSourcePid) ->
     gen_server:cast(RtSourcePid, {connect_failed, self(), Reason}).

--- a/src/riak_repl_bq.erl
+++ b/src/riak_repl_bq.erl
@@ -33,7 +33,7 @@ status(Pid) ->
     end.
 
 stop(Pid) ->
-    gen_server:call(Pid, stop).
+    gen_server:call(Pid, stop, infinity).
 
 %% gen_server
 

--- a/src/riak_repl_console.erl
+++ b/src/riak_repl_console.erl
@@ -268,7 +268,7 @@ clusters([]) ->
     {ok, Clusters} = riak_core_cluster_mgr:get_known_clusters(),
     %% TODO: include our own cluster in the listing
     %% MyAddr = ???
-    %% MyMembers = gen_server:call(?CLUSTER_MANAGER_SERVER, {get_my_members, MyAddr}),
+    %% MyMembers = gen_server:call(?CLUSTER_MANAGER_SERVER, {get_my_members, MyAddr}, infinity),
     %% io:format("~-20s ~-15s ~p~n", [string_of_ipaddr(MyAddr), " ", MyMembers]),
     lists:foreach(
       fun(ClusterName) ->

--- a/src/riak_repl_fullsync_helper.erl
+++ b/src/riak_repl_fullsync_helper.erl
@@ -64,7 +64,7 @@ stop(Pid) ->
 %% a gen_fsm event {Ref, merkle_built} to the OwnerFsm or
 %% a {Ref, {error, Reason}} event on failures
 make_merkle(Pid, Partition, Filename) ->
-    riak_core_gen_server:call(Pid, {make_merkle, Partition, Filename}).
+    riak_core_gen_server:call(Pid, {make_merkle, Partition, Filename}, ?LONG_TIMEOUT).
 
 %% Make a sorted file of key/object hashes.
 %% 
@@ -72,7 +72,7 @@ make_merkle(Pid, Partition, Filename) ->
 %% a gen_fsm event {Ref, keylist_built} to the OwnerFsm or
 %% a {Ref, {error, Reason}} event on failures
 make_keylist(Pid, Partition, Filename) ->
-    riak_core_gen_server:call(Pid, {make_keylist, Partition, Filename}).
+    riak_core_gen_server:call(Pid, {make_keylist, Partition, Filename}, ?LONG_TIMEOUT).
    
 %% Convert a couch_btree to a sorted keylist file.
 %%
@@ -80,17 +80,17 @@ make_keylist(Pid, Partition, Filename) ->
 %% Sends a gen_fsm event {Ref, converted} on success or
 %% {Ref, {error, Reason}} on failure
 merkle_to_keylist(Pid, MerkleFn, KeyListFn) ->
-    riak_core_gen_server:call(Pid, {merkle_to_keylist, MerkleFn, KeyListFn}).
+    riak_core_gen_server:call(Pid, {merkle_to_keylist, MerkleFn, KeyListFn}, ?LONG_TIMEOUT).
     
 %% Computes the difference between two keylist sorted files.
 %% Returns {ok, Ref} or {error, Reason}
 %% Differences are sent as {Ref, {merkle_diff, {Bkey, Vclock}}}
 %% and finally {Ref, diff_done}.  Any errors as {Ref, {error, Reason}}.
 diff(Pid, Partition, TheirFn, OurFn) ->
-    riak_core_gen_server:call(Pid, {diff, Partition, TheirFn, OurFn, -1, true}).
+    riak_core_gen_server:call(Pid, {diff, Partition, TheirFn, OurFn, -1, true}, ?LONG_TIMEOUT).
 
 diff_stream(Pid, Partition, TheirFn, OurFn, Count) ->
-    riak_core_gen_server:call(Pid, {diff, Partition, TheirFn, OurFn, Count, false}).
+    riak_core_gen_server:call(Pid, {diff, Partition, TheirFn, OurFn, Count, false}, ?LONG_TIMEOUT).
 
 %% ====================================================================
 %% gen_server callbacks

--- a/src/riak_repl_keylist_server.erl
+++ b/src/riak_repl_keylist_server.erl
@@ -382,7 +382,7 @@ diff_keylist({Ref, diff_done}, #state{diff_ref=Ref} = State) ->
 %% diff_bloom states
 
 %% Pause or Cancel
-diff_bloom(Command, #state{diff_pid=Pid} = State)
+diff_bloom(Command, State)
         when Command == pause_fullsync; Command == cancel_fullsync ->
     riak_repl_tcp_server:send(State#state.transport, State#state.socket, Command),
     log_stop(Command, State),

--- a/src/riak_repl_leader.erl
+++ b/src/riak_repl_leader.erl
@@ -77,11 +77,11 @@ set_candidates(Candidates, Workers) ->
 
 %% Return the current leader node
 leader_node() ->
-    gen_server:call(?SERVER, leader_node).
+    gen_server:call(?SERVER, leader_node, infinity).
 
 %% Are we the leader?
 is_leader() ->
-    gen_server:call(?SERVER, is_leader).
+    gen_server:call(?SERVER, is_leader, infinity).
 
 %% Send the object to the leader
 postcommit(Object) ->
@@ -95,13 +95,13 @@ postcommit(Object) ->
 %% Add the pid of a riak_repl_tcp_sender process.  The pid is monitored
 %% and removed from the list when it exits. 
 add_receiver_pid(Pid) when is_pid(Pid) ->
-    gen_server:call(?SERVER, {add_receiver_pid, Pid}).
+    gen_server:call(?SERVER, {add_receiver_pid, Pid}, infinity).
 
 rm_receiver_pid(Pid) when is_pid(Pid) ->
-    gen_server:call(?SERVER, {rm_receiver_pid, Pid}).
+    gen_server:call(?SERVER, {rm_receiver_pid, Pid}, infinity).
 
 receiver_pids() ->
-    gen_server:call(?SERVER, receiver_pids).
+    gen_server:call(?SERVER, receiver_pids, infinity).
 
 ensure_sites() ->
     gen_server:cast(?SERVER, ensure_sites).
@@ -113,14 +113,14 @@ ensure_sites() ->
 %% Called by riak_repl_leader_helper whenever a leadership election
 %% takes place.
 set_leader(LocalPid, LeaderNode, LeaderPid) ->
-    gen_server:call(LocalPid, {set_leader_node, LeaderNode, LeaderPid}).
+    gen_server:call(LocalPid, {set_leader_node, LeaderNode, LeaderPid}, infinity).
 
 %%%===================================================================
 %%% Unit test support for riak_repl_leader_helper
 %%%===================================================================
 
 helper_pid() ->
-    gen_server:call(?SERVER, helper_pid).
+    gen_server:call(?SERVER, helper_pid, infinity).
 
 %%%===================================================================
 %%% gen_server callbacks

--- a/src/riak_repl_pb_get.erl
+++ b/src/riak_repl_pb_get.erl
@@ -1,5 +1,7 @@
 -module(riak_repl_pb_get).
 
+-include("riak_repl.hrl").
+
 -include_lib("riak_repl_pb_api/include/riak_repl_pb.hrl").
 -include_lib("riak_pb/include/riak_kv_pb.hrl").
 -include_lib("riak_pb/include/riak_pb_kv_codec.hrl").
@@ -165,7 +167,7 @@ proxy_get_13(State, CName, CNames, B, K, GetOptions) ->
                 true ->
                     Leader = riak_core_cluster_mgr:get_leader(),
                     ProxyForCluster = riak_repl_util:make_pg_proxy_name(ClusterName),
-                    gen_server:call({ProxyForCluster, Leader}, {proxy_get, B, K, GetOptions});
+                    gen_server:call({ProxyForCluster, Leader}, {proxy_get, B, K, GetOptions}, ?LONG_TIMEOUT);
                 false ->
                     notconnected
             end

--- a/src/riak_repl_tcp_client.erl
+++ b/src/riak_repl_tcp_client.erl
@@ -63,7 +63,7 @@ status(Pid, Timeout) ->
     gen_server:call(Pid, status, Timeout).
 
 cluster_name(Pid) ->
-    gen_server:call(Pid, cluster_name).
+    gen_server:call(Pid, cluster_name, ?LONG_TIMEOUT).
 
 proxy_get(Pid, Bucket, Key, Options) ->
     gen_server:call(Pid, {proxy_get, Bucket, Key, Options}, infinity).

--- a/src/riak_repl_tcp_server.erl
+++ b/src/riak_repl_tcp_server.erl
@@ -61,19 +61,19 @@ start_link(Listener, Socket, Transport, _Opts) ->
     gen_server:start_link(?MODULE, [Listener, Socket, Transport], []).
 
 set_socket(Pid, Socket) ->
-    gen_server:call(Pid, {set_socket, Socket}).
+    gen_server:call(Pid, {set_socket, Socket}, ?LONG_TIMEOUT).
 
 start_fullsync(Pid) ->
-    gen_server:call(Pid, start_fullsync).
+    gen_server:call(Pid, start_fullsync, ?LONG_TIMEOUT).
 
 cancel_fullsync(Pid) ->
-    gen_server:call(Pid, cancel_fullsync).
+    gen_server:call(Pid, cancel_fullsync, ?LONG_TIMEOUT).
 
 pause_fullsync(Pid) ->
-    gen_server:call(Pid, pause_fullsync).
+    gen_server:call(Pid, pause_fullsync, ?LONG_TIMEOUT).
 
 resume_fullsync(Pid) ->
-    gen_server:call(Pid, resume_fullsync).
+    gen_server:call(Pid, resume_fullsync, ?LONG_TIMEOUT).
 
 status(Pid) ->
     status(Pid, infinity).

--- a/test/riak_core_cluster_mgr_sup_tests.erl
+++ b/test/riak_core_cluster_mgr_sup_tests.erl
@@ -1,5 +1,6 @@
 -module(riak_core_cluster_mgr_sup_tests).
 -compile(export_all).
+-ifdef(EQC).
 -include_lib("riak_core/include/riak_core_connection.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -113,3 +114,5 @@ wait(WaitFun, Wait, Itor) ->
             timer:sleep(Wait),
             wait(WaitFun, Wait, Itor - 1)
     end.
+
+-endif. % EQC

--- a/test/rt_sink_eqc.erl
+++ b/test/rt_sink_eqc.erl
@@ -1,5 +1,6 @@
 -module(rt_sink_eqc).
 
+-ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
 -include_lib("eqc/include/eqc_statem.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -616,3 +617,5 @@ fake_source_loop(State) ->
         What ->
             fake_source_loop(State)
     end.
+
+-endif. % EQC

--- a/test/rt_source_eqc.erl
+++ b/test/rt_source_eqc.erl
@@ -1,5 +1,6 @@
 -module(rt_source_eqc).
 
+-ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
 -include_lib("eqc/include/eqc_statem.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -691,3 +692,5 @@ fake_sink_nom_frames({ok, Frame, Rest}, History) ->
     fake_sink_nom_frames(Rest, [Frame | History]);
 fake_sink_nom_frames(Bin, History) ->
     fake_sink_nom_frames(riak_repl2_rtframe:decode(Bin), History).
+
+-endif. % EQC


### PR DESCRIPTION
Addresses #298 

In general, I used `?LONG_TIMEOUT` whenever the callee was not an atom and therefore not 100% clear that the callee is on the local node.  A more knowledgable reviewer should take a careful look at those cases and, when you _do_ know that the call is staying on the same node, change the timeout to `infinity`.
