### PR TITLE
removed delayed_write option to file:open

### DIFF
--- a/src/riak_repl_keylist_server.erl
+++ b/src/riak_repl_keylist_server.erl
@@ -244,8 +244,7 @@ wait_keylist(kl_wait, State) ->
 wait_keylist({kl_hunk, Hunk}, #state{their_kl_fh=FH0} = State) ->
     FH = case FH0 of
         undefined ->
-            {ok, F} = file:open(State#state.their_kl_fn, [write, raw, binary,
-                    delayed_write]),
+            {ok, F} = file:open(State#state.their_kl_fn, [write, raw, binary]),
             F;
         _ ->
             FH0

--- a/src/riak_repl_syncv1_client.erl
+++ b/src/riak_repl_syncv1_client.erl
@@ -68,7 +68,7 @@ merkle_exchange({merkle,Size,Partition},State=#state{work_dir=WorkDir}) ->
                                                                  OurKeyListFn),
     TheirMerkleFn = riak_repl_util:merkle_filename(WorkDir, Partition, theirs),
     TheirKeyListFn = riak_repl_util:keylist_filename(WorkDir, Partition, theirs),
-    {ok, FP} = file:open(TheirMerkleFn, [write, raw, binary, delayed_write]),
+    {ok, FP} = file:open(TheirMerkleFn, [write, raw, binary]),
     {next_state, merkle_recv, State#state{merkle_fp=FP, 
                                           their_merkle_fn=TheirMerkleFn,
                                           their_merkle_sz=Size, 


### PR DESCRIPTION
use of delayed_write has been resolved in R16B01, however we're still using R15. We're hoping that this may be the cause of `premature_eof` errors that we've seen with some customers.

See also:
- http://www.erlang.org/download/otp_src_R16B01.readme
- https://github.com/erlang/otp/commit/a73414d2e8ad03538b28546756e7e7264654466d

```
OTP-10984  Fixed a race condition when using delayed_write when writing
          to a file which would cause the same data to be written
          multiple times.
```
