### PR TITLE
Handle race by treating cluster as disconnected.

### DIFF
--- a/src/riak_repl_pb_get.erl
+++ b/src/riak_repl_pb_get.erl
@@ -170,7 +170,17 @@ proxy_get_13(State, CName, CNames, B, K, GetOptions) ->
                 true ->
                     Leader = riak_core_cluster_mgr:get_leader(),
                     ProxyForCluster = riak_repl_util:make_pg_proxy_name(ClusterName),
-                    gen_server:call({ProxyForCluster, Leader}, {proxy_get, B, K, GetOptions}, ?LONG_TIMEOUT);
+                    try gen_server:call({ProxyForCluster, Leader},
+                                        {proxy_get, B, K, GetOptions},
+                                        ?LONG_TIMEOUT) of
+                        Result ->
+                            Result
+                    catch
+                        _:Error ->
+                            lager:debug("proxy_get_13 failed: ~p",
+                                        [Error]),
+                            notconnected
+                    end;
                 false ->
                     notconnected
             end


### PR DESCRIPTION
Prevent a hard crash when the cluster has been connected, but the
gen_server has not been registered because we're still in the process of
reconfiguring after a topology change in riak_repl2_pg_block_requester.
