### PR TITLE
Make the interval the rtsink rechecks the active flag configurable.

### DIFF
--- a/src/riak_repl2_rtsink_conn.erl
+++ b/src/riak_repl2_rtsink_conn.erl
@@ -28,7 +28,7 @@
          terminate/2, code_change/3]).
 
 % how long to wait to reschedule socket reactivate.
--define(REACTIVATE_SOCK_INT, 10).
+-define(REACTIVATE_SOCK_INT_MILLIS, 10).
 
 -record(state, {remote,           %% Remote site name
                 transport,        %% Module for sending
@@ -375,14 +375,15 @@ schedule_reactivate_socket(State = #state{transport = T,
     end.
 
 get_reactivate_socket_interval() ->
-    app_helper:get_env(riak_repl, reactivate_socket_interval, ?REACTIVATE_SOCK_INT).
+    app_helper:get_env(riak_repl, reactivate_socket_interval, ?REACTIVATE_SOCK_INT_MILLIS).
+
 
 %% ===================================================================
 %% EUnit tests
 %% ===================================================================
 -ifdef(TEST).
 
--define(REACTIVATE_SOCK_INT_TEST_VAL, 20).
+-define(REACTIVATE_SOCK_INT_MILLIS_TEST_VAL, 20).
 
 riak_repl2_rtsink_conn_test_() ->
     { setup,
@@ -400,8 +401,8 @@ cleanup(_Ctx) ->
 
 reactivate_socket_interval_test_case() ->
 
-    ?assertEqual(?REACTIVATE_SOCK_INT, get_reactivate_socket_interval()),
+    ?assertEqual(?REACTIVATE_SOCK_INT_MILLIS, get_reactivate_socket_interval()),
  
-    application:set_env(riak_repl, reactivate_socket_interval, ?REACTIVATE_SOCK_INT_TEST_VAL),
-    ?assertEqual(?REACTIVATE_SOCK_INT_TEST_VAL, get_reactivate_socket_interval()).
+    application:set_env(riak_repl, reactivate_socket_interval, ?REACTIVATE_SOCK_INT_MILLIS_TEST_VAL),
+    ?assertEqual(?REACTIVATE_SOCK_INT_MILLIS_TEST_VAL, get_reactivate_socket_interval()).
 -endif.

--- a/src/riak_repl2_rtsink_conn.erl
+++ b/src/riak_repl2_rtsink_conn.erl
@@ -23,8 +23,7 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
-% how long to wait for a reply from remote cluster before moving on to
-% next partition.
+% how long to wait to reschedule socket reactivate.
 -define(REACTIVATE_SOCK_INT, 5000).
 
 -record(state, {remote,           %% Remote site name
@@ -317,7 +316,8 @@ reset_ref_seq(Seq, State) ->
 
 %% Work out the highest sequence number that can be acked
 %% and return it, completed always has one or more elements on first
-%% call.
+%% call
+
 ack_to(Acked, []) ->
     {Acked, []};
 ack_to(Acked, [Seq | Completed2] = Completed) -> 
@@ -358,21 +358,15 @@ schedule_reactivate_socket(State = #state{transport = T,
             self() ! reactivate_socket,
             State#state{active = false, deactivated = Deactivated + 1};
         false ->
-            %% already deactivated, try again in configured interval, or 10ms
-            ReactivateSockInt = case app_helper:get_env(riak_repl, reactivate_socket_interval, ?REACTIVATE_SOCK_INT) of
-                undefined ->
-                    lager:error("rtsink_recheck_active_flag is not configured in 
-                      riak_repl, defaulting to ~sms.", [?REACTIVATE_SOCK_INT]),
-                    10;
-                Res ->
-                  lager:error("rtsink_recheck_active_flag is configured in 
-                    riak_repl is configured to: ~sms.", [Res]),
-                   Res
-            end,
+            %% already deactivated, try again in configured interval, or default
+            ReactivateSockInt = app_helper:get_env(riak_repl, reactivate_socket_interval, ?REACTIVATE_SOCK_INT),
+ 
+            lager:info("reactivate_socket_interval is configured in 
+              riak_repl to: ~sms.", [ReactivateSockInt]),
+
             erlang:send_after(ReactivateSockInt, self(), reactivate_socket),
             State#state{active = {false, scheduled}};
         {false, scheduled} ->
             %% have a check scheduled already
             State
     end.
-    

--- a/src/riak_repl2_rtsink_conn.erl
+++ b/src/riak_repl2_rtsink_conn.erl
@@ -384,7 +384,7 @@ get_reactivate_socket_interval() ->
 
 -define(REACTIVATE_SOCK_INT_TEST_VAL, 20).
 
-app_helper_test_() ->
+riak_repl2_rtsink_conn_test_() ->
     { setup,
       fun setup/0,
       fun cleanup/1,

--- a/src/riak_repl2_rtsink_conn.erl
+++ b/src/riak_repl2_rtsink_conn.erl
@@ -24,7 +24,7 @@
          terminate/2, code_change/3]).
 
 % how long to wait to reschedule socket reactivate.
--define(REACTIVATE_SOCK_INT, 5000).
+-define(REACTIVATE_SOCK_INT, 10).
 
 -record(state, {remote,           %% Remote site name
                 transport,        %% Module for sending
@@ -316,7 +316,7 @@ reset_ref_seq(Seq, State) ->
 
 %% Work out the highest sequence number that can be acked
 %% and return it, completed always has one or more elements on first
-%% call
+%% call.
 
 ack_to(Acked, []) ->
     {Acked, []};
@@ -361,7 +361,7 @@ schedule_reactivate_socket(State = #state{transport = T,
             %% already deactivated, try again in configured interval, or default
             ReactivateSockInt = app_helper:get_env(riak_repl, reactivate_socket_interval, ?REACTIVATE_SOCK_INT),
  
-            lager:info("reactivate_socket_interval is configured in 
+            lager:debug("reactivate_socket_interval is configured in 
               riak_repl to: ~sms.", [ReactivateSockInt]),
 
             erlang:send_after(ReactivateSockInt, self(), reactivate_socket),


### PR DESCRIPTION
Addresses https://github.com/basho/riak_repl/issues/252 by adding app.config riak_repl, reactivate_socket_interval configuration to schedule_reactivate_socket/1. Added test for helper function.
