### PR TITLE
Fixed realtime protocol version check

### DIFF
--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -344,7 +344,7 @@ recv(TcpBin, State = #state{remote = Name,
     case riak_repl2_rtframe:decode(TcpBin) of
         {ok, undefined, Cont} ->
             {noreply, State#state{cont = Cont}};
-        {ok, {ack, Seq}, Cont} when ProtoMajor == 2 ->
+        {ok, {ack, Seq}, Cont} when ProtoMajor >= 2 ->
             %% TODO: report this better per-remote
             riak_repl_stats:objects_sent(),
             ok = riak_repl2_rtq:ack(Name, Seq),

--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -340,10 +340,11 @@ recv(TcpBin, State = #state{remote = Name,
                             hb_timeout_tref = HBTRef}) ->
     %% hb_timeout_tref might be undefined if we have are getting
     %% acks/heartbeats back-to-back and we haven't sent a heartbeat yet.
+    {realtime, {ProtoMajor, _}, {ProtoMajor, _}} = State#state.proto,
     case riak_repl2_rtframe:decode(TcpBin) of
         {ok, undefined, Cont} ->
             {noreply, State#state{cont = Cont}};
-        {ok, {ack, Seq}, Cont} when State#state.proto == {2,0} ->
+        {ok, {ack, Seq}, Cont} when ProtoMajor == 2 ->
             %% TODO: report this better per-remote
             riak_repl_stats:objects_sent(),
             ok = riak_repl2_rtq:ack(Name, Seq),


### PR DESCRIPTION
The wrong check was causing the ack to be proxied through the helper.
The helper builds a map for acks from v1 to the actual v2 sequence
number. However, because this was a version 2 protocol, the map was
not needed, and thus not built. Without finding the v1 sequence number,
and ack is never sent to the rtq, leaving the object forever unacked.
