### PR TITLE
Catch errors on connect in the RT source connection

### DIFF
--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -105,7 +105,8 @@ connected(Socket, Transport, Endpoint, Proto, RtSourcePid, Props) ->
         _:Reason ->
             lager:warning("Unable to contact RT source connection process (~p). Killing it to force reconnect.",
                           [RtSourcePid]),
-            exit(RtSourcePid, {unable_to_contact, Reason})
+            exit(RtSourcePid, {unable_to_contact, Reason}),
+            ok
     end.
 
 connect_failed(_ClientProto, Reason, RtSourcePid) ->

--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -95,12 +95,18 @@ legacy_status(Pid, Timeout) ->
 
 %% connection manager callbacks
 connected(Socket, Transport, Endpoint, Proto, RtSourcePid, Props) ->
-    _RemoteClusterName = proplists:get_value(clustername, Props),
     Transport:controlling_process(Socket, RtSourcePid),
     Transport:setopts(Socket, [{active, true}]),
-    gen_server:call(RtSourcePid,
-                    {connected, Socket, Transport, Endpoint, Proto},
-                    ?LONG_TIMEOUT).
+    try
+        gen_server:call(RtSourcePid,
+                        {connected, Socket, Transport, Endpoint, Proto},
+                        ?LONG_TIMEOUT)
+    catch
+        _:Reason ->
+            lager:warning("Unable to contact RT source connection process (~p). Killing it to force reconnect.",
+                          [RtSourcePid]),
+            exit(RtSourcePid, {unable_to_contact, Reason})
+    end.
 
 connect_failed(_ClientProto, Reason, RtSourcePid) ->
     gen_server:cast(RtSourcePid, {connect_failed, self(), Reason}).


### PR DESCRIPTION
Presently, the RT Source conn can timeout on it's connected call from the connection manager.
This is bad since the connection manager won't retry the connection.

This change catches the failed gen_server:call and kills the RT source conn process. That allows the rt source conn supervisor to restart the connection, since the connection manager has washed it's hands of it by then.
