### PR TITLE
Fix typo in rt_heartbeat_ config vars

### DIFF
--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -223,9 +223,9 @@ handle_call({connected, Socket, Transport, EndPoint, Proto}, _From,
                     {reply, ok, State2};
                 _ ->
                     %% 1.1 and above, start with a heartbeat
-                    HBInterval = app_helper:get_env(riak_repl, rt_hearbeat_interval,
+                    HBInterval = app_helper:get_env(riak_repl, rt_heartbeat_interval,
                                                     ?DEFAULT_HBINTERVAL),
-                    HBTimeout = app_helper:get_env(riak_repl, rt_hearbeat_timeout,
+                    HBTimeout = app_helper:get_env(riak_repl, rt_heartbeat_timeout,
                                                    ?DEFAULT_HBTIMEOUT),
                     State3 = State2#state{hb_interval = HBInterval,
                                           hb_timeout = HBTimeout},


### PR DESCRIPTION
While writing the riak_test for RT heartbeats, it was observed that the configuration variables for defining the timeout intervals where not being honored. This was due to a typo in the RT source code. This PR corrects the typo. The riak_test validates the correction and the overall functioning of the heartbeat feature.
