### PR TITLE
Drop bad data from the backend.

### DIFF
--- a/src/riak_repl_fullsync_helper.erl
+++ b/src/riak_repl_fullsync_helper.erl
@@ -481,36 +481,48 @@ missing_key(PBKey, DiffState) ->
 %%
 %% @see http://www.javalimit.com/2010/05/passing-funs-to-other-erlang-nodes.html
 merkle_fold(K, V, Pid) ->
-    riak_core_gen_server:cast(Pid, {merkle, K, hash_object(V)}),
+    try
+        riak_core_gen_server:cast(Pid, {merkle, K, hash_object(V)})
+    catch _:_ -> 
+            ok
+    end,
     Pid.
 
 %% @private
 %%
 %% @doc Visting function for building keylists. Similar to merkle_fold.
 keylist_fold(K, V, {MPid, Count, Total}) ->
-    H = hash_object(V),
-    Bin = term_to_binary({pack_key(K), H}),
-    %% write key/value hash to file
-    riak_core_gen_server:cast(MPid, {keylist, Bin}),
-    case Count of
-        100 ->
-            %% send keylist_ack to "self" every 100 key/value hashes
-            ok = riak_core_gen_server:call(MPid, keylist_ack, infinity),
-            {MPid, 0, Total+1};
-        _ ->
-            {MPid, Count+1, Total+1}
+    try
+        H = hash_object(V),
+        Bin = term_to_binary({pack_key(K), H}),
+        %% write key/value hash to file
+        riak_core_gen_server:cast(MPid, {keylist, Bin}),
+        case Count of
+            100 ->
+                %% send keylist_ack to "self" every 100 key/value hashes
+                ok = riak_core_gen_server:call(MPid, keylist_ack, infinity),
+                {MPid, 0, Total+1};
+            _ ->
+                {MPid, Count+1, Total+1}
+        end
+    catch _:_ ->
+            {MPid, Count, Total}
     end;
 %% legacy support for the 2-tuple accumulator in 1.2.0 and earlier
 keylist_fold(K, V, {MPid, Count}) ->
-    H = hash_object(V),
-    Bin = term_to_binary({pack_key(K), H}),
-    %% write key/value hash to file
-    riak_core_gen_server:cast(MPid, {keylist, Bin}),
-    case Count of
-        100 ->
-            %% send keylist_ack to "self" every 100 key/value hashes
-            ok = riak_core_gen_server:call(MPid, keylist_ack, infinity),
-            {MPid, 0};
-        _ ->
-            {MPid, Count+1}
+    try
+        H = hash_object(V),
+        Bin = term_to_binary({pack_key(K), H}),
+        %% write key/value hash to file
+        riak_core_gen_server:cast(MPid, {keylist, Bin}),
+        case Count of
+            100 ->
+                %% send keylist_ack to "self" every 100 key/value hashes
+                ok = riak_core_gen_server:call(MPid, keylist_ack, infinity),
+                {MPid, 0};
+            _ ->
+                {MPid, Count+1}
+        end
+    catch _:_ ->
+            {MPid, Count}
     end.

--- a/src/riak_repl_keylist_server.erl
+++ b/src/riak_repl_keylist_server.erl
@@ -600,8 +600,14 @@ bloom_fold({B, K}, V, {MPid, Bloom, Client, Transport, Socket, 0, WinSz} = Acc) 
 bloom_fold({B, K}, V, {MPid, Bloom, Client, Transport, Socket, NSent0, WinSz}) ->
     NSent = case ebloom:contains(Bloom, <<B/binary, K/binary>>) of
                 true ->
-                    RObj = binary_to_term(V),
-                    gen_fsm:sync_send_event(MPid, {diff_obj, RObj}, infinity),
+                    case binary_to_term(V) of 
+                        {'EXIT', _} -> 
+                            ok;
+                        RObj -> 
+                            gen_fsm:sync_send_event(MPid, 
+                                                    {diff_obj, RObj}, 
+                                                    infinity)
+                    end,
                     NSent0 - 1;
                 false ->
                     ok,

--- a/src/riak_repl_keylist_server.erl
+++ b/src/riak_repl_keylist_server.erl
@@ -600,7 +600,7 @@ bloom_fold({B, K}, V, {MPid, Bloom, Client, Transport, Socket, 0, WinSz} = Acc) 
 bloom_fold({B, K}, V, {MPid, Bloom, Client, Transport, Socket, NSent0, WinSz}) ->
     NSent = case ebloom:contains(Bloom, <<B/binary, K/binary>>) of
                 true ->
-                    case binary_to_term(V) of 
+                    case (catch binary_to_term(V)) of 
                         {'EXIT', _} -> 
                             ok;
                         RObj -> 


### PR DESCRIPTION
wherever we're handling data straight out of the backend, don't trust it and make sure all binary_to_term calls are done inside of try-catch statements, then attempt to noop or exit safely.
