### PR TITLE
Make the rt sink connection socket mode configurable

### DIFF
--- a/ebin/riak_repl.app
+++ b/ebin/riak_repl.app
@@ -3,7 +3,7 @@
  riak_repl,
  [{description,  "Enterprise replication for Riak"},
   {id,           "riak_repl"},
-  {vsn,          "1.4.2"},
+  {vsn,          "1.4.3"},
   {modules,      ['bounded_queue',
                   'couch_btree',
                   'couch_file',

--- a/rebar.config
+++ b/rebar.config
@@ -5,8 +5,8 @@
 {erl_first_files, ["src/gen_leader.erl"]}.
 {lib_dirs, [".."]}.
 {deps, [
-        {riak_core, ".*", {git, "git://github.com/basho/riak_core", {tag, "1.4.2"}}},
-        {riak_kv, ".*", {git, "git://github.com/basho/riak_kv", {tag, "1.4.2"}}},
+        {riak_core, ".*", {git, "git://github.com/basho/riak_core", {tag, "1.4.3"}}},
+        {riak_kv, ".*", {git, "git://github.com/basho/riak_kv", {tag, "1.4.2p1"}}},
         {riak_search, ".*", {git, "git://github.com/basho/riak_search",
                                  {tag, "1.4.2"}}},
         {meck, ".*", {git, "git://github.com/eproxus/meck.git", {branch, "master"}}},

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -487,7 +487,7 @@ handle_socket_msg({location, Partition, {Node, Ip, Port}}, #state{whereis_waitin
             start_up_reqs(State3)
     end;
 handle_socket_msg({location_busy, Partition}, #state{whereis_waiting = Waiting} = State) ->
-    lager:info("anya location_busy, partition = ~p", [Partition]),
+    lager:debug("anya location_busy, partition = ~p", [Partition]),
     case proplists:get_value(Partition, Waiting) of
         undefined ->
             State;

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -486,6 +486,24 @@ handle_socket_msg({location, Partition, {Node, Ip, Port}}, #state{whereis_waitin
             State3 = start_fssource(Partition2, Ip, Port, State2),
             start_up_reqs(State3)
     end;
+handle_socket_msg({location_busy, Partition}, #state{whereis_waiting = Waiting} = State) ->
+    lager:info("anya location_busy, partition = ~p", [Partition]),
+    case proplists:get_value(Partition, Waiting) of
+        undefined ->
+            State;
+        {N, OldNode, Tref} ->
+            lager:info("anya Partition ~p is too busy on cluster ~p at node ~p",
+                       [Partition, State#state.other_cluster, OldNode]),
+            erlang:cancel_timer(Tref),
+            Waiting2 = proplists:delete(Partition, Waiting),
+            State2 = State#state{whereis_waiting = Waiting2},
+            Partition2 = {Partition, N, OldNode},
+            PQueue = State2#state.partition_queue,
+            PQueue2 = queue:in(Partition2, PQueue),
+            NewBusies = sets:add_element(OldNode, State#state.busy_nodes),
+            State3 = State2#state{partition_queue = PQueue2, busy_nodes = NewBusies},
+            start_up_reqs(State3)
+    end;
 handle_socket_msg({location_busy, Partition, Node}, #state{whereis_waiting = Waiting} = State) ->
     case proplists:get_value(Partition, Waiting) of
         undefined ->
@@ -503,6 +521,19 @@ handle_socket_msg({location_busy, Partition, Node}, #state{whereis_waiting = Wai
             NewBusies = sets:add_element(Node, State#state.busy_nodes),
             State3 = State2#state{partition_queue = PQueue2, busy_nodes = NewBusies},
             start_up_reqs(State3)
+    end;
+handle_socket_msg({location_down, Partition}, #state{whereis_waiting=Waiting} = State) ->
+    lager:warning("anya location_down, partition = ~p", [Partition]),
+    case proplists:get_value(Partition, Waiting) of
+        undefined ->
+            State;
+        {_N, _OldNode, Tref} ->
+            lager:info("Partition ~p is unavailable on cluster ~p",
+                [Partition, State#state.other_cluster]),
+            erlang:cancel_timer(Tref),
+            Waiting2 = proplists:delete(Partition, Waiting),
+            State2 = State#state{whereis_waiting = Waiting2},
+            start_up_reqs(State2)
     end;
 handle_socket_msg({location_down, Partition, _Node}, #state{whereis_waiting=Waiting} = State) ->
     case proplists:get_value(Partition, Waiting) of

--- a/src/riak_repl2_fscoordinator_serv.erl
+++ b/src/riak_repl2_fscoordinator_serv.erl
@@ -101,7 +101,7 @@ init({Socket, Transport, OkProto, _Props}) ->
     Max = app_helper:get_env(riak_repl, max_fssink_node, ?DEFAULT_MAX_SINKS_NODE),
     {ok, Proto} = OkProto,
     lager:info("Starting fullsync coordinator server (sink) with
-               max_fssink_node=~p and proto=~p", [Max, Proto]),
+               max_fssink_node=~p", [Max]),
     SocketTag = riak_repl_util:generate_socket_tag("fs_coord_srv", Transport, Socket),
     lager:debug("Keeping stats for " ++ SocketTag),
     riak_core_tcp_mon:monitor(Socket, {?TCP_MON_FULLSYNC_APP, coordsrv,

--- a/src/riak_repl2_rtsink_conn.erl
+++ b/src/riak_repl2_rtsink_conn.erl
@@ -33,6 +33,7 @@
                 ver,              %% wire format agreed with rt source
                 max_pending,      %% Maximum number of operations
                 active = true,    %% If socket is set active
+                socket_mode = {active, once}, %% Configurable, default is {active, once}
                 deactivated = 0,  %% Count of times deactivated
                 source_drops = 0, %% Count of upstream drops
                 helper,           %% Helper PID
@@ -96,8 +97,10 @@ init([OkProto, Remote]) ->
     {ok, Helper} = riak_repl2_rtsink_helper:start_link(self()),
     riak_repl2_rt:register_sink(self()),
     MaxPending = app_helper:get_env(riak_repl, rtsink_max_pending, 100),
+    SocketMode = app_helper:get_env(riak_repl, sink_socket_mode, {active, once}),
+    lager:info("Sink socket mode set to:~p", [SocketMode]),
     {ok, #state{remote = Remote, proto = Proto, max_pending = MaxPending,
-                helper = Helper, ver = Ver}}.
+                 socket_mode = SocketMode, helper = Helper, ver = Ver}}.
 
 handle_call(status, _From, State = #state{remote = Remote,
                                           transport = T, socket = _S, helper = Helper,
@@ -137,8 +140,8 @@ handle_call(legacy_status, _From, State = #state{remote = Remote,
               {socket, riak_core_tcp_mon:format_socket_stats(SocketStats,[])}
              ],
     {reply, {status, Status}, State};
-handle_call({set_socket, Socket, Transport}, _From, State) ->
-    Transport:setopts(Socket, [{active, once}]), % pick up errors in tcp_error msg
+handle_call({set_socket, Socket, Transport}, _From, State = #state{socket_mode = SocketMode}) ->
+    Transport:setopts(Socket, [SocketMode]), % pick up errors in tcp_error msg
     lager:debug("Starting realtime connection service"),
     {reply, ok, State#state{socket=Socket, transport=Transport}};
 handle_call(stop, _From, State) ->
@@ -188,7 +191,7 @@ handle_info({Error, _S, Reason}, State= #state{cont = Cont}) when
                   [peername(State), Reason, size(Cont)]),
     {stop, normal, State};
 handle_info(reactivate_socket, State = #state{remote = Remote, transport = T, socket = S,
-                                              max_pending = MaxPending}) ->
+                                              max_pending = MaxPending,  socket_mode = SocketMode}) ->
     case pending(State) > MaxPending of
         true ->
             {noreply, schedule_reactivate_socket(State#state{active = false})};
@@ -198,7 +201,7 @@ handle_info(reactivate_socket, State = #state{remote = Remote, transport = T, so
             %% Check the socket is ok
             case T:peername(S) of
                 {ok, _} ->
-                    T:setopts(S, [{active, once}]), % socket could die, pick it up on tcp_error msgs
+                    T:setopts(S, [SocketMode]), % socket could die, pick it up on tcp_error msgs
                     {noreply, State#state{active = true}};
                 {error, Reason} ->
                     riak_repl_stats:rt_sink_errors(),
@@ -219,14 +222,20 @@ send_heartbeat(Transport, Socket) ->
     Transport:send(Socket, riak_repl2_rtframe:encode(heartbeat, undefined)).
 
 %% Receive TCP data - decode framing and dispatch
-recv(TcpBin, State = #state{transport = T, socket = S}) ->
+recv(TcpBin, State = #state{transport = T, socket = S, socket_mode=SocketMode}) ->
     case riak_repl2_rtframe:decode(TcpBin) of
         {ok, undefined, Cont} ->
-            case State#state.active of
-                true ->
-                    T:setopts(S, [{active, once}]);
-                _ ->
-                    ok
+            case SocketMode of
+                {active, once} ->
+                    case State#state.active of
+                        true ->
+                            lager:info("Resetting socket to ~p", [SocketMode]),
+                            T:setopts(S, [SocketMode]);
+                        _ ->
+                            ok
+                    end;
+                 _ ->
+                    ok  
             end,
             {noreply, State#state{cont = Cont}};
         {ok, {objects, {Seq, BinObjs}}, Cont} ->

--- a/src/riak_repl_app.erl
+++ b/src/riak_repl_app.erl
@@ -199,8 +199,9 @@ maybe_retry_ip_rpc(Results, Nodes, BadNodes, Args) ->
     Zipped = lists:zip(Results, Nodes2),
     MaybeRetry = fun
         ({{badrpc, {'EXIT', {undef, _StrackTrace}}}, Node}) ->
-            lager:debug("XXX Got a badrpc"),
-            rpc:call(Node, riak_repl_app, get_matching_address, Args);
+            RPCResult = rpc:call(Node, riak_repl_app, get_matching_address, Args),
+            lager:debug("rpc to get_matching_address: ~p", [RPCResult]),
+            RPCResult;
         ({Result, _Node}) ->
             Result
     end,

--- a/src/riak_repl_console.erl
+++ b/src/riak_repl_console.erl
@@ -332,7 +332,7 @@ connect([Address]) ->
             PortStr = string:sub_word(Address, 2, $:),
             connect([IP, PortStr]);
         _ ->
-            io:format("Error: remote connection is missing port. Expected 'connect <host:ip>'~n"),
+            io:format("Error: remote connection is missing port. Expected 'connect <host:port>'~n"),
             {error, {badarg, Address}}
     end;
 connect([IP, PortStr]) ->

--- a/src/riak_repl_pb_get.erl
+++ b/src/riak_repl_pb_get.erl
@@ -170,7 +170,17 @@ proxy_get_13(State, CName, CNames, B, K, GetOptions) ->
                 true ->
                     Leader = riak_core_cluster_mgr:get_leader(),
                     ProxyForCluster = riak_repl_util:make_pg_proxy_name(ClusterName),
-                    gen_server:call({ProxyForCluster, Leader}, {proxy_get, B, K, GetOptions}, ?LONG_TIMEOUT);
+                    try gen_server:call({ProxyForCluster, Leader},
+                                        {proxy_get, B, K, GetOptions},
+                                        ?LONG_TIMEOUT) of
+                        Result ->
+                            Result
+                    catch
+                        _:Error ->
+                            lager:debug("proxy_get_13 failed: ~p",
+                                        [Error]),
+                            notconnected
+                    end;
                 false ->
                     notconnected
             end

--- a/src/riak_repl_wm_stats.erl
+++ b/src/riak_repl_wm_stats.erl
@@ -32,7 +32,6 @@
          pretty_print/2,
          jsonify_stats/2
         ]).
-
 -include_lib("webmachine/include/webmachine.hrl").
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -263,7 +262,7 @@ jsonify_stats_test_() ->
                           {last_fullsync_started, StrDate}
                         ]}]}],
              Got = jsonify_stats(Input, []),
-             ?debugFmt("Expected: ~p~nGot: ~p", [Expected, Got]),
+             %?debugFmt("Expected: ~p~nGot: ~p", [Expected, Got]),
              ?assertEqual(Expected, Got),
              _Result = mochijson2:encode({struct, Got}) % fail if crash
       end},


### PR DESCRIPTION
The realtime sink socket mode is configurable using the following in app.config:

{riak_repl, sink_socket_mode, {active, {<mode>}}

Where valid values for <mode> are:

{active, true}
{active, once}

NB: though {active, false} is a valid setting socket setting, the real time sink module does not support this.

The semantics of these settings are outlined here:

http://www.erlang.org/doc/man/inet.html#setopts-2

Specifically:

"If the value is true, which is the default, everything received from the socket will be sent as messages to the receiving process. 

If the value is once ({active, once}), one data message from the socket will be sent to the process. To receive one more message, setopts/2 must be called again with the {active, once} option."
