### PR TITLE
add rebar.config dep for ebloom

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,6 +4,8 @@
 {erl_opts, [debug_info, fail_on_warning, {parse_transform, lager_transform}]}.
 {erl_first_files, ["src/gen_leader.erl"]}.
 {deps, [
+        {lager, "2.0.0", {git, "git://github.com/basho/lager.git", {tag, "2.0.0"}}},
+        {ebloom, ".*", {git, "git://github.com/basho/ebloom.git", {branch, "develop"}}},
         {riak_search, ".*", {git, "git://github.com/basho/riak_search.git", {branch, "develop"}}},
         {riak_repl_pb_api, ".*", {git, "git@github.com:basho/riak_repl_pb_api.git", {branch, "develop"}}}
        ]}.

--- a/src/riak_repl.app.src
+++ b/src/riak_repl.app.src
@@ -9,6 +9,7 @@
                   sasl,
                   crypto,
                   ssl,
+                  ebloom,
                   riak_core,
                   riak_kv,
                   ranch]},


### PR DESCRIPTION
This repo depends on ebloom and used to pick it up indirectly from its
riak_kv dependency, but the riak_kv dependency on ebloom was recently
removed in commit 8bd8cde. Add an explicit dependency on ebloom here.
