### PR TITLE
Queue implementation for heartbeat tracking

### DIFF
--- a/src/riak_repl2_rtsink_conn.erl
+++ b/src/riak_repl2_rtsink_conn.erl
@@ -19,6 +19,9 @@
          status/1, status/2,
          legacy_status/1, legacy_status/2]).
 
+%% Export for intercept use in testing
+-export([send_heartbeat/2]).
+
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
@@ -202,6 +205,9 @@ terminate(_Reason, _State) ->
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
+send_heartbeat(Transport, Socket) ->
+    Transport:send(Socket, riak_repl2_rtframe:encode(heartbeat, undefined)).
+
 %% Receive TCP data - decode framing and dispatch
 recv(TcpBin, State = #state{transport = T, socket = S}) ->
     case riak_repl2_rtframe:decode(TcpBin) of
@@ -216,7 +222,7 @@ recv(TcpBin, State = #state{transport = T, socket = S}) ->
         {ok, {objects, {Seq, BinObjs}}, Cont} ->
             recv(Cont, do_write_objects(Seq, BinObjs, State));
         {ok, heartbeat, Cont} ->
-            T:send(S, riak_repl2_rtframe:encode(heartbeat, undefined)),
+            send_heartbeat(T, S),
             recv(Cont, State#state{hb_last = os:timestamp()});
         {error, Reason} ->
             %% TODO: Log Something bad happened

--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -268,7 +268,7 @@ handle_info({tcp_error, _S, Reason},
 
 handle_info(send_heartbeat, State) ->
     {noreply, send_heartbeat(State)};
-handle_info({heartbeat_timeout}, State = #state{hb_sent_q = HBSentQ,
+handle_info(heartbeat_timeout, State = #state{hb_sent_q = HBSentQ,
                                                 remote = Remote}) ->
     case queue:out(HBSentQ) of 
         {TimeSent, HBSentQ2} ->
@@ -284,9 +284,7 @@ handle_info({heartbeat_timeout}, State = #state{hb_sent_q = HBSentQ,
             State2 = State#state{hb_sent_q = HBSentQ2},
             lager:debug("hb_sent_q empty when received heartbeat_timeout"),
             {stop, normal, State2}
-    end.
-
-%% handle_info({heartbeat_timeout, _HBSent}, State = #state{remote = Remote}) ->
+    end;
 handle_info({heartbeat_timeout, _HBSent}, State = #state{remote = Remote}) ->
     %% Timeout message was in the queue when we received the heartbeat
     %% already handled, ignore.

--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -61,9 +61,11 @@
                 proto,     % protocol version negotiated
                 helper_pid,% riak_repl2_rtsource_helper pid
                 hb_interval,% milliseconds to send new heartbeat after last
+                hb_interval_tref,
                 hb_timeout,% milliseconds to wait for heartbeat after send
                 hb_timeout_tref,% heartbeat timeout timer reference
-                hb_sent,   % now() last heartbeat was sent
+                hb_sent_q,   % queue of heartbeats now() that were sent
+                hb_sent_q_len = 0,
                 hb_rtt,    % RTT in milliseconds for last completed heartbeat
                 cont = <<>>}). % continuation from previous TCP buffer
 
@@ -224,7 +226,8 @@ handle_call({connected, Socket, Transport, EndPoint, Proto}, _From,
                     HBTimeout = app_helper:get_env(riak_repl, rt_heartbeat_timeout,
                                                    ?DEFAULT_HBTIMEOUT),
                     State3 = State2#state{hb_interval = HBInterval,
-                                          hb_timeout = HBTimeout},
+                                          hb_timeout = HBTimeout,
+                                          hb_sent_q = queue:new() },
                     {reply, ok, send_heartbeat(State3)}
             end;
         ER ->
@@ -262,15 +265,28 @@ handle_info({tcp_error, _S, Reason},
     lager:warning("Realtime connection ~s to ~p network error ~p - ~b bytes pending\n",
                   [peername(State), Remote, Reason, size(Cont)]),
     {stop, normal, State};
+
 handle_info(send_heartbeat, State) ->
     {noreply, send_heartbeat(State)};
-handle_info({heartbeat_timeout, HBSent}, State = #state{hb_sent = HBSent,
-                                                        remote = Remote}) ->
-    Duration = timer:now_diff(now(), HBSent) div 1000,
-    lager:warning("Realtime connection ~s to ~p heartbeat timeout "
+handle_info({heartbeat_timeout}, State = #state{hb_sent_q = HBSentQ,
+                                                remote = Remote}) ->
+    case queue:out(HBSentQ) of 
+        {TimeSent, HBSentQ2} ->
+            Duration = timer:now_diff(now(), TimeSent) div 1000,
+            lager:warning("Realtime connection ~s to ~p heartbeat timeout "
                   "after ~p milliseconds\n",
                   [peername(State), Remote, Duration]),
-    {stop, normal, State};
+            State2 = State#state{hb_sent_q = HBSentQ2, 
+            hb_sent_q_len = decr(State#state.hb_sent_q_len)},
+            lager:debug("hb_sent_q_len after heartbeat_timeout: ~s", [State2#state.hb_sent_q_len]),
+            {stop, normal, State2};
+        {empty, HBSentQ2} ->
+            State2 = State#state{hb_sent_q = HBSentQ2},
+            lager:debug("hb_sent_q empty when received heartbeat_timeout"),
+            {stop, normal, State2}
+    end.
+
+%% handle_info({heartbeat_timeout, _HBSent}, State = #state{remote = Remote}) ->
 handle_info({heartbeat_timeout, _HBSent}, State = #state{remote = Remote}) ->
     %% Timeout message was in the queue when we received the heartbeat
     %% already handled, ignore.
@@ -301,7 +317,7 @@ code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
 recv(TcpBin, State = #state{remote = Name,
-                            hb_sent = HBSent,
+                            hb_sent_q = HBSentQ,
                             hb_timeout_tref = HBTRef}) ->
     case riak_repl2_rtframe:decode(TcpBin) of
         {ok, undefined, Cont} ->
@@ -321,11 +337,15 @@ recv(TcpBin, State = #state{remote = Name,
         {ok, heartbeat, Cont} ->
             %% Compute last heartbeat roundtrip in msecs and
             %% reschedule next
+            {{value, HBSent}, HBSentQ2} = queue:out(HBSentQ),
+            lager:debug("hb_sent: ~w", [HBSent]),
             HBRTT = timer:now_diff(now(), HBSent) div 1000,
             erlang:cancel_timer(HBTRef),
-            State2 = State#state{hb_sent = undefined,
+            State2 = State#state{hb_sent_q = HBSentQ2,
                                  hb_timeout_tref = undefined,
+                                 hb_sent_q_len = decr(State#state.hb_sent_q_len),
                                  hb_rtt = HBRTT},
+            lager:debug("hb_sent_q_len after heartbeat_recv: ~p", [State2#state.hb_sent_q_len]),
             recv(Cont, schedule_heartbeat(State2));
         {error, Reason} ->
             %% Something bad happened
@@ -344,14 +364,29 @@ send_heartbeat(State = #state{hb_interval = undefined}) ->
 %% will catch any bug that causes the helper process to hang as
 %% well as connection issues - either way we want to re-establish.
 send_heartbeat(State = #state{hb_timeout = HBTimeout,
+                              hb_sent_q = SentQ,
                               helper_pid = HelperPid}) ->
     Now = now(), % using now as need a unique reference for this heartbeat
                  % to spot late heartbeat timeout messages
     riak_repl2_rtsource_helper:send_heartbeat(HelperPid),
     TRef = erlang:send_after(HBTimeout, self(), {heartbeat_timeout, Now}),
-    State#state{hb_sent = Now, hb_timeout_tref = TRef}.
+    State2 = State#state{hb_interval_tref = undefined, hb_timeout_tref = TRef, 
+                hb_sent_q_len = State#state.hb_sent_q_len + 1, hb_sent_q = queue:in(Now, SentQ)},
+    lager:debug("hb_sent_q_len after sending heartbeat: ~p", [State2#state.hb_sent_q_len]),
+    State2.
 
 %% Schedule the next heartbeat
-schedule_heartbeat(State = #state{hb_interval = HBInterval}) ->
-    erlang:send_after(HBInterval, self(), send_heartbeat),
+schedule_heartbeat(State = #state{hb_interval_tref = undefined, hb_interval = HBInterval}) ->
+    TRef = erlang:send_after(HBInterval, self(), send_heartbeat),
+    State#state{hb_interval_tref = TRef};
+ 
+schedule_heartbeat(State) ->
     State.
+
+%% for heartbeat queue len tracking
+decr(Val) when Val > 0 ->
+    Val - 1;
+decr(Val) when Val =< 0 ->
+    0.
+
+

--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -341,10 +341,8 @@ recv(TcpBin, State = #state{remote = Name,
             %% reset heartbeat timer, since we've seen activity from the peer
             case HBTRef of
                 undefined ->
-                    lager:debug("got ack"),
                     recv(Cont, State);
                 _ ->
-                    lager:debug("got ack, resetting HB timer"),
                     cancel_timer(HBTRef),
                     recv(Cont, schedule_heartbeat(State#state{hb_timeout_tref=undefined}))
             end;

--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -296,7 +296,7 @@ handle_info({heartbeat_timeout, HBSent}, State = #state{hb_sent_q = HBSentQ,
             lager:warning("Realtime connection ~s to ~p heartbeat timeout "
                           "after ~p milliseconds\n",
                           [peername(State), Remote, Duration]),
-            lager:debug("hb_sent_q_len after heartbeat_timeout: ~s", 
+            lager:debug("hb_sent_q_len after heartbeat_timeout: ~p", 
                         [queue:len(HBSentQ2)]),
             {stop, normal, State2}
     end;
@@ -323,9 +323,14 @@ terminate(_Reason, #state{helper_pid = HelperPid}) ->
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
+cancel_timer(undefined) -> ok;
+cancel_timer(TRef)      -> erlang:cancel_timer(TRef).
+
 recv(TcpBin, State = #state{remote = Name,
                             hb_sent_q = HBSentQ,
                             hb_timeout_tref = HBTRef}) ->
+    %% hb_timeout_tref might be undefined if we have are getting
+    %% acks/heartbeats back-to-back and we haven't sent a heartbeat yet.
     case riak_repl2_rtframe:decode(TcpBin) of
         {ok, undefined, Cont} ->
             {noreply, State#state{cont = Cont}};
@@ -336,22 +341,24 @@ recv(TcpBin, State = #state{remote = Name,
             %% reset heartbeat timer, since we've seen activity from the peer
             case HBTRef of
                 undefined ->
+                    lager:debug("got ack"),
                     recv(Cont, State);
                 _ ->
-                    erlang:cancel_timer(HBTRef),
-                    recv(Cont, schedule_heartbeat(State))
+                    lager:debug("got ack, resetting HB timer"),
+                    cancel_timer(HBTRef),
+                    recv(Cont, schedule_heartbeat(State#state{hb_timeout_tref=undefined}))
             end;
         {ok, heartbeat, Cont} ->
             %% Compute last heartbeat roundtrip in msecs and
-            %% reschedule next
+            %% reschedule next.
             {{value, HBSent}, HBSentQ2} = queue:out(HBSentQ),
-            lager:debug("hb_sent: ~w", [HBSent]),
+            lager:debug("got heartbeat, hb_sent: ~w", [HBSent]),
             HBRTT = timer:now_diff(now(), HBSent) div 1000,
-            erlang:cancel_timer(HBTRef),
+            cancel_timer(HBTRef),
             State2 = State#state{hb_sent_q = HBSentQ2,
                                  hb_timeout_tref = undefined,
                                  hb_rtt = HBRTT},
-            lager:debug("hb_sent_q_len after heartbeat_recv: ~p", [queue:len(HBSentQ2)]),
+            lager:debug("got heartbeat, hb_sent_q_len after heartbeat_recv: ~p", [queue:len(HBSentQ2)]),
             recv(Cont, schedule_heartbeat(State2));
         {error, Reason} ->
             %% Something bad happened

--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -65,7 +65,6 @@
                 hb_timeout,% milliseconds to wait for heartbeat after send
                 hb_timeout_tref,% heartbeat timeout timer reference
                 hb_sent_q,   % queue of heartbeats now() that were sent
-                hb_sent_q_len = 0,
                 hb_rtt,    % RTT in milliseconds for last completed heartbeat
                 cont = <<>>}). % continuation from previous TCP buffer
 
@@ -268,29 +267,39 @@ handle_info({tcp_error, _S, Reason},
 
 handle_info(send_heartbeat, State) ->
     {noreply, send_heartbeat(State)};
-handle_info(heartbeat_timeout, State = #state{hb_sent_q = HBSentQ,
-                                                remote = Remote}) ->
-    case queue:out(HBSentQ) of 
-        {TimeSent, HBSentQ2} ->
-            Duration = timer:now_diff(now(), TimeSent) div 1000,
+handle_info({heartbeat_timeout, HBSent}, State = #state{hb_sent_q = HBSentQ,
+                                                        hb_interval_tref = IntervalTRef,
+                                                        hb_timeout = HBTimeout,
+                                                        remote = Remote}) ->
+    %% Heartbeats are sent and received in order - this must match
+    %% or we have a logic error and should crash.
+    {{value, HBSent}, HBSentQ2} = queue:out(HBSentQ),
+    Duration = timer:now_diff(now(), HBSent) div 1000,
+
+    %% If an ack was is received in the heartbeat timeout window, the heartbeat
+    %% timeout timer is cancelled and we no longer want to exit.  It is possible
+    %% the timer has already fired while we have an ack or heartbeat response
+    %% in the message queue.  In which case, either
+    %%   heartbeat interval timer is pending - so tref NOT undefined
+    %%   heartbeat interval timer fired, new hb_sent entry added - so NOT qempty
+
+    State2 = State#state{hb_rtt = Duration, hb_sent_q = HBSentQ2},
+    case IntervalTRef /= undefined orelse
+         queue:len(HBSentQ2) /= 0 of
+        true ->
+            lager:info("Realtime connection ~s to ~p heartbeat rtt ~p "
+                       "milliseconds exceeded timeout ~p, "
+                       "but saved by incoming data\n",
+                       [peername(State), Remote, Duration, HBTimeout]),
+            {noreply, State2};
+        false ->
             lager:warning("Realtime connection ~s to ~p heartbeat timeout "
-                  "after ~p milliseconds\n",
-                  [peername(State), Remote, Duration]),
-            State2 = State#state{hb_sent_q = HBSentQ2, 
-            hb_sent_q_len = decr(State#state.hb_sent_q_len)},
-            lager:debug("hb_sent_q_len after heartbeat_timeout: ~s", [State2#state.hb_sent_q_len]),
-            {stop, normal, State2};
-        {empty, HBSentQ2} ->
-            State2 = State#state{hb_sent_q = HBSentQ2},
-            lager:debug("hb_sent_q empty when received heartbeat_timeout"),
+                          "after ~p milliseconds\n",
+                          [peername(State), Remote, Duration]),
+            lager:debug("hb_sent_q_len after heartbeat_timeout: ~s", 
+                        [queue:len(HBSentQ2)]),
             {stop, normal, State2}
     end;
-handle_info({heartbeat_timeout, _HBSent}, State = #state{remote = Remote}) ->
-    %% Timeout message was in the queue when we received the heartbeat
-    %% already handled, ignore.
-    lager:info("Realtime connection ~s to ~p received stale timeout\n",
-               [peername(State), Remote]),
-    {noreply, State};
 handle_info(Msg, State) ->
     lager:warning("Unhandled info:  ~p", [Msg]),
     {noreply, State}.
@@ -341,9 +350,8 @@ recv(TcpBin, State = #state{remote = Name,
             erlang:cancel_timer(HBTRef),
             State2 = State#state{hb_sent_q = HBSentQ2,
                                  hb_timeout_tref = undefined,
-                                 hb_sent_q_len = decr(State#state.hb_sent_q_len),
                                  hb_rtt = HBRTT},
-            lager:debug("hb_sent_q_len after heartbeat_recv: ~p", [State2#state.hb_sent_q_len]),
+            lager:debug("hb_sent_q_len after heartbeat_recv: ~p", [queue:len(HBSentQ2)]),
             recv(Cont, schedule_heartbeat(State2));
         {error, Reason} ->
             %% Something bad happened
@@ -368,9 +376,9 @@ send_heartbeat(State = #state{hb_timeout = HBTimeout,
                  % to spot late heartbeat timeout messages
     riak_repl2_rtsource_helper:send_heartbeat(HelperPid),
     TRef = erlang:send_after(HBTimeout, self(), {heartbeat_timeout, Now}),
-    State2 = State#state{hb_interval_tref = undefined, hb_timeout_tref = TRef, 
-                hb_sent_q_len = State#state.hb_sent_q_len + 1, hb_sent_q = queue:in(Now, SentQ)},
-    lager:debug("hb_sent_q_len after sending heartbeat: ~p", [State2#state.hb_sent_q_len]),
+    State2 = State#state{hb_interval_tref = undefined, hb_timeout_tref = TRef,
+                         hb_sent_q = queue:in(Now, SentQ)},
+    lager:debug("hb_sent_q_len after sending heartbeat: ~p", [queue:len(SentQ)+1]),
     State2.
 
 %% Schedule the next heartbeat
@@ -381,10 +389,5 @@ schedule_heartbeat(State = #state{hb_interval_tref = undefined, hb_interval = HB
 schedule_heartbeat(State) ->
     State.
 
-%% for heartbeat queue len tracking
-decr(Val) when Val > 0 ->
-    Val - 1;
-decr(Val) when Val =< 0 ->
-    0.
 
 


### PR DESCRIPTION
NOTE: this is a replacement for PR #370 

Issue

Issue: #368

Overview

Per discussions with Jon M and Andrew T, this solution is an alternative to simply not calculating RTT of heartbeats when multiple heartbeat messages arrive. Here, a queue of heartbeat sent messages is used to track the sent heartbeats (state#hb_sent_q), in case more than one is outstanding. The RTT calculation uses the first element in the queue.

Test: https://github.com/basho/riak_test/pull/352
