### PR TITLE
Fix for RTQ EQC prop_main and prop_parallel

### DIFF
--- a/test/riak_repl2_rtq_eqc.erl
+++ b/test/riak_repl2_rtq_eqc.erl
@@ -375,7 +375,7 @@ pull(Name, Q) ->
                 {Ref, ok} ->
                     ok
             after
-                5 ->
+                100 ->
                     lager:info("No pull ack from ~p~n", [Name]),
                     error 
             end
@@ -389,7 +389,7 @@ pull(Name, Q) ->
         {Ref, _Wut} ->
             none
     after
-        20 ->
+        100 ->
             lager:info("queue empty: ~p~n", [Name]),
             none
     end.

--- a/test/riak_repl2_rtq_eqc.erl
+++ b/test/riak_repl2_rtq_eqc.erl
@@ -389,7 +389,7 @@ pull(Name, Q) ->
         {Ref, _Wut} ->
             none
     after
-        100 ->
+        500 ->
             lager:info("queue empty: ~p~n", [Name]),
             none
     end.


### PR DESCRIPTION
During statem test execution, riak_repl2_rtq_eqc reads from the RTQ queue using its pull/2 function. This function defines an anonymous DeliverFun to be called by the RTQ, which uses erlang messaging to send a pulled object back to the client (test) process. Messaging was found to be occasionally timing out. This cased the RTQ, when seeing the DeliverFun to fail, not to mark the pulled object as completed, and thus, when the test client was re-registered, the same object would be delivered. The test model would then identify this duplicate and error out.

A similar problem was affecting the prop_parallel test, except that the timeouts were occurring in the test, not in the DeliverFun ack clause. This was causing the test to believe that the queue was empty (return -> none).

Bumping this up to 500 ms appears to fix the problem on a late model MPB, and not slow down the test considerably. We may want to test this on various platforms and find a better value, but this fixes it for dev for now.
