### PR TITLE
added user event messages

### DIFF
--- a/include/riak_repl.hrl
+++ b/include/riak_repl.hrl
@@ -31,6 +31,7 @@
 -define(CONSOLE_RPC_TIMEOUT, 5000).
 -define(RETRY_AAE_LOCKED_INTERVAL, 1000).
 -define(DEFAULT_FULLSYNC_STRATEGY, keylist). %% keylist | aae
+-define(LOG_USER_CMD(Msg, Params), lager:notice("[user] " ++ Msg, Params)).
 
 -type(ip_addr_str() :: string()).
 -type(ip_portnum() :: non_neg_integer()).

--- a/src/riak_repl_console.erl
+++ b/src/riak_repl_console.erl
@@ -260,6 +260,7 @@ clustername([]) ->
     io:format("~s~n", [MyName]),
     ok;
 clustername([ClusterName]) ->
+    ?LOG_USER_CMD("Set clustername to ~p", [ClusterName]),
     riak_core_ring_manager:ring_trans(fun riak_core_connection:set_symbolic_clustername/2,
                                       ClusterName),
     ok.
@@ -325,6 +326,7 @@ connections([]) ->
     ok.
 
 connect([Address]) ->
+    ?LOG_USER_CMD("Connect to cluster at ~p", [Address]),
     NWords = string:words(Address, $:),
     case NWords of
         2 ->
@@ -336,6 +338,7 @@ connect([Address]) ->
             {error, {badarg, Address}}
     end;
 connect([IP, PortStr]) ->
+    ?LOG_USER_CMD("Connect to cluster at ~p:~p", [IP, PortStr]),
     {Port,_Rest} = string:to_integer(PortStr),
     case riak_core_connection:symbolic_clustername() of
         "undefined" ->
@@ -352,6 +355,7 @@ connect([IP, PortStr]) ->
 %% | ip:port
 %% | ip port
 disconnect([Address]) ->
+    ?LOG_USER_CMD("Disconnect from cluster at ~p", [Address]),
     NWords = string:words(Address, $:),
     case NWords of
         1 ->
@@ -373,6 +377,7 @@ disconnect([Address]) ->
             {error, {badarg, Address}}
     end;
 disconnect([IP, PortStr]) ->
+    ?LOG_USER_CMD("Disconnect from cluster at ~p:~p", [IP, PortStr]),
     {Port,_Rest} = string:to_integer(PortStr),
     riak_core_cluster_mgr:remove_remote_cluster({IP, Port}),
     ok.
@@ -380,12 +385,16 @@ disconnect([IP, PortStr]) ->
 realtime([Cmd, Remote]) ->
     case Cmd of
         "enable" ->
+            ?LOG_USER_CMD("Enable Realtime Replication to cluster ~p", [Remote]),
             riak_repl2_rt:enable(Remote);
         "disable" ->
+            ?LOG_USER_CMD("Disable Realtime Replication to cluster ~p", [Remote]),
             riak_repl2_rt:disable(Remote);
         "start" ->
+            ?LOG_USER_CMD("Start Realtime Replication to cluster ~p", [Remote]),
             riak_repl2_rt:start(Remote);
         "stop" ->
+            ?LOG_USER_CMD("Stop Realtime Replication to cluster ~p", [Remote]),
             riak_repl2_rt:stop(Remote);
         % easier to put this clause here and update 1 file
         % than update riak_core's riak-repl bin script and make yet anothor
@@ -398,26 +407,33 @@ realtime([Cmd]) ->
     Remotes = riak_repl2_rt:enabled(),
     case Cmd of
         "start" ->
+            ?LOG_USER_CMD("Start Realtime Replication to all connected clusters", []),
             [riak_repl2_rt:start(Remote) || Remote <- Remotes];
         "stop" ->
+            ?LOG_USER_CMD("Stop Realtime Replication to all connected clusters",
+                      []),
             [riak_repl2_rt:stop(Remote) || Remote <- Remotes]
     end,
     ok. %% TODO: we could gather the return codes of the list comprehensions
+        %% TODO: we could gather the return codes of the list comprehensions
 
 fullsync([Cmd, Remote]) ->
     Leader = riak_core_cluster_mgr:get_leader(),
     case Cmd of
         "enable" ->
+            ?LOG_USER_CMD("Enable Fullsync Replication to cluster ~p", [Remote]),
             riak_core_ring_manager:ring_trans(fun
                     riak_repl_ring:fs_enable_trans/2, Remote),
             riak_repl2_fscoordinator_sup:start_coord(Leader, Remote),
             ok;
         "disable" ->
+            ?LOG_USER_CMD("Disable Fullsync Replication to cluster ~p", [Remote]),
             riak_core_ring_manager:ring_trans(fun
                     riak_repl_ring:fs_disable_trans/2, Remote),
             riak_repl2_fscoordinator_sup:stop_coord(Leader, Remote),
             ok;
         "start" ->
+            ?LOG_USER_CMD("Start Fullsync Replication to cluster ~p", [Remote]),
             Fullsyncs = riak_repl2_fscoordinator_sup:started(Leader),
             case proplists:get_value(Remote, Fullsyncs) of
                 undefined ->
@@ -429,6 +445,7 @@ fullsync([Cmd, Remote]) ->
                     ok
             end;
         "stop" ->
+            ?LOG_USER_CMD("Stop Fullsync Replication to cluster ~p", [Remote]),
             Fullsyncs = riak_repl2_fscoordinator_sup:started(Leader),
             case proplists:get_value(Remote, Fullsyncs) of
                 undefined ->
@@ -444,9 +461,11 @@ fullsync([Cmd]) ->
     Fullsyncs = riak_repl2_fscoordinator_sup:started(Leader),
     case Cmd of
         "start" ->
+            ?LOG_USER_CMD("Start Fullsync Replication to all connected clusters",[]),
             [riak_repl2_fscoordinator:start_fullsync(Pid) || {_, Pid} <-
                 Fullsyncs];
         "stop" ->
+            ?LOG_USER_CMD("Stop Fullsync Replication to all connected clusters",[]),
             [riak_repl2_fscoordinator:stop_fullsync(Pid) || {_, Pid} <-
                 Fullsyncs]
     end,
@@ -455,10 +474,12 @@ fullsync([Cmd]) ->
 proxy_get([Cmd, Remote]) ->
     case Cmd of
         "enable" ->
+            ?LOG_USER_CMD("Enable Riak CS Proxy GET block provider for ~p",[Remote]),
             riak_core_ring_manager:ring_trans(fun
                     riak_repl_ring:pg_enable_trans/2, Remote),
             ok;
         "disable" ->
+            ?LOG_USER_CMD("Disable Riak CS Proxy GET block provider for ~p",[Remote]),
             riak_core_ring_manager:ring_trans(fun
                     riak_repl_ring:pg_disable_trans/2, Remote),
             ok
@@ -469,14 +490,17 @@ modes([]) ->
     io:format("Current replication modes: ~p~n",[CurrentModes]),
     ok;
 modes(NewModes) ->
+    ?LOG_USER_CMD("Set replication mode(s) to ~p",[NewModes]),
     Modes = [ list_to_atom(Mode) || Mode <- NewModes],
     set_modes(Modes),
     modes([]).
 
 realtime_cascades(["always"]) ->
+    ?LOG_USER_CMD("Enable Realtime Replication cascading", []),
     riak_core_ring_manager:ring_trans(fun
         riak_repl_ring:rt_cascades_trans/2, always);
 realtime_cascades(["never"]) ->
+    ?LOG_USER_CMD("Disable Realtime Replication cascading", []),
     riak_core_ring_manager:ring_trans(fun
         riak_repl_ring:rt_cascades_trans/2, never);
 realtime_cascades([]) ->
@@ -501,9 +525,11 @@ max_fssource_node([]) ->
 max_fssource_node([FSSourceNode]) ->
     NewVal = erlang:list_to_integer(FSSourceNode),
     riak_core_util:rpc_every_member(?MODULE, max_fssource_node, [NewVal], ?CONSOLE_RPC_TIMEOUT),
+    ?LOG_USER_CMD("Set max number of Fullsync workers per Source node to ~p",[NewVal]),
     max_fssource_node([]),
     ok;
 max_fssource_node(NewVal) ->
+    ?LOG_USER_CMD("Locally set max number of Fullsync workers to ~p",[NewVal]),
     application:set_env(riak_repl, max_fssource_node, NewVal).
 
 max_fssource_cluster([]) ->
@@ -514,9 +540,11 @@ max_fssource_cluster([]) ->
 max_fssource_cluster([FSSourceCluster]) ->
     NewVal = erlang:list_to_integer(FSSourceCluster),
     riak_core_util:rpc_every_member(?MODULE, max_fssource_cluster, [NewVal], ?CONSOLE_RPC_TIMEOUT),
+    ?LOG_USER_CMD("Set max number of Fullsync workers for Source cluster to ~p",[NewVal]),
     max_fssource_cluster([]),
     ok;
 max_fssource_cluster(NewVal) ->
+    ?LOG_USER_CMD("Locally set max number of Fullsync workersfor Source cluster to ~p",[NewVal]),
     application:set_env(riak_repl, max_fssource_cluster, NewVal).
 
 max_fssink_node([]) ->
@@ -525,9 +553,11 @@ max_fssink_node([]) ->
 max_fssink_node([FSSinkNode]) ->
     NewVal = erlang:list_to_integer(FSSinkNode),
     riak_core_util:rpc_every_member(?MODULE, max_fssink_node, [NewVal], ?CONSOLE_RPC_TIMEOUT),
+    ?LOG_USER_CMD("Set max number of Fullsync works per Sink node to ~p",[NewVal]),
     max_fssink_node([]),
     ok;
 max_fssink_node(NewVal) ->
+    ?LOG_USER_CMD("Locally set max number of Fullsync workers per Sink node to ~p",[NewVal]),
     application:set_env(riak_repl, max_fssink_node, NewVal).
 
 show_nat_map([]) ->
@@ -547,6 +577,7 @@ add_nat_map([External, Internal]) ->
             io:format("Bad internal IP ~p", [Reason]),
             error;
         {ExternalIP, InternalIP} ->
+            ?LOG_USER_CMD("Add a NAT map from External IP ~p to Internal IP ~p", [ExternalIP, InternalIP]),
             riak_core_ring_manager:ring_trans(
                 fun riak_repl_ring:add_nat_map/2,
                 {ExternalIP, InternalIP}),
@@ -563,6 +594,7 @@ del_nat_map([External, Internal]) ->
             io:format("Bad internal IP ~p", [Reason]),
             error;
         {ExternalIP, InternalIP} ->
+            ?LOG_USER_CMD("Delete a NAT map from External IP ~p to Internal IP ~p", [ExternalIP, InternalIP]),
             riak_core_ring_manager:ring_trans(
                 fun riak_repl_ring:del_nat_map/2,
                 {ExternalIP, InternalIP}),


### PR DESCRIPTION
See John C's Riak Event Logging gist
https://gist.github.com/jcapricebasho/4b98b1afc6204ce9df52

sample output:

```
131:2013-12-02 15:05:18.306 [notice] <0.653.0>@riak_repl_console:clustername:263 [user] Set clustername to "foo"
149:2013-12-02 15:06:03.644 [notice] <0.2736.0>@riak_repl_console:connect:329 [user] Connect to cluster at "127.0.0.1:10046"
150:2013-12-02 15:06:03.644 [notice] <0.2736.0>@riak_repl_console:connect:341 [user] Connect to cluster at "127.0.0.1":"10046"
157:2013-12-02 15:06:10.091 [notice] <0.2849.0>@riak_repl_console:realtime:388 [user] Enable Realtime Replication to cluster "bar"
158:2013-12-02 15:06:13.631 [notice] <0.2900.0>@riak_repl_console:realtime:394 [user] Start Realtime Replication to cluster "bar"
162:2013-12-02 15:06:19.313 [notice] <0.2988.0>@riak_repl_console:fullsync:424 [user] Enable Fullsync Replication to cluster "bar"
650:2013-12-02 15:06:22.519 [notice] <0.3162.0>@riak_repl_console:fullsync:436 [user] Start Fullsync Replication to cluster "bar"
748:2013-12-02 15:06:25.634 [notice] <0.3269.0>@riak_repl_console:fullsync:448 [user] Stop Fullsync Replication to cluster "bar"
749:2013-12-02 15:06:31.505 [notice] <0.3351.0>@riak_repl_console:realtime:397 [user] Stop Realtime Replication to cluster "bar"
751:2013-12-02 15:06:34.631 [notice] <0.3392.0>@riak_repl_console:realtime:391 [user] Disable Realtime Replication to cluster "bar"
752:2013-12-02 15:06:41.102 [notice] <0.3496.0>@riak_repl_console:fullsync:430 [user] Disable Fullsync Replication to cluster "bar"
754:2013-12-02 15:06:51.352 [notice] <0.3645.0>@riak_repl_console:modes:493 [user] Set replication mode(s) to ["mode_repl13"]
755:2013-12-02 15:07:24.887 [notice] <0.4129.0>@riak_repl_console:add_nat_map:580 [user] Add a NAT map from External IP {8,8,7,7} to Internal IP {127,0,0,1}
756:2013-12-02 15:07:29.759 [notice] <0.4198.0>@riak_repl_console:del_nat_map:597 [user] Delete a NAT map from External IP {8,8,7,7} to Internal IP {127,0,0,1}
757:2013-12-02 15:07:55.650 [notice] <0.4577.0>@riak_repl_console:realtime_cascades:499 [user] Enable Realtime Replication cascading
758:2013-12-02 15:07:58.309 [notice] <0.4609.0>@riak_repl_console:realtime_cascades:503 [user] Disable Realtime Replication cascading
759:2013-12-02 15:08:27.640 [notice] <0.5033.0>@riak_repl_console:proxy_get:477 [user] Enable Riak CS Proxy GET block provider for "bar"
762:2013-12-02 15:08:31.688 [notice] <0.5100.0>@riak_repl_console:proxy_get:482 [user] Disable Riak CS Proxy GET block provider for "bar"
```
