### PR TITLE
Fix for RTQ EQC prop_main()

### DIFF
--- a/test/riak_repl2_rtq_eqc.erl
+++ b/test/riak_repl2_rtq_eqc.erl
@@ -375,7 +375,7 @@ pull(Name, Q) ->
                 {Ref, ok} ->
                     ok
             after
-                5 ->
+                100 ->
                     lager:info("No pull ack from ~p~n", [Name]),
                     error 
             end
@@ -389,7 +389,7 @@ pull(Name, Q) ->
         {Ref, _Wut} ->
             none
     after
-        20 ->
+        100 ->
             lager:info("queue empty: ~p~n", [Name]),
             none
     end.


### PR DESCRIPTION
#### Details

During statem test execution, riak_repl2_rtq_eqc reads from the queue using its pull/2 function. This function defines an anonymous DeliverFun to be called by the RTQ, which uses erlang messaging to send a pulled object back to the client (test) process. Messaging was found to be occasionally timing out. This cased the RTQ, when seeing the DeliverFun to fail, not to mark the pulled object as completed, and thus, when the test client was re-registered, the same object would be delivered. The test model would then identify this duplicate and error out.

This fix only appears to fix the prop_main (sequential) test, so this PR only addresses that fix. Fixes for the parallel and pulse tests defined in the EQC test will be addressed in other PRs.
