### PR TITLE
Move tcp-mon, connection and service manager supervisors from replication to core

### DIFF
--- a/src/riak_core_cluster_mgr_sup.erl
+++ b/src/riak_core_cluster_mgr_sup.erl
@@ -22,23 +22,11 @@ init([]) ->
                           fun riak_repl_app:cluster_mgr_write_cluster_members_to_ring/2,
                           fun riak_repl_app:cluster_mgr_read_cluster_targets_from_ring/0],
     Processes =
-        [%% TODO: move these to riak core
-         %% Service Manager (inbound connections)
-         {riak_core_service_mgr, {riak_core_service_mgr, start_link, []},
-          permanent, 5000, worker, [riak_core_service_mgr]},
-         %% Connection Manager Stats - don't start it from here. It gets registered
-         %% {riak_core_connection_mgr_stats, {riak_core_connection_mgr_stats, start_link, []},
-          %% permanent, 5000, worker, [riak_core_connection_mgr_stats]},
-         %% Connection Manager (outbound connections)
-         {riak_core_connection_mgr, {riak_core_connection_mgr, start_link, []},
-          permanent, 5000, worker, [riak_core_connection_mgr]},
-         %% Cluster Client Connection Supervisor
+        [%% Cluster Client Connection Supervisor
          {riak_core_cluster_conn_sup, {riak_core_cluster_conn_sup, start_link, []},
           permanent, infinity, supervisor, [riak_core_cluster_conn_sup]},
          %% Cluster Manager
          {riak_repl_cluster_mgr, {riak_core_cluster_mgr, start_link, ClusterMgrDefaults},
-          permanent, 5000, worker, [riak_core_cluster_mgr]},
-         {riak_core_tcp_mon, {riak_core_tcp_mon, start_link, []},
-          permanent, 5000, worker, [riak_core_tcp_mon]}
+          permanent, 5000, worker, [riak_core_cluster_mgr]}
         ],
     {ok, {{rest_for_one, 9, 10}, Processes}}.


### PR DESCRIPTION
In order for the connection and service manager to be fully moved to core, we need to move
their supervisors. Also, I've moved the tcp_mon supervisor because it's really a core thing too.

The matching PR fro core is here...
https://github.com/basho/riak_core/pull/383

Doesn't that code look cleaner now!

NOTE: Please do not merge after the +1 here. I need to press the merge buttons on both riak_repl and riak_core at nearly the same time :-) Thanks.
