### PR TITLE
Handle decommissioned clusterid for replicated CS manifests

### DIFF
--- a/src/riak_repl_console.erl
+++ b/src/riak_repl_console.erl
@@ -32,7 +32,11 @@
          cascades/1,
          show_nat_map/1,
          add_nat_map/1,
-         del_nat_map/1
+         del_nat_map/1,
+         add_block_provider_redirect/1,
+         show_block_provider_redirect/1,
+         show_local_cluster_id/1,
+         delete_block_provider_redirect/1
      ]).
 
 add_listener(Params) ->
@@ -569,7 +573,28 @@ del_nat_map([External, Internal]) ->
             ok
     end.
 
-%% helper functions
+add_block_provider_redirect([FromClusterId, ToClusterId]) ->
+    lager:info("Redirecting cluster id: ~p to ~p", [FromClusterId, ToClusterId]),
+    riak_core_metadata:put({<<"replication">>, <<"cluster-mapping">>}, 
+                           FromClusterId, ToClusterId).
+
+show_block_provider_redirect([FromClusterId]) ->
+    case riak_core_metadata:get({<<"replication">>, <<"cluster-mapping">>}, FromClusterId) of
+        undefined ->
+            io:format("No mapping for ~p~n", [FromClusterId]);
+        ToClusterId ->
+            io:format("Cluster id ~p redirecting to cluster id ~p~n", [FromClusterId, ToClusterId])
+    end.
+
+delete_block_provider_redirect([FromClusterId]) ->
+    lager:info("Deleting redirect to ~p", [FromClusterId]),
+    riak_core_metadata:delete({<<"replication">>, <<"cluster-mapping">>}, FromClusterId).
+
+show_local_cluster_id([]) ->
+    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+    ClusterId = lists:flatten(
+        io_lib:format("~p", [riak_core_ring:cluster_name(Ring)])),
+    io:format("local cluster id: ~p~n", [ClusterId]).
 
 parse_ip_and_maybe_port(String, Hostname) ->
     case string:tokens(String, ":") of

--- a/src/riak_repl_console.erl
+++ b/src/riak_repl_console.erl
@@ -573,6 +573,11 @@ del_nat_map([External, Internal]) ->
             ok
     end.
 
+% NB: the following commands are around the "Dead Cluster" redirect feature,
+%     306. They all operate using cluster_id (tuple), not clustername, for now, as 
+%     of this writing we had no reliable way to map a clustername to an id 
+%     over disterlang. When this API becomes available, this feature may use
+%     it. 
 add_block_provider_redirect([FromClusterId, ToClusterId]) ->
     lager:info("Redirecting cluster id: ~p to ~p", [FromClusterId, ToClusterId]),
     riak_core_metadata:put({<<"replication">>, <<"cluster-mapping">>}, 


### PR DESCRIPTION
#### Overview

Repl support for feature 306. Provide a redirection mechanism, via configuration, allowing proxy_get to be directed to an alternate cluster id from one that may be decommissioned or otherwise unreachable.

Initially, the configuration will be accomplished using "raw" cluster ids, instead of cluster names, since there is no existing, non dist-erlang API for getting a remote cluster name from a connected cluster. This will be addressed in follow-on versions.
#### Configuration

Four riak-repl sub-commands are added:
- show-local-cluster-id: displays the local cluster_id as a tuple, to be used in further configurations
- add-block-provider-redirect [from-cluster-id] [to-cluster-id]
- delete-block-provider-redirect [from-cluster-id]
- show-block-provider-redirect 
#### Issue

https://github.com/basho/riak_repl/issues/306
