### PR TITLE
Check repl hook result before concatenating

### DIFF
--- a/src/riak_repl2_rt.erl
+++ b/src/riak_repl2_rt.erl
@@ -136,11 +136,12 @@ get_sink_pids() ->
 
 %% Realtime replication post-commit hook
 postcommit(RObj) ->
-    case riak_repl_util:repl_helper_send_realtime(RObj, riak_client:new(node(), undefined))++[RObj] of
+    case riak_repl_util:repl_helper_send_realtime(RObj, riak_client:new(node(), undefined)) of
         %% always put the objects onto the shared queue in the new format; we'll
         %% down-convert if we have to before sending them to the RT sinks (based
         %% on what the RT source and sink negotiated as the common version).
-        Objects when is_list(Objects) ->
+        Objects0 when is_list(Objects0) ->
+            Objects = Objects0 ++ [RObj],
             BinObjs = riak_repl_util:to_wire(w1, Objects),
             %% try the proxy first, avoids race conditions with unregister()
             %% during shutdown


### PR DESCRIPTION
if the repl hook returns `cancel`, ++ fails. Move the concatenation beneath the guard.

```
2013-10-02 17:35:15.034 UTC [debug] <0.10480.44>@riak_kv_put_fsm:decode_postcommit:831 Problem invoking post-commit hook riak_repl2_rt:postcommit -> error:badarg
[{erlang,'++',[cancel,[{r_object,<<48,98,58,194,228,235,74,15,121,81,110,248,43,193,29,0,93,22,204>>,<<191,45,92,146,191,140,75,128,132,133,108,216,170,188,28,110,0,0,3,1>>,[{r_content,{dict,4,16,16,8,80,48,{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},{{[],[],[],[],[],[],[],[],[],[],[[<<"X-Riak-VTag">>,50,66,55,119,84,105,67,113,110,118,111,85,119,66,99,121,104,54,49,107,53,53]],[[<<"index">>]],[],[[<<"X-Riak-Last-Modified">>|{1380,735314,955510}]],[],[[<<"X-Riak-Meta">>,{<<"RCS-bucket">>,<<"mhealth-splunk">>},{<<"RCS-key">>,<<"defaultdb/db_1376636657_1373385661_41.tar.bz2">>},{<<"RCS-bcsum">>,<<114,139,157,63,123,118,26,38,96,233,11,142,190,10,141,179>>}]]}}},<<202,198,199,82,169,84,131,214,114,55,212,141,199,226,186,222,87,86,167,168,235,170,165,117,55,27,93,228,84,211,134,92,25,156,217,142,95,28,98,246,125,103,142,111,8,70,142,197,242,17,201,74,104,192,138,233,245,157,187,41,244,15,82,151,63,235,174,251,229,99,42,196,246,158,215,83,242,169,202,239,173,72,140,93,21,106,157,71,87,174,93,103,204,51,120,136,44,152,44,21,53,236,7,19,94,178,23,53,26,13,3,254,231,7,187,245,96,105,125,62,111,173,143,139,204,251,252,30,127,43,148,199,
```
