### PR TITLE
Ensure re-election connects clusters.

### DIFF
--- a/src/riak_core_cluster_mgr.erl
+++ b/src/riak_core_cluster_mgr.erl
@@ -706,6 +706,9 @@ become_leader(State, LeaderNode) when State#state.is_leader == false ->
     State#state{is_leader = true};
 become_leader(State, LeaderNode) ->
     lager:debug("ClusterManager: ~p still the leader", [LeaderNode]),
+    %% if the ring transitioned, triggering an election, if re-elected
+    %% ensure we have connections to remote clusters still.
+    erlang:send_after(5000, self(), connect_to_clusters),
     State.
 
 %% stop being a cluster manager leader


### PR DESCRIPTION
In the event that a node is added to a cluster, when it's already the
leader in a singleton cluster, if it happens to be re-elected ensure
that we have all of the necessary connections to remote clusters that
might be necessary.

Needs testing, we need to identify how to reproduce.
