### PR TITLE
Prevent potential race condition.

### DIFF
--- a/src/riak_core_cluster_mgr.erl
+++ b/src/riak_core_cluster_mgr.erl
@@ -206,7 +206,7 @@ init(Defaults) ->
         false ->
             ServiceProto = {?CLUSTER_PROTO_ID, [{1,0}]},
             ServiceSpec = {ServiceProto, {?CTRL_OPTIONS, ?MODULE, ctrlService, []}},
-            riak_core_service_mgr:register_service(ServiceSpec, {round_robin,?MAX_CONS});
+            riak_core_service_mgr:sync_register_service(ServiceSpec, {round_robin,?MAX_CONS});
         true ->
             ok
     end,

--- a/src/riak_repl2_fscoordinator_serv.erl
+++ b/src/riak_repl2_fscoordinator_serv.erl
@@ -25,7 +25,7 @@
 %% service manager callback Function Exports
 %% ------------------------------------------------------------------
 
--export([register_service/0, start_service/5]).
+-export([sync_register_service/0, start_service/5]).
 
 %% ------------------------------------------------------------------
 %% gen_server Function Exports
@@ -78,12 +78,12 @@ status(Pid, Timeout) ->
 %% service manager Function Definitions
 %% ------------------------------------------------------------------
 
-register_service() ->
+sync_register_service() ->
     ProtoPrefs = {fs_coordinate, [{1,0}]},
     TcpOptions = [{keepalive, true}, {packet, 4}, {active, false}, 
         {nodelay, true}],
     HostSpec = {ProtoPrefs, {TcpOptions, ?MODULE, start_service, undefined}},
-    riak_core_service_mgr:register_service(HostSpec, {round_robin, undefined}).
+    riak_core_service_mgr:sync_register_service(HostSpec, {round_robin, undefined}).
 
 start_service(Socket, Transport, Proto, _Args, Props) ->
     {ok, Pid} = riak_repl2_fscoordinator_serv_sup:start_child(Socket,

--- a/src/riak_repl2_fssink.erl
+++ b/src/riak_repl2_fssink.erl
@@ -35,7 +35,7 @@
 
 -behaviour(gen_server).
 %% API
--export([start_link/4, register_service/0, start_service/5, legacy_status/2, fullsync_complete/1]).
+-export([start_link/4, sync_register_service/0, start_service/5, legacy_status/2, fullsync_complete/1]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -59,8 +59,8 @@ fullsync_complete(Pid) ->
     %% cast to avoid deadlock in terminate
     gen_server:cast(Pid, fullsync_complete).
 
-%% Register with service manager
-register_service() ->
+%% @doc Register with service manager
+sync_register_service() ->
     %% 1,0 and up supports keylist strategy
     %% 1,1 and up supports binary object
     %% 2,0 and up supports AAE strategy
@@ -70,7 +70,7 @@ register_service() ->
                   {active, false},
                   {nodelay, true}],
     HostSpec     = {ProtoPrefs, {TcpOptions, ?MODULE, start_service, undefined}},
-    riak_core_service_mgr:register_service(HostSpec, {round_robin, undefined}).
+    riak_core_service_mgr:sync_register_service(HostSpec, {round_robin, undefined}).
 
 %% Callback from service manager
 start_service(Socket, Transport, Proto, _Args, Props) ->

--- a/src/riak_repl2_pg_block_requester.erl
+++ b/src/riak_repl2_pg_block_requester.erl
@@ -10,7 +10,7 @@
 
 -behaviour(gen_server).
 %% API
--export([start_link/4, register_service/0, start_service/5, status/1, status/2,
+-export([start_link/4, sync_register_service/0, start_service/5, status/1, status/2,
          proxy_get/4]).
 
 %% gen_server callbacks
@@ -31,8 +31,8 @@
 start_link(Socket, Transport, Proto, Props) ->
     gen_server:start_link(?MODULE, [Socket, Transport, Proto, Props], []).
 
-%% Register with service manager
-register_service() ->
+%% @doc Register with service manager
+sync_register_service() ->
     lager:debug("Registering proxy_get requester service"),
     ProtoPrefs = {proxy_get,[{1,0}]},
     TcpOptions = [{keepalive, true}, % find out if connection is dead, this end doesn't send
@@ -40,7 +40,7 @@ register_service() ->
                   {active, false},
                   {nodelay, true}],
     HostSpec = {ProtoPrefs, {TcpOptions, ?MODULE, start_service, undefined}},
-    riak_core_service_mgr:register_service(HostSpec, {round_robin, undefined}).
+    riak_core_service_mgr:sync_register_service(HostSpec, {round_robin, undefined}).
 
 %% Callback from service manager
 start_service(Socket, Transport, Proto, _Args, Props) ->

--- a/src/riak_repl2_rtsink_conn.erl
+++ b/src/riak_repl2_rtsink_conn.erl
@@ -16,7 +16,9 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
--export([register_service/0, start_service/5]).
+-export([sync_register_service/0,
+         start_service/5]).
+
 -export([start_link/2,
          stop/1,
          set_socket/3,
@@ -52,14 +54,14 @@
                 cont = <<>>       %% Continuation from previous TCP buffer
                }).
 
-%% Register with service manager
-register_service() ->
+%% @doc Register with service manager
+sync_register_service() ->
     ProtoPrefs = {realtime,[{2,0}, {1,4}, {1,1}, {1,0}]},
     TcpOptions = [{keepalive, true}, % find out if connection is dead, this end doesn't send
                   {packet, 0},
                   {nodelay, true}],
     HostSpec = {ProtoPrefs, {TcpOptions, ?MODULE, start_service, undefined}},
-    riak_core_service_mgr:register_service(HostSpec, {round_robin, undefined}).
+    riak_core_service_mgr:sync_register_service(HostSpec, {round_robin, undefined}).
 
 %% Callback from service manager
 start_service(Socket, Transport, Proto, _Args, Props) ->


### PR DESCRIPTION
Prevent a potential race condition where services may or may not be
registered by the service manager because of the ordering of
registration, and the nature of cast'ing the registration messages.

Conflicts:
    src/riak_repl2_rtsink_conn.erl
    src/riak_repl_app.erl

@metadave 
