### PR TITLE
don't blow up on stat errors

### DIFF
--- a/src/riak_repl_console.erl
+++ b/src/riak_repl_console.erl
@@ -960,6 +960,7 @@ proplists_get([Key | Path], Props, Default) when is_list(Props) ->
         undefined ->
             Default;
         too_busy ->
+            lager:debug("Something was too busy to give stats"),
             Default;
         AList when is_list(AList) ->
             proplists_get(Path, AList, Default);

--- a/src/riak_repl_console.erl
+++ b/src/riak_repl_console.erl
@@ -952,14 +952,20 @@ proplists_get([], undefined, Default) ->
     Default;
 proplists_get([], Value, _Default) ->
     Value;
+proplists_get([Key], Props, Default) when is_list(Props) ->
+    Value = proplists:get_value(Key, Props),
+    proplists_get([], Value, Default);
 proplists_get([Key | Path], Props, Default) when is_list(Props) ->
     case proplists:get_value(Key, Props) of
         undefined ->
             Default;
+        too_busy ->
+            Default;
         AList when is_list(AList) ->
             proplists_get(Path, AList, Default);
-        _Wut ->
-            erlang:error(badarg)
+        Wut ->
+            lager:warning("~p Not a list when getting stepwise key ~p: ~p", [Wut, [Key | Path], Props]),
+            Default
     end.
 
 get_first_kbsp(Str) ->


### PR DESCRIPTION
Status 'too_busy' returns default value. This means A warning is only
generated if a truely unexpected value is found.

This is a squash and minor change to the 1.3.3 patch.
