### PR TITLE
Backport of 'Fix typo in rt_heartbeat_ config vars' from 1.4 to 1.3.3

### DIFF
--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -25,7 +25,7 @@
 %%    as new ones can be established harmlessly.  Keep it simple.
 %%
 %% 3. If rtsource receives the heartbeat back, it cancels the timer
-%%    and updates the hearbeat round trip time (hb_rtt) then sets
+%%    and updates the heartbeat round trip time (hb_rtt) then sets
 %%    a new heartbeat_interval timer.
 %%
 %%    If the heartbeat_timeout fires, the rtsource connection terminates.
@@ -212,9 +212,9 @@ handle_call({connected, Socket, Transport, EndPoint, Proto}, _From,
                     {reply, ok, State2};
                 _ ->
                     %% 1.1 and above, start with a heartbeat
-                    HBInterval = app_helper:get_env(riak_repl, rt_hearbeat_interval,
+                    HBInterval = app_helper:get_env(riak_repl, rt_heartbeat_interval,
                                                     ?DEFAULT_HBINTERVAL),
-                    HBTimeout = app_helper:get_env(riak_repl, rt_hearbeat_timeout,
+                    HBTimeout = app_helper:get_env(riak_repl, rt_heartbeat_timeout,
                                                    ?DEFAULT_HBTIMEOUT),
                     State3 = State2#state{hb_interval = HBInterval,
                                           hb_timeout = HBTimeout},


### PR DESCRIPTION
Fixing some typos for heartbeat config variables.  

For issue #374.
