### PR TITLE
Resolve race condition when joining a node.

### DIFF
--- a/src/riak_repl_ring_handler.erl
+++ b/src/riak_repl_ring_handler.erl
@@ -45,6 +45,14 @@ handle_event({ring_update, NewRing}, State=#state{ring=OldRing}) ->
         _ ->
             ok
     end,
+    %% Force the cluster manager to connect to the clusters when it
+    %% learns about an event *after* an election has occurred.
+    case riak_repl2_leader:is_leader() of
+        true ->
+            riak_core_cluster_mgr:connect_to_clusters();
+        _ ->
+            ok
+    end,
     {ok, State#state{ring=FinalRing}};
 handle_event(_Event, State) ->
     {ok, State}.


### PR DESCRIPTION
Port ring handler fix to the 2.0 branch.

In the event that a joining node happens to trigger an election, which
completes prior to ring convergence, it will never receive the repl
configuration on the source side in time to perform outbound connections
to the sink cluster.

Manually trigger the connection handler code when a ring event occurs,
and the current node is the leader.

This fix, unfortunately, ties riak_repl2_leader to cluster manager,
which is probably undesirable moving forward, but provides a compatible
patch for the upcoming 1.4.4 release.

This is a patch for the 1.4 branch, but should also be ported forward to
2.0.
