### PR TITLE
Queue implementation for heartbeat tracking

### DIFF
--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -261,7 +261,7 @@ handle_info({tcp_error, _S, Reason},
 
 handle_info(send_heartbeat, State) ->
     {noreply, send_heartbeat(State)};
-handle_info({heartbeat_timeout}, State = #state{hb_sent_q = HBSentQ,
+handle_info(heartbeat_timeout, State = #state{hb_sent_q = HBSentQ,
                                                 remote = Remote}) ->
     case queue:out(HBSentQ) of 
         {TimeSent, HBSentQ2} ->
@@ -277,9 +277,7 @@ handle_info({heartbeat_timeout}, State = #state{hb_sent_q = HBSentQ,
             State2 = State#state{hb_sent_q = HBSentQ2},
             lager:debug("hb_sent_q empty when received heartbeat_timeout"),
             {stop, normal, State2}
-    end.
-
-%% handle_info({heartbeat_timeout, _HBSent}, State = #state{remote = Remote}) ->
+    end;
 handle_info({heartbeat_timeout, _HBSent}, State = #state{remote = Remote}) ->
     %% Timeout message was in the queue when we received the heartbeat
     %% already handled, ignore.

--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -61,9 +61,11 @@
                 proto,     % protocol version negotiated
                 helper_pid,% riak_repl2_rtsource_helper pid
                 hb_interval,% milliseconds to send new heartbeat after last
+                hb_interval_tref,
                 hb_timeout,% milliseconds to wait for heartbeat after send
                 hb_timeout_tref,% heartbeat timeout timer reference
-                hb_sent,   % now() last heartbeat was sent
+                hb_sent_q,   % queue of heartbeats now() that were sent
+                hb_sent_q_len = 0,
                 hb_rtt,    % RTT in milliseconds for last completed heartbeat
                 cont = <<>>}). % continuation from previous TCP buffer
 
@@ -217,7 +219,8 @@ handle_call({connected, Socket, Transport, EndPoint, Proto}, _From,
                     HBTimeout = app_helper:get_env(riak_repl, rt_hearbeat_timeout,
                                                    ?DEFAULT_HBTIMEOUT),
                     State3 = State2#state{hb_interval = HBInterval,
-                                          hb_timeout = HBTimeout},
+                                          hb_timeout = HBTimeout,
+                                          hb_sent_q = queue:new() },
                     {reply, ok, send_heartbeat(State3)}
             end;
         ER ->
@@ -255,15 +258,28 @@ handle_info({tcp_error, _S, Reason},
     lager:warning("Realtime connection ~s to ~p network error ~p - ~b bytes pending\n",
                   [peername(State), Remote, Reason, size(Cont)]),
     {stop, normal, State};
+
 handle_info(send_heartbeat, State) ->
     {noreply, send_heartbeat(State)};
-handle_info({heartbeat_timeout, HBSent}, State = #state{hb_sent = HBSent,
-                                                        remote = Remote}) ->
-    Duration = timer:now_diff(now(), HBSent) div 1000,
-    lager:warning("Realtime connection ~s to ~p heartbeat timeout "
+handle_info({heartbeat_timeout}, State = #state{hb_sent_q = HBSentQ,
+                                                remote = Remote}) ->
+    case queue:out(HBSentQ) of 
+        {TimeSent, HBSentQ2} ->
+            Duration = timer:now_diff(now(), TimeSent) div 1000,
+            lager:warning("Realtime connection ~s to ~p heartbeat timeout "
                   "after ~p milliseconds\n",
                   [peername(State), Remote, Duration]),
-    {stop, normal, State};
+            State2 = State#state{hb_sent_q = HBSentQ2, 
+            hb_sent_q_len = decr(State#state.hb_sent_q_len)},
+            lager:debug("hb_sent_q_len after heartbeat_timeout: ~s", [State2#state.hb_sent_q_len]),
+            {stop, normal, State2};
+        {empty, HBSentQ2} ->
+            State2 = State#state{hb_sent_q = HBSentQ2},
+            lager:debug("hb_sent_q empty when received heartbeat_timeout"),
+            {stop, normal, State2}
+    end.
+
+%% handle_info({heartbeat_timeout, _HBSent}, State = #state{remote = Remote}) ->
 handle_info({heartbeat_timeout, _HBSent}, State = #state{remote = Remote}) ->
     %% Timeout message was in the queue when we received the heartbeat
     %% already handled, ignore.
@@ -294,7 +310,7 @@ code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
 recv(TcpBin, State = #state{remote = Name,
-                            hb_sent = HBSent,
+                            hb_sent_q = HBSentQ,
                             hb_timeout_tref = HBTRef}) ->
     case riak_repl2_rtframe:decode(TcpBin) of
         {ok, undefined, Cont} ->
@@ -314,11 +330,15 @@ recv(TcpBin, State = #state{remote = Name,
         {ok, heartbeat, Cont} ->
             %% Compute last heartbeat roundtrip in msecs and
             %% reschedule next
+            {{value, HBSent}, HBSentQ2} = queue:out(HBSentQ),
+            lager:debug("hb_sent: ~w", [HBSent]),
             HBRTT = timer:now_diff(now(), HBSent) div 1000,
             erlang:cancel_timer(HBTRef),
-            State2 = State#state{hb_sent = undefined,
+            State2 = State#state{hb_sent_q = HBSentQ2,
                                  hb_timeout_tref = undefined,
+                                 hb_sent_q_len = decr(State#state.hb_sent_q_len),
                                  hb_rtt = HBRTT},
+            lager:debug("hb_sent_q_len after heartbeat_recv: ~p", [State2#state.hb_sent_q_len]),
             recv(Cont, schedule_heartbeat(State2));
         {error, Reason} ->
             %% Something bad happened
@@ -337,14 +357,29 @@ send_heartbeat(State = #state{hb_interval = undefined}) ->
 %% will catch any bug that causes the helper process to hang as
 %% well as connection issues - either way we want to re-establish.
 send_heartbeat(State = #state{hb_timeout = HBTimeout,
+                              hb_sent_q = SentQ,
                               helper_pid = HelperPid}) ->
     Now = now(), % using now as need a unique reference for this heartbeat
                  % to spot late heartbeat timeout messages
     riak_repl2_rtsource_helper:send_heartbeat(HelperPid),
     TRef = erlang:send_after(HBTimeout, self(), {heartbeat_timeout, Now}),
-    State#state{hb_sent = Now, hb_timeout_tref = TRef}.
+    State2 = State#state{hb_interval_tref = undefined, hb_timeout_tref = TRef, 
+                hb_sent_q_len = State#state.hb_sent_q_len + 1, hb_sent_q = queue:in(Now, SentQ)},
+    lager:debug("hb_sent_q_len after sending heartbeat: ~p", [State2#state.hb_sent_q_len]),
+    State2.
 
 %% Schedule the next heartbeat
-schedule_heartbeat(State = #state{hb_interval = HBInterval}) ->
-    erlang:send_after(HBInterval, self(), send_heartbeat),
+schedule_heartbeat(State = #state{hb_interval_tref = undefined, hb_interval = HBInterval}) ->
+    TRef = erlang:send_after(HBInterval, self(), send_heartbeat),
+    State#state{hb_interval_tref = TRef};
+ 
+schedule_heartbeat(State) ->
     State.
+
+%% for heartbeat queue len tracking
+decr(Val) when Val > 0 ->
+    Val - 1;
+decr(Val) when Val =< 0 ->
+    0.
+
+


### PR DESCRIPTION
#### Issue

Issue: https://github.com/basho/riak_repl/issues/368
#### Overview

Per discussions with Jon M and Andrew T, this solution is an alternative to simply not calculating RTT of heartbeats when multiple heartbeat messages arrive. Here, a queue of heartbeat sent messages is used to track the sent heartbeats (state#hb_sent_q), in case more than one is outstanding. The RTT calculation uses the first element in the queue.
