### PR TITLE
Fixed repl mutator registration

### DIFF
--- a/src/riak_repl_sup.erl
+++ b/src/riak_repl_sup.erl
@@ -17,7 +17,12 @@ start_link() ->
 %% @spec init([]) -> SupervisorTree
 %% @doc supervisor callback.
 init([]) ->
-    riak_kv_mutator:register(riak_repl_reduced, 5),
+    case riak_core_capability:get({riak_kv, mutators}, false) of
+        false ->
+            ok;
+        true ->
+            riak_kv_mutator:register(riak_repl_reduced, 5)
+    end,
     Processes = [
                  {riak_repl_client_sup, {riak_repl_client_sup, start_link, []},
                   permanent, infinity, supervisor, [riak_repl_client_sup]},


### PR DESCRIPTION
Registers only if {riak_kv, mutators} capability is true (it
defaults to false).

There is not test because building and starting a cluster _is_ the test (ergo, any riak_test tests this code path). The old version of the code crashed develop on startup due to undef'ed function. This will also ensure shrunk objects can be consistently unshrunk across the cluster.
