### PR TITLE
Do not calculate heartbeat RTT in riak_repl2_rtsource_conn if state#hb_sent is undefined

### DIFF
--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -317,7 +317,7 @@ recv(TcpBin, State = #state{remote = Name,
             case HBSent of
                 undefined ->
                     lager:debug("hb_sent undefined in heartbeat RTT calc"),
-                    {noreply, State};
+                    recv(Cont, State);
                 _ ->
                     HBRTT = timer:now_diff(now(), HBSent) div 1000,
                     erlang:cancel_timer(HBTRef),

--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -316,7 +316,7 @@ recv(TcpBin, State = #state{remote = Name,
             %% reschedule next
             case HBSent of
                 undefined ->
-                    lager:info("hb_sent undefined in heartbeat RTT calc"),
+                    lager:debug("hb_sent undefined in heartbeat RTT calc"),
                     {noreply, State};
                 _ ->
                     HBRTT = timer:now_diff(now(), HBSent) div 1000,


### PR DESCRIPTION
### Issue

https://github.com/basho/riak_repl/issues/368
### Discussion

As described in the issue, occasionally more than one (4) heartbeat message arrive at once. This means that between calls to recv, state#hb_sent is never set to a valid timestamp, as in send_heartbeat/2. The current RTT calculation assumes hb_sent is valid and sends the value into timer:now_diff, but in this case it is not.

This PR is a simple fix to this problem: do not calculate the RTT hb_sent is undefined. However, this will have the effect of possibly skewing the RTT calculations, at least in this case.

This fix does appear to stop the errors from happening, since 'undefined' leads to a badmatch of timer:now_diff and consequently a server crash and RT connection restart.
