### PR TITLE
Backport use of Long Timeouts from 1.4 to 1.3

### DIFF
--- a/include/riak_repl.hrl
+++ b/include/riak_repl.hrl
@@ -25,6 +25,8 @@
 -define(DEFAULT_MAX_SINKS_NODE, 1).
 %% 20 seconds. sources should claim within 5 seconds, but give them a little more time
 -define(RESERVATION_TIMEOUT, (20 * 1000)).
+%% allow 1 minute for reservation call to succeed before timeout and 'down' response.
+-define(RESERVE_TIMEOUT, (60 * 1000)).
 -define(DEFAULT_MAX_FS_BUSIES_TOLERATED, 10).
 -define(RETRY_WHEREIS_INTERVAL, 1000).
 -define(CONSOLE_RPC_TIMEOUT, 5000).
@@ -88,4 +90,3 @@
 
 
 -define(LONG_TIMEOUT, 120*1000).
-

--- a/include/riak_repl.hrl
+++ b/include/riak_repl.hrl
@@ -87,3 +87,5 @@
 -define(REPL_MODES, [{mode_repl12,?REPL_HOOK12}, {mode_repl13,?REPL_HOOK_BNW}]).
 
 
+-define(LONG_TIMEOUT, 120*1000).
+

--- a/src/riak_core_cluster_mgr.erl
+++ b/src/riak_core_cluster_mgr.erl
@@ -139,12 +139,12 @@ set_leader(LeaderNode, _LeaderPid) ->
 %% Reply with the current leader node.
 -spec get_leader() -> node().
 get_leader() ->
-    gen_server:call(?SERVER, leader_node).
+    gen_server:call(?SERVER, leader_node, infinity).
 
 %% @doc True if the local manager is the leader.
 -spec get_is_leader() -> boolean().
 get_is_leader() ->
-    gen_server:call(?SERVER, get_is_leader).
+    gen_server:call(?SERVER, get_is_leader, infinity).
 
 %% @doc Register a function that will get called to get out local riak node
 %% member's IP addrs. MemberFun(inet:addr()) -> [{IP,Port}] were IP is a string
@@ -172,24 +172,24 @@ remove_remote_cluster(Cluster) ->
 %% @doc Retrieve a list of known remote clusters that have been resolved (they responded).
 -spec(get_known_clusters() -> {ok,[clustername()]} | term()).
 get_known_clusters() ->
-    gen_server:call(?SERVER, get_known_clusters).
+    gen_server:call(?SERVER, get_known_clusters, infinity).
 
 %% @doc Retrieve a list of IP,Port tuples we are connected to or trying to connect to
 get_connections() ->
-    gen_server:call(?SERVER, get_connections).
+    gen_server:call(?SERVER, get_connections, infinity).
 
 get_my_members(MyAddr) ->
-    gen_server:call(?SERVER, {get_my_members, MyAddr}).
+    gen_server:call(?SERVER, {get_my_members, MyAddr}, infinity).
 
 %% @doc Return a list of the known IP addresses of all nodes in the remote cluster.
 -spec(get_ipaddrs_of_cluster(clustername()) -> [ip_addr()]).
 get_ipaddrs_of_cluster(ClusterName) ->
-        gen_server:call(?SERVER, {get_known_ipaddrs_of_cluster, {name,ClusterName}}).
+        gen_server:call(?SERVER, {get_known_ipaddrs_of_cluster, {name,ClusterName}}, infinity).
 
 %% @doc stops the local server.
 -spec stop() -> 'ok'.
 stop() ->
-    gen_server:call(?SERVER, stop).
+    gen_server:call(?SERVER, stop, infinity).
 
 -spec set_gc_interval(Interval :: timeout()) -> 'ok'.
 set_gc_interval(Interval) ->
@@ -781,7 +781,7 @@ ctrlServiceProcess(Socket, Transport, MyVer, RemoteVer, ClientAddr) ->
                 {error, closed} ->
                     {error, connection_closed};
                 {ok, MyAddr} ->
-                    BalancedMembers = gen_server:call(?SERVER, {get_my_members, MyAddr}),
+                    BalancedMembers = gen_server:call(?SERVER, {get_my_members, MyAddr}, infinity),
                     ok = Transport:send(Socket, term_to_binary(BalancedMembers)),
                     ctrlServiceProcess(Socket, Transport, MyVer, RemoteVer, ClientAddr);
                 Error ->

--- a/src/riak_repl2_fs_node_reserver.erl
+++ b/src/riak_repl2_fs_node_reserver.erl
@@ -40,6 +40,8 @@ start_link() ->
 reserve(Partition) ->
     Node = get_partition_node(Partition),
     % I don't want to crash the caller if the node is down
+    %% TODO: add explicit timeout to this call
+    %% TODO: add timeout handling to catch?
     try gen_server:call({?SERVER, Node}, {reserve, Partition}) of
         Out -> Out
     catch

--- a/src/riak_repl2_fssource.erl
+++ b/src/riak_repl2_fssource.erl
@@ -27,8 +27,9 @@ start_link(Partition, IP) ->
 %% connection manager callbacks
 connected(Socket, Transport, Endpoint, Proto, Pid, Props) ->
     Transport:controlling_process(Socket, Pid),
+    %% Pid is running local when connection manager calls us here.
     gen_server:call(Pid,
-        {connected, Socket, Transport, Endpoint, Proto, Props}, ?LONG_TIMEOUT).
+        {connected, Socket, Transport, Endpoint, Proto, Props}, infinity).
 
 connect_failed(_ClientProto, Reason, RtSourcePid) ->
     gen_server:cast(RtSourcePid, {connect_failed, self(), Reason}).

--- a/src/riak_repl2_fssource.erl
+++ b/src/riak_repl2_fssource.erl
@@ -28,20 +28,20 @@ start_link(Partition, IP) ->
 connected(Socket, Transport, Endpoint, Proto, Pid, Props) ->
     Transport:controlling_process(Socket, Pid),
     gen_server:call(Pid,
-        {connected, Socket, Transport, Endpoint, Proto, Props}).
+        {connected, Socket, Transport, Endpoint, Proto, Props}, ?LONG_TIMEOUT).
 
 connect_failed(_ClientProto, Reason, RtSourcePid) ->
     gen_server:cast(RtSourcePid, {connect_failed, self(), Reason}).
 
 start_fullsync(Pid) ->
-    gen_server:call(Pid, start_fullsync).
+    gen_server:call(Pid, start_fullsync, ?LONG_TIMEOUT).
 
 stop_fullsync(Pid) ->
-    gen_server:call(Pid, stop_fullsync).
+    gen_server:call(Pid, stop_fullsync, ?LONG_TIMEOUT).
 
 %% get the cluster name
 cluster_name(Pid) ->
-    gen_server:call(Pid, cluster_name).
+    gen_server:call(Pid, cluster_name, ?LONG_TIMEOUT).
 
 legacy_status(Pid, Timeout) ->
     gen_server:call(Pid, legacy_status, Timeout).

--- a/src/riak_repl2_leader.erl
+++ b/src/riak_repl2_leader.erl
@@ -64,11 +64,11 @@ register_notify_fun(Fun) ->
 
 %% Return the current leader node
 leader_node() ->
-    gen_server:call(?SERVER, leader_node).
+    gen_server:call(?SERVER, leader_node, infinity).
 
 %% Are we the leader?
 is_leader() ->
-    gen_server:call(?SERVER, is_leader).
+    gen_server:call(?SERVER, is_leader, infinity).
 
 %%%===================================================================
 %%% Callback for riak_repl_leader_helper
@@ -77,14 +77,14 @@ is_leader() ->
 %% Called by riak_repl_leader_helper whenever a leadership election
 %% takes place.
 set_leader(LocalPid, LeaderNode, LeaderPid) ->
-    gen_server:call(LocalPid, {set_leader_node, LeaderNode, LeaderPid}).
+    gen_server:call(LocalPid, {set_leader_node, LeaderNode, LeaderPid}, infinity).
 
 %%%===================================================================
 %%% Unit test support for riak_repl_leader_helper
 %%%===================================================================
 
 helper_pid() ->
-    gen_server:call(?SERVER, helper_pid).
+    gen_server:call(?SERVER, helper_pid, infinity).
 
 %%%===================================================================
 %%% gen_server callbacks

--- a/src/riak_repl2_rt.erl
+++ b/src/riak_repl2_rt.erl
@@ -128,12 +128,12 @@ register_remote_locator() ->
 
 %% Register an active realtime sink (supervised under ranch)
 register_sink(Pid) ->
-    gen_server:call(?SERVER, {register_sink, Pid}).
+    gen_server:call(?SERVER, {register_sink, Pid}, infinity).
 
 %% Get list of sink pids 
 %% TODO: Remove this once rtsink_sup is working right
 get_sink_pids() ->
-    gen_server:call(?SERVER, get_sink_pids).
+    gen_server:call(?SERVER, get_sink_pids, infinity).
 
 %% Realtime replication post-commit hook
 postcommit(RObj) ->

--- a/src/riak_repl2_rtq.erl
+++ b/src/riak_repl2_rtq.erl
@@ -68,17 +68,17 @@ start_test() ->
     gen_server:start(?MODULE, [], []).
 
 register(Name) ->
-    gen_server:call(?SERVER, {register, Name}).
+    gen_server:call(?SERVER, {register, Name}, infinity).
 
 unregister(Name) ->
-    gen_server:call(?SERVER, {unregister, Name}).
+    gen_server:call(?SERVER, {unregister, Name}, infinity).
 
 
 is_empty(Name) ->
-    gen_server:call(?SERVER, {is_empty, Name}).
+    gen_server:call(?SERVER, {is_empty, Name}, infinity).
 
 all_queues_empty() ->
-    gen_server:call(?SERVER, all_queues_empty).
+    gen_server:call(?SERVER, all_queues_empty, infinity).
 
 %% Set the maximum number of bytes to use - could take a while to return
 %% on a big queue
@@ -93,28 +93,28 @@ pull(Name, DeliverFun) ->
     gen_server:cast(?SERVER, {pull, Name, DeliverFun}).
 
 pull_sync(Name, DeliverFun) ->
-    gen_server:call(?SERVER, {pull_with_ack, Name, DeliverFun}).
+    gen_server:call(?SERVER, {pull_with_ack, Name, DeliverFun}, infinity).
 
 ack(Name, Seq) ->
     gen_server:cast(?SERVER, {ack, Name, Seq}).
 
 ack_sync(Name, Seq) ->
-    gen_server:call(?SERVER, {ack_sync, Name, Seq}).
+    gen_server:call(?SERVER, {ack_sync, Name, Seq}, infinity).
 
 status() ->
-    gen_server:call(?SERVER, status).
+    gen_server:call(?SERVER, status, infinity).
 
 dumpq() ->
-    gen_server:call(?SERVER, dumpq).
+    gen_server:call(?SERVER, dumpq, infinity).
 
 shutdown() ->
-    gen_server:call(?SERVER, shutting_down).
+    gen_server:call(?SERVER, shutting_down, infinity).
 
 stop() ->
-    gen_server:call(?SERVER, stop).
+    gen_server:call(?SERVER, stop, infinity).
 
 is_running() ->
-    gen_server:call(?SERVER, is_running).
+    gen_server:call(?SERVER, is_running, infinity).
 
 
 %% Internals
@@ -353,7 +353,6 @@ cleanup(QTab, Seq, State) ->
         _ ->
             lager:warning("Unexpected object in RTQ")
     end.
-
 
 ets_obj_size(Obj, #state{word_size = WordSize}) when is_binary(Obj) ->
   BSize = erlang:byte_size(Obj),

--- a/src/riak_repl2_rtsink_conn.erl
+++ b/src/riak_repl2_rtsink_conn.erl
@@ -72,13 +72,13 @@ set_socket(Pid, Socket, Transport) ->
     gen_server:call(Pid, {set_socket, Socket, Transport}, infinity).
 
 status(Pid) ->
-    status(Pid, 5000).
+    status(Pid, ?LONG_TIMEOUT).
 
 status(Pid, Timeout) ->
     gen_server:call(Pid, status, Timeout).
 
 legacy_status(Pid) ->
-    legacy_status(Pid, 5000).
+    legacy_status(Pid, ?LONG_TIMEOUT).
 
 legacy_status(Pid, Timeout) ->
     gen_server:call(Pid, legacy_status, Timeout).

--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -72,7 +72,7 @@ start_link(Remote) ->
     gen_server:start_link(?MODULE, [Remote], []).
 
 stop(Pid) ->
-    gen_server:call(Pid, stop).
+    gen_server:call(Pid, stop, ?LONG_TIMEOUT).
     
 status(Pid) ->
     status(Pid, infinity).
@@ -93,7 +93,8 @@ connected(Socket, Transport, Endpoint, Proto, RtSourcePid, Props) ->
     Transport:controlling_process(Socket, RtSourcePid),
     Transport:setopts(Socket, [{active, true}]),
     gen_server:call(RtSourcePid,
-                    {connected, Socket, Transport, Endpoint, Proto}).
+                    {connected, Socket, Transport, Endpoint, Proto},
+                    ?LONG_TIMEOUT).
 
 connect_failed(_ClientProto, Reason, RtSourcePid) ->
     gen_server:cast(RtSourcePid, {connect_failed, self(), Reason}).

--- a/src/riak_repl_bq.erl
+++ b/src/riak_repl_bq.erl
@@ -33,7 +33,7 @@ status(Pid) ->
     end.
 
 stop(Pid) ->
-    gen_server:call(Pid, stop).
+    gen_server:call(Pid, stop, infinity).
 
 %% gen_server
 

--- a/src/riak_repl_console.erl
+++ b/src/riak_repl_console.erl
@@ -246,7 +246,7 @@ clusters([]) ->
     {ok, Clusters} = riak_core_cluster_mgr:get_known_clusters(),
     %% TODO: include our own cluster in the listing
     %% MyAddr = ???
-    %% MyMembers = gen_server:call(?CLUSTER_MANAGER_SERVER, {get_my_members, MyAddr}),
+    %% MyMembers = gen_server:call(?CLUSTER_MANAGER_SERVER, {get_my_members, MyAddr}, infinity),
     %% io:format("~-20s ~-15s ~p~n", [string_of_ipaddr(MyAddr), " ", MyMembers]),
     lists:foreach(
       fun(ClusterName) ->

--- a/src/riak_repl_fullsync_helper.erl
+++ b/src/riak_repl_fullsync_helper.erl
@@ -64,7 +64,7 @@ stop(Pid) ->
 %% a gen_fsm event {Ref, merkle_built} to the OwnerFsm or
 %% a {Ref, {error, Reason}} event on failures
 make_merkle(Pid, Partition, Filename) ->
-    riak_core_gen_server:call(Pid, {make_merkle, Partition, Filename}).
+    riak_core_gen_server:call(Pid, {make_merkle, Partition, Filename}, ?LONG_TIMEOUT).
 
 %% Make a sorted file of key/object hashes.
 %% 
@@ -72,7 +72,7 @@ make_merkle(Pid, Partition, Filename) ->
 %% a gen_fsm event {Ref, keylist_built} to the OwnerFsm or
 %% a {Ref, {error, Reason}} event on failures
 make_keylist(Pid, Partition, Filename) ->
-    riak_core_gen_server:call(Pid, {make_keylist, Partition, Filename}).
+    riak_core_gen_server:call(Pid, {make_keylist, Partition, Filename}, ?LONG_TIMEOUT).
    
 %% Convert a couch_btree to a sorted keylist file.
 %%
@@ -80,17 +80,17 @@ make_keylist(Pid, Partition, Filename) ->
 %% Sends a gen_fsm event {Ref, converted} on success or
 %% {Ref, {error, Reason}} on failure
 merkle_to_keylist(Pid, MerkleFn, KeyListFn) ->
-    riak_core_gen_server:call(Pid, {merkle_to_keylist, MerkleFn, KeyListFn}).
+    riak_core_gen_server:call(Pid, {merkle_to_keylist, MerkleFn, KeyListFn}, ?LONG_TIMEOUT).
     
 %% Computes the difference between two keylist sorted files.
 %% Returns {ok, Ref} or {error, Reason}
 %% Differences are sent as {Ref, {merkle_diff, {Bkey, Vclock}}}
 %% and finally {Ref, diff_done}.  Any errors as {Ref, {error, Reason}}.
 diff(Pid, Partition, TheirFn, OurFn) ->
-    riak_core_gen_server:call(Pid, {diff, Partition, TheirFn, OurFn, -1, true}).
+    riak_core_gen_server:call(Pid, {diff, Partition, TheirFn, OurFn, -1, true}, ?LONG_TIMEOUT).
 
 diff_stream(Pid, Partition, TheirFn, OurFn, Count) ->
-    riak_core_gen_server:call(Pid, {diff, Partition, TheirFn, OurFn, Count, false}).
+    riak_core_gen_server:call(Pid, {diff, Partition, TheirFn, OurFn, Count, false}, ?LONG_TIMEOUT).
 
 %% ====================================================================
 %% gen_server callbacks

--- a/src/riak_repl_keylist_server.erl
+++ b/src/riak_repl_keylist_server.erl
@@ -380,7 +380,7 @@ diff_keylist({Ref, diff_done}, #state{diff_ref=Ref} = State) ->
 %% diff_bloom states
 
 %% Pause or Cancel
-diff_bloom(Command, #state{diff_pid=Pid} = State)
+diff_bloom(Command, State)
         when Command == pause_fullsync; Command == cancel_fullsync ->
     riak_repl_tcp_server:send(State#state.transport, State#state.socket, Command),
     log_stop(Command, State),

--- a/src/riak_repl_leader.erl
+++ b/src/riak_repl_leader.erl
@@ -77,11 +77,11 @@ set_candidates(Candidates, Workers) ->
 
 %% Return the current leader node
 leader_node() ->
-    gen_server:call(?SERVER, leader_node).
+    gen_server:call(?SERVER, leader_node, infinity).
 
 %% Are we the leader?
 is_leader() ->
-    gen_server:call(?SERVER, is_leader).
+    gen_server:call(?SERVER, is_leader, infinity).
 
 %% Send the object to the leader
 postcommit(Object) ->
@@ -95,13 +95,13 @@ postcommit(Object) ->
 %% Add the pid of a riak_repl_tcp_sender process.  The pid is monitored
 %% and removed from the list when it exits. 
 add_receiver_pid(Pid) when is_pid(Pid) ->
-    gen_server:call(?SERVER, {add_receiver_pid, Pid}).
+    gen_server:call(?SERVER, {add_receiver_pid, Pid}, infinity).
 
 rm_receiver_pid(Pid) when is_pid(Pid) ->
-    gen_server:call(?SERVER, {rm_receiver_pid, Pid}).
+    gen_server:call(?SERVER, {rm_receiver_pid, Pid}, infinity).
 
 receiver_pids() ->
-    gen_server:call(?SERVER, receiver_pids).
+    gen_server:call(?SERVER, receiver_pids, infinity).
 
 ensure_sites() ->
     gen_server:cast(?SERVER, ensure_sites).
@@ -113,14 +113,14 @@ ensure_sites() ->
 %% Called by riak_repl_leader_helper whenever a leadership election
 %% takes place.
 set_leader(LocalPid, LeaderNode, LeaderPid) ->
-    gen_server:call(LocalPid, {set_leader_node, LeaderNode, LeaderPid}).
+    gen_server:call(LocalPid, {set_leader_node, LeaderNode, LeaderPid}, infinity).
 
 %%%===================================================================
 %%% Unit test support for riak_repl_leader_helper
 %%%===================================================================
 
 helper_pid() ->
-    gen_server:call(?SERVER, helper_pid).
+    gen_server:call(?SERVER, helper_pid, infinity).
 
 %%%===================================================================
 %%% gen_server callbacks

--- a/src/riak_repl_pb_get.erl
+++ b/src/riak_repl_pb_get.erl
@@ -1,5 +1,7 @@
 -module(riak_repl_pb_get).
 
+-include("riak_repl.hrl").
+
 -include_lib("riak_repl_pb_api/include/riak_repl_pb.hrl").
 -include_lib("riak_pb/include/riak_kv_pb.hrl").
 -include_lib("riak_pb/include/riak_pb_kv_codec.hrl").

--- a/src/riak_repl_tcp_client.erl
+++ b/src/riak_repl_tcp_client.erl
@@ -63,7 +63,7 @@ status(Pid, Timeout) ->
     gen_server:call(Pid, status, Timeout).
 
 cluster_name(Pid) ->
-    gen_server:call(Pid, cluster_name).
+    gen_server:call(Pid, cluster_name, ?LONG_TIMEOUT).
 
 proxy_get(Pid, Bucket, Key, Options) ->
     gen_server:call(Pid, {proxy_get, Bucket, Key, Options}, infinity).

--- a/src/riak_repl_tcp_server.erl
+++ b/src/riak_repl_tcp_server.erl
@@ -60,19 +60,19 @@ start_link(Listener, Socket, Transport, _Opts) ->
     gen_server:start_link(?MODULE, [Listener, Socket, Transport], []).
 
 set_socket(Pid, Socket) ->
-    gen_server:call(Pid, {set_socket, Socket}).
+    gen_server:call(Pid, {set_socket, Socket}, ?LONG_TIMEOUT).
 
 start_fullsync(Pid) ->
-    gen_server:call(Pid, start_fullsync).
+    gen_server:call(Pid, start_fullsync, ?LONG_TIMEOUT).
 
 cancel_fullsync(Pid) ->
-    gen_server:call(Pid, cancel_fullsync).
+    gen_server:call(Pid, cancel_fullsync, ?LONG_TIMEOUT).
 
 pause_fullsync(Pid) ->
-    gen_server:call(Pid, pause_fullsync).
+    gen_server:call(Pid, pause_fullsync, ?LONG_TIMEOUT).
 
 resume_fullsync(Pid) ->
-    gen_server:call(Pid, resume_fullsync).
+    gen_server:call(Pid, resume_fullsync, ?LONG_TIMEOUT).
 
 status(Pid) ->
     status(Pid, infinity).


### PR DESCRIPTION
Port most of https://github.com/basho/riak_repl/pull/299 from 1.4 to 1.3

The bulk of changes are to use explicit timeout values, rather than the very short default of 5 seconds.
Most will use the new LONG_TIMEOUT of 2 minutes, when they are possibly calls to remote nodes.
Known calls to local nodes now use infinity.
One additional catch of a timeout in the node_reserver makes it operate smoothly instead of crashing - it returns "down" which just mimics a node that is unavailable for work.

The commits from PR #299 were cherry-picked and edited to remove any cruft from 1.4. The EQC changes and changes to files that don't exist in 1.3 (proxy-get files) were removed.

Please note that this does address the gen_server call to get known ipaddrs in the cluster manager :-)
