### PR TITLE
Backport fix for Issue 384: Repl stats errors to 1.4

### DIFF
--- a/src/riak_repl_wm_stats.erl
+++ b/src/riak_repl_wm_stats.erl
@@ -32,7 +32,6 @@
          pretty_print/2,
          jsonify_stats/2
         ]).
-
 -include_lib("webmachine/include/webmachine.hrl").
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -263,7 +262,7 @@ jsonify_stats_test_() ->
                           {last_fullsync_started, StrDate}
                         ]}]}],
              Got = jsonify_stats(Input, []),
-             ?debugFmt("Expected: ~p~nGot: ~p", [Expected, Got]),
+             %?debugFmt("Expected: ~p~nGot: ~p", [Expected, Got]),
              ?assertEqual(Expected, Got),
              _Result = mochijson2:encode({struct, Got}) % fail if crash
       end},


### PR DESCRIPTION
Added handling for the case where the sink socket has gone {active, {false, scheduled}} (likely in the event of too many messages) and a timer has been started to reactive it, leading to:

[error] <0.3958.789> webmachine error: path="/riak-repl/stats"
{error,{exit,{json_encode,{bad_term,{false,scheduled}}},[{mochijson2,json_encode,2,[{file,"src/mochijson2.erl"},{line,149}]},{mochijson2,'-json_encode_proplist/2-fun-0-',3,[{file,"src/mochijson2.erl"},{line,167}]},{lists,foldl,3,[{file,"lists.erl"},{line,1197}]},{mochijson2,json_encode_proplist,2,[{file,"src/mochijson2.erl"},{line,170}]},{mochijson2,'-json_encode_proplist/2-fun-0-',3,[{file,"src/mochijson2.erl"},{line,167}]},{lists,foldl,3,[{file,"lists.erl"},{line,1197}]},{mochijson2,json_encode_proplist,2,[{file,"src/mochijson2.erl"},{line,170}]},{mochijson2,'-json_encode_proplist/2-fun-0-',3,[{file,"src/mochijson2.erl"},{line,167}]}]}}

Also, added a catch all so that bad names would not lead to a crash.

Updated the eunit tests for both.
#### Issue

https://github.com/basho/riak_repl/issues/384
#### Relate PR

This PR also contains the commits for this PR:

https://github.com/basho/riak_repl/pull/404
