### PR TITLE
Ensure we re-connect to leader.

### DIFF
--- a/src/riak_repl2_fscoordinator_serv.erl
+++ b/src/riak_repl2_fscoordinator_serv.erl
@@ -25,7 +25,7 @@
 %% service manager callback Function Exports
 %% ------------------------------------------------------------------
 
--export([register_service/0, start_service/5]).
+-export([sync_register_service/0, start_service/5]).
 
 %% ------------------------------------------------------------------
 %% gen_server Function Exports
@@ -78,12 +78,12 @@ status(Pid, Timeout) ->
 %% service manager Function Definitions
 %% ------------------------------------------------------------------
 
-register_service() ->
+sync_register_service() ->
     ProtoPrefs = {fs_coordinate, [{1,0}]},
     TcpOptions = [{keepalive, true}, {packet, 4}, {active, false}, 
         {nodelay, true}],
     HostSpec = {ProtoPrefs, {TcpOptions, ?MODULE, start_service, undefined}},
-    riak_core_service_mgr:register_service(HostSpec, {round_robin, undefined}).
+    riak_core_service_mgr:sync_register_service(HostSpec, {round_robin, undefined}).
 
 start_service(Socket, Transport, Proto, _Args, Props) ->
     {ok, Pid} = riak_repl2_fscoordinator_serv_sup:start_child(Socket,

--- a/src/riak_repl2_fssink.erl
+++ b/src/riak_repl2_fssink.erl
@@ -35,7 +35,7 @@
 
 -behaviour(gen_server).
 %% API
--export([start_link/4, register_service/0, start_service/5, legacy_status/2, fullsync_complete/1]).
+-export([start_link/4, sync_register_service/0, start_service/5, legacy_status/2, fullsync_complete/1]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -60,7 +60,7 @@ fullsync_complete(Pid) ->
     gen_server:cast(Pid, fullsync_complete).
 
 %% Register with service manager
-register_service() ->
+sync_register_service() ->
     %% 1,0 and up supports keylist strategy
     %% 1,1 and up supports binary object
     %% 2,0 and up supports AAE strategy
@@ -70,7 +70,7 @@ register_service() ->
                   {active, false},
                   {nodelay, true}],
     HostSpec     = {ProtoPrefs, {TcpOptions, ?MODULE, start_service, undefined}},
-    riak_core_service_mgr:register_service(HostSpec, {round_robin, undefined}).
+    riak_core_service_mgr:sync_register_service(HostSpec, {round_robin, undefined}).
 
 %% Callback from service manager
 start_service(Socket, Transport, Proto, _Args, Props) ->

--- a/src/riak_repl2_pg_block_provider.erl
+++ b/src/riak_repl2_pg_block_provider.erl
@@ -147,7 +147,7 @@ handle_msg(get_cluster_info, State=#state{transport=Transport, socket=Socket}) -
 handle_msg({proxy_get, Ref, Bucket, Key, Options},
             State=#state{transport=Transport, socket=Socket,
                          proxy_gets_provided=PGCount}) ->
-    lager:debug("Got proxy_get for ~p:~p", [Bucket, Key]),
+    lager:info("Got proxy_get for ~p:~p", [Bucket, Key]),
     C = State#state.client,
     Res = C:get(Bucket, Key, Options),
     Data = term_to_binary({proxy_get_resp, Ref, Res}),

--- a/src/riak_repl2_rtq_proxy.erl
+++ b/src/riak_repl2_rtq_proxy.erl
@@ -21,7 +21,7 @@
 
 -record(state, {nodes=[],          %% peer replication nodes
                 versions=[],     %% {node(), wire-version()}
-                meta_support=[] :: [{node(), bool()}]
+                meta_support=[] :: [{node(), boolean()}]
                 }).
 
 %%%===================================================================

--- a/src/riak_repl2_rtsink_conn.erl
+++ b/src/riak_repl2_rtsink_conn.erl
@@ -12,7 +12,7 @@
 %% API
 -include("riak_repl.hrl").
 
--export([register_service/0, start_service/5]).
+-export([sync_register_service/0, start_service/5]).
 -export([start_link/2,
          stop/1,
          set_socket/3,
@@ -45,13 +45,13 @@
                }).
 
 %% Register with service manager
-register_service() ->
+sync_register_service() ->
     ProtoPrefs = {realtime,[{2,0}, {1,4}, {1,1}, {1,0}]},
     TcpOptions = [{keepalive, true}, % find out if connection is dead, this end doesn't send
                   {packet, 0},
                   {nodelay, true}],
     HostSpec = {ProtoPrefs, {TcpOptions, ?MODULE, start_service, undefined}},
-    riak_core_service_mgr:register_service(HostSpec, {round_robin, undefined}).
+    riak_core_service_mgr:sync_register_service(HostSpec, {round_robin, undefined}).
 
 %% Callback from service manager
 start_service(Socket, Transport, Proto, _Args, Props) ->

--- a/test/riak_core_cluster_mgr_tests.erl
+++ b/test/riak_core_cluster_mgr_tests.erl
@@ -468,7 +468,7 @@ start_fake_remote_cluster_service() ->
     %% which the cluster manager will use during testing to connect to us.
     ServiceProto = {test_cluster_mgr, [{1,0}]},
     ServiceSpec = {ServiceProto, {?CTRL_OPTIONS, ?MODULE, ctrlService, []}},
-    riak_core_service_mgr:register_service(ServiceSpec, {round_robin,10}).
+    riak_core_service_mgr:sync_register_service(ServiceSpec, {round_robin,10}).
 
 become_leader() ->
     riak_core_cluster_mgr:set_leader(node(), self()).

--- a/test/riak_repl2_rt_source_sink_tests.erl
+++ b/test/riak_repl2_rt_source_sink_tests.erl
@@ -209,7 +209,7 @@ start_sink(Version) ->
     TellMe = self(),
     catch(meck:unload(riak_core_service_mgr)),
     meck:new(riak_core_service_mgr, [passthrough]),
-    meck:expect(riak_core_service_mgr, register_service, fun(HostSpec, _Strategy) ->
+    meck:expect(riak_core_service_mgr, sync_register_service, fun(HostSpec, _Strategy) ->
         {_Proto, {TcpOpts, _Module, _StartCB, _CBArg}} = HostSpec,
         {ok, Listen} = gen_tcp:listen(?SINK_PORT, [binary, {reuseaddr, true} | TcpOpts]),
         TellMe ! sink_listening,
@@ -229,7 +229,7 @@ start_sink(Version) ->
     end.
 
 listen_sink() ->
-    riak_repl2_rtsink_conn:register_service().
+    riak_repl2_rtsink_conn:sync_register_service().
 
 start_source() ->
     start_source(?VER1).

--- a/test/rt_sink_eqc.erl
+++ b/test/rt_sink_eqc.erl
@@ -145,7 +145,7 @@ setup() ->
     riak_repl_test_util:abstract_gen_tcp(),
     bug_rt(),
     start_service_manager(),
-    riak_repl2_rtsink_conn:register_service(),
+    riak_repl2_rtsink_conn:sync_register_service(),
     abstract_fake_source(),
     start_fake_rtq().
 

--- a/test/rt_source_eqc.erl
+++ b/test/rt_source_eqc.erl
@@ -598,12 +598,12 @@ start_tcp_mon() ->
 start_fake_sink() ->
     riak_repl_test_util:reset_meck(riak_core_service_mgr, [no_link, passthrough]),
     WhoToTell = self(),
-    meck:expect(riak_core_service_mgr, register_service, fun(HostSpec, _Strategy) ->
+    meck:expect(riak_core_service_mgr, sync_register_service, fun(HostSpec, _Strategy) ->
         riak_repl_test_util:kill_and_wait(fake_sink),
         {_Proto, {TcpOpts, _Module, _StartCB, _CBArgs}} = HostSpec,
         sink_listener(TcpOpts, WhoToTell)
     end),
-    riak_repl2_rtsink_conn:register_service().
+    riak_repl2_rtsink_conn:sync_register_service().
 
 sink_listener(TcpOpts, WhoToTell) ->
     TcpOpts2 = [binary, {reuseaddr, true} | TcpOpts],


### PR DESCRIPTION
Prevent connections to non-leader nodes, when the sink leader changes,
because that's where all proxy_get requests were originating.  This
prevents a non-leader node from being the primary connection for the
proxy_get requests.
