### PR TITLE
Add sink cluster name to fullsync completion message

### DIFF
--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -359,7 +359,9 @@ handle_info({'EXIT', Pid, Cause}, State) when Cause =:= normal; Cause =:= shutdo
             Waiting = State#state.whereis_waiting,
             case {EmptyRunning, QEmpty, Waiting} of
                 {true, true, []} ->
-                    lager:info("Fullsync complete to ~p", [State#state.other_cluster]),
+                    MyClusterName = riak_core_connection:symbolic_clustername(),
+                    lager:info("Fullsync complete from ~s to ~s",
+                               [MyClusterName, State#state.other_cluster]),
                     % clear the "rt dirty" stat if it's set,
                     % otherwise, don't do anything
                     State3 = notify_rt_dirty_nodes(State),

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -359,7 +359,7 @@ handle_info({'EXIT', Pid, Cause}, State) when Cause =:= normal; Cause =:= shutdo
             Waiting = State#state.whereis_waiting,
             case {EmptyRunning, QEmpty, Waiting} of
                 {true, true, []} ->
-                    lager:info("Fullsync complete"),
+                    lager:info("Fullsync complete to ~p", [State#state.other_cluster]),
                     % clear the "rt dirty" stat if it's set,
                     % otherwise, don't do anything
                     State3 = notify_rt_dirty_nodes(State),


### PR DESCRIPTION
This PR adds the name of the sink cluster to the info log message for when a full sync completes. This is very handy when debugging/monitoring the completion of fullsyncs when more than one fullsync may be running concurrently.

Pretty trivial change to a lager:info() call. Tested.

The old message:
`2013-06-11 18:29:49.705 [info] <0.2992.0>@riak_repl2_fscoordinator:handle_info:362 Fullsync complete`

The new message:
`2013-06-11 18:29:49.705 [info] <0.2992.0>@riak_repl2_fscoordinator:handle_info:362 Fullsync complete to "B"`
