### PR TITLE
Fix for heartbeat timeout bug discovered in riak_test repl_rt_heartbeat

### DIFF
--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -282,26 +282,20 @@ handle_info({Error, _S, Reason},
 handle_info(send_heartbeat, State) ->
     {noreply, send_heartbeat(State)};
 handle_info({heartbeat_timeout, HBSent}, State = #state{hb_sent_q = HBSentQ,
-                                                        hb_interval_tref = IntervalTRef,
+                                                        hb_timeout_tref = HBTRef,
                                                         hb_timeout = HBTimeout,
                                                         remote = Remote}) ->
     TimeSinceTimeout = timer:now_diff(now(), HBSent) div 1000,
 
-    %% If an ack was is received in the heartbeat timeout window, the heartbeat
-    %% timeout timer is cancelled and we no longer want to exit.  It is possible
-    %% the timer has already fired while we have an ack or heartbeat response
-    %% in the message queue.  In which case, either
-    %%   heartbeat interval timer is pending - so tref NOT undefined
-    %%   heartbeat interval timer fired, new hb_sent entry added - so NOT qempty
-
-    case IntervalTRef /= undefined orelse
-         queue:len(HBSentQ) /= 0 of
-        true ->
+    %% hb_timeout_tref is the authority of whether we should
+    %% restart the conection on heartbeat timeout or not.
+    case HBTRef of
+        undefined ->
             lager:info("Realtime connection ~s to ~p heartbeat "
-                       "  time since timeout ~p",
+                       "time since timeout ~p",
                        [peername(State), Remote, TimeSinceTimeout]),
             {noreply, State};
-        false ->
+        _ ->
             lager:warning("Realtime connection ~s to ~p heartbeat timeout "
                           "after ~p milliseconds\n",
                           [peername(State), Remote, HBTimeout]),
@@ -362,7 +356,7 @@ recv(TcpBin, State = #state{remote = Name,
                     recv(Cont, State);
                 _ ->
                     erlang:cancel_timer(HBTRef),
-                    recv(Cont, schedule_heartbeat(State))
+                    recv(Cont, schedule_heartbeat(State#state{hb_timeout_tref=undefined}))
             end;
         {ok, heartbeat, Cont} ->
             %% Compute last heartbeat roundtrip in msecs and


### PR DESCRIPTION
The test uses an intercept to drop heartbeat messages and then waits to ensure RT restart. This was discovered not to be working on 1.4 in advance of the ATT upgrade this evening.

The problem was the code was checking the queue for zero len, and not stopping if true.

Fix was to remove check of heartbeat queue, and make  #state.hb_timeout_tref in riak_repl2_rtsource_conn:handle_info/3 the authority of whether to stop, and restart the connection. 
