### PR TITLE
Add riak_core_connection and tests.

### DIFF
--- a/ebin/riak_repl.app
+++ b/ebin/riak_repl.app
@@ -77,6 +77,7 @@
                   'riak_repl2_pg_sup',
                   'riak_repl2_pg_proxy',
                   'riak_repl2_pg_proxy_sup',
+                  'riak_core_connection',
                   'riak_core_connection_mgr',
                   'riak_core_connection_mgr_stats',
                   'riak_core_service_mgr']},

--- a/include/riak_core_connection.hrl
+++ b/include/riak_core_connection.hrl
@@ -1,0 +1,100 @@
+%% -------------------------------------------------------------------
+%%
+%% Riak Core Connection Manager
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% handshake messages to safely initiate a connection. Let's not accept
+%% a connection to a telnet session by accident!
+-define(CTRL_REV, {1,0}).
+-define(CTRL_HELLO, <<"riak-ctrl:hello">>).
+-define(CTRL_TELL_IP_ADDR, <<"riak-ctrl:ip_addr">>).
+-define(CTRL_ACK, <<"riak-ctrl:ack">>).
+-define(CTRL_ASK_NAME, <<"riak-ctrl:ask_name">>).
+-define(CTRL_ASK_MEMBERS, <<"riak-ctrl:ask_members">>).
+
+
+-define(CONNECTION_SETUP_TIMEOUT, 10000).
+
+
+
+-define(CTRL_OPTIONS, [binary,
+                       {keepalive, true},
+                       {nodelay, true},
+                       {packet, 4},
+                       {reuseaddr, true},
+                       {active, false}]).
+
+%% Tcp options shared during the connection and negotiation phase
+-define(CONNECT_OPTIONS, [binary,
+                          {keepalive, true},
+                          {nodelay, true},
+                          {packet, 4},
+                          {reuseaddr, true},
+                          {active, false}]).
+
+-type(ip_addr_str() :: string()).
+-type(ip_portnum() :: non_neg_integer()).
+-type(ip_addr() :: {ip_addr_str(), ip_portnum()}).
+-type(tcp_options() :: [any()]).
+
+-type(proto_id() :: atom()).
+-type(rev() :: non_neg_integer()). %% major or minor revision number
+-type(proto() :: {proto_id(), {rev(), rev()}}). %% e.g. {myproto, 1, 0}
+-type(protoprefs() :: {proto_id(), [{rev(), rev()}]}).
+
+
+%% Function = fun(Socket, Transport, Protocol, Args) -> ok
+%% Protocol :: proto()
+-type(service_started_callback() :: fun((inet:socket(), module(), proto(), [any()]) -> no_return())).
+
+%% Host protocol spec
+-type(hostspec() :: {protoprefs(), {tcp_options(), module(), service_started_callback(), [any()]}}).
+
+%% Client protocol spec
+-type(clientspec() :: {protoprefs(), {tcp_options(), module(),[any()]}}).
+
+
+%% Scheduler strategies tell the connection manager how distribute the load.
+%%
+%% Client scheduler strategies
+%% ---------------------------
+%% default := service side decides how to choose node to connect to. limits number of
+%%            accepted connections to max_nb_cons().
+%% askme := the connection manager will call your client for a custom protocol strategy
+%%          and likewise will expect that the service side has plugged the cluster
+%%          manager with support for that custom strategy. UNSUPPORTED so far.
+%%          TODO: add a behaviour for the client to implement that includes this callback.
+%% Service scheduler strategies
+%% ----------------------------
+%% round_robin := choose the next available node on cluster to service request. limits
+%%                the number of accepted connections to max_nb_cons().
+%% custom := service must provide a strategy to the cluster manager for choosing nodes
+%%           UNSUPPORTED so far. Should we use a behaviour for the service module?
+-type(max_nb_cons() :: non_neg_integer()).
+-type(client_scheduler_strategy() :: default | askme).
+-type(service_scheduler_strategy() :: {round_robin, max_nb_cons()} | custom).
+
+%% service manager statistics, can maybe get shared by other layers too
+-record(stats, {open_connections = 0 : non_negative_integer()
+                }).
+
+
+-type(cluster_finder_fun() :: fun(() -> {ok,node()} | {error, term()})).
+

--- a/src/riak_core_cluster_conn.erl
+++ b/src/riak_core_cluster_conn.erl
@@ -8,7 +8,7 @@
 -module(riak_core_cluster_conn).
 
 -include("riak_core_cluster.hrl").
--include_lib("riak_core/include/riak_core_connection.hrl").
+-include("riak_core_connection.hrl").
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/riak_core_cluster_mgr.erl
+++ b/src/riak_core_cluster_mgr.erl
@@ -47,7 +47,7 @@
 -behaviour(gen_server).
 
 -include("riak_core_cluster.hrl").
--include_lib("riak_core/include/riak_core_connection.hrl").
+-include("riak_core_connection.hrl").
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -define(TRACE(Stmt),Stmt).

--- a/src/riak_core_connection.erl
+++ b/src/riak_core_connection.erl
@@ -1,0 +1,244 @@
+%% -------------------------------------------------------------------
+%%
+%% Riak Subprotocol Server Dispatch and Client Connections
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_core_connection).
+-author("Chris Tilt").
+
+-include("riak_core_connection.hrl").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-define(TRACE(Stmt),Stmt).
+-else.
+-define(TRACE(Stmt),ok).
+-endif.
+
+
+%% public API
+-export([connect/2,
+         sync_connect/2]).
+
+%% internal functions
+-export([async_connect_proc/3]).
+
+%%TODO: move to riak_ring_core...symbolic cluster naming
+-export([set_symbolic_clustername/2, set_symbolic_clustername/1,
+         symbolic_clustername/1, symbolic_clustername/0]).
+
+%% @doc Sets the symbolic, human readable, name of this cluster.
+set_symbolic_clustername(Ring, ClusterName) ->
+    {new_ring,
+     riak_core_ring:update_meta(symbolic_clustername, ClusterName, Ring)}.
+
+set_symbolic_clustername(ClusterName) when is_list(ClusterName) ->
+    {error, "argument is not a string"};
+set_symbolic_clustername(ClusterName) ->
+    case riak_core_ring_manager:get_my_ring() of
+        {ok, _Ring} ->
+            riak_core_ring_manager:ring_trans(fun riak_core_connection:set_symbolic_clustername/2,
+                                              ClusterName);
+        {error, Reason} ->
+            lager:error("Can't set symbolic clustername because: ~p", [Reason])
+    end.
+
+symbolic_clustername(Ring) ->
+    case riak_core_ring:get_meta(symbolic_clustername, Ring) of
+        {ok, Name} -> Name;
+        undefined -> "undefined"
+    end.
+
+%% @doc Returns the symbolic, human readable, name of this cluster.
+symbolic_clustername() ->
+    case riak_core_ring_manager:get_my_ring() of
+        {ok, Ring} ->
+            symbolic_clustername(Ring);
+        {error, Reason} ->
+            lager:error("Can't read symbolic clustername because: ~p", [Reason]),
+            "undefined"
+    end.
+
+%% Make async connection request. The connection manager is responsible for retry/backoff
+%% and calls your module's functions on success or error (asynchrously):
+%%   Module:connected(Socket, TransportModule, {IpAddress, Port}, {Proto, MyVer, RemoteVer}, Args)
+%%   Module:connect_failed(Proto, {error, Reason}, Args)
+%%       Reason could be 'protocol_version_not_supported"
+%%
+%%
+%% You can set options on the tcp connection, e.g.
+%% [{packet, 4}, {active, false}, {keepalive, true}, {nodelay, true}]
+%%
+%% ClientProtocol specifies the preferences of the client, in terms of what versions
+%% of a protocol it speaks. The host will choose the highest common major version and
+%% inform the client via the callback Module:connected() in the HostProtocol parameter.
+%%
+%% Note: that the connection will initially be setup with the `binary` option
+%% because protocol negotiation requires binary. TODO: should we allow non-binary
+%% options? Check that binary is not overwritten.
+%%
+%% connect returns the pid() of the asynchronous process that will attempt the connection.
+
+-spec(connect(ip_addr(), clientspec()) -> pid()).
+connect({IP,Port}, ClientSpec) ->
+    ?TRACE(?debugMsg("spawning async_connect link")),
+    %% start a process to handle the connection request asyncrhonously
+    proc_lib:spawn_link(?MODULE, async_connect_proc, [self(), {IP,Port}, ClientSpec]).
+
+sync_connect({IP,Port}, ClientSpec) ->
+    sync_connect_status(self(), {IP,Port}, ClientSpec).
+
+%% @private
+
+%% exchange brief handshake with client to ensure that we're supporting sub-protocols.
+%% client -> server : Hello {1,0} [Capabilities]
+%% server -> client : Ack {1,0} [Capabilities]
+exchange_handshakes_with(host, Socket, Transport, MyCaps) ->
+    Hello = term_to_binary({?CTRL_HELLO, ?CTRL_REV, MyCaps}),
+    case Transport:send(Socket, Hello) of
+        ok ->
+            ?TRACE(?debugFmt("exchange_handshakes: waiting for ~p from host", [?CTRL_ACK])),
+            case Transport:recv(Socket, 0, ?CONNECTION_SETUP_TIMEOUT) of
+                {ok, Ack} ->
+                    case binary_to_term(Ack) of
+                        {?CTRL_ACK, TheirRev, TheirCaps} ->
+                            Props = [{local_revision, ?CTRL_REV}, {remote_revision, TheirRev} | TheirCaps],
+                            {ok,Props};
+                        {error, _Reason} = Error ->
+                            Error;
+                        Msg ->
+                            {error, Msg}
+                    end;
+                {error, Reason} ->
+                    {error, Reason}
+            end;
+        Error ->
+            Error
+    end.
+
+async_connect_proc(Parent, {IP,Port}, ProtocolSpec) ->
+    sync_connect_status(Parent, {IP,Port}, ProtocolSpec).
+
+%% connect synchronously to remote addr/port and return status
+sync_connect_status(_Parent, {IP,Port}, {ClientProtocol, {Options, Module, Args}}) ->
+    Timeout = ?CONNECTION_SETUP_TIMEOUT,
+    Transport = ranch_tcp,
+    %%   connect to host's {IP,Port}
+    ?TRACE(?debugFmt("sync_connect: connect to ~p", [{IP,Port}])),
+    case gen_tcp:connect(IP, Port, ?CONNECT_OPTIONS, Timeout) of
+        {ok, Socket} ->
+            ?TRACE(?debugFmt("Setting system options on client side: ~p", [?CONNECT_OPTIONS])),
+            Transport:setopts(Socket, ?CONNECT_OPTIONS),
+            SSLEnabled = app_helper:get_env(riak_core, ssl_enabled, false),
+            %% handshake to make sure it's a riak sub-protocol dispatcher
+            MyName = symbolic_clustername(),
+            MyCaps = [{clustername, MyName}, {ssl_enabled, SSLEnabled}],
+            case exchange_handshakes_with(host, Socket, Transport, MyCaps) of
+                {ok,TheirCaps} ->
+                    case try_ssl(Socket, Transport, MyCaps, TheirCaps) of
+                        {error, Reason} ->
+                            {error, Reason};
+                        {NewTransport, NewSocket} ->
+                            %% ask for protocol, see what host has
+                            case negotiate_proto_with_server(NewSocket, NewTransport, ClientProtocol) of
+                                {ok,HostProtocol} ->
+                                    %% set client's requested Tcp options
+                                    ?TRACE(?debugFmt("Setting user options on client side; ~p", [Options])),
+                                    %% notify requester of connection and negotiated protocol from host
+                                    %% pass back returned value in case problem detected on connection
+                                    %% by module.  requestor is responsible for transferring control
+                                    %% of the socket.
+                                    NewTransport:setopts(NewSocket, Options),
+                                    Module:connected(NewSocket, NewTransport,
+                                        {IP, Port}, HostProtocol,
+                                        Args, TheirCaps);
+                                {error, Reason} ->
+                                    ?TRACE(?debugFmt("negotiate_proto_with_server returned: ~p", [{error,Reason}])),
+                                    %% Module:connect_failed(ClientProtocol, {error, Reason}, Args),
+                                    {error, Reason}
+                            end
+                    end;
+                {error, closed} ->
+                    %% socket got closed, don't report this
+                    {error, closed};
+                {error, Reason} ->
+                    lager:error("Failed to exchange handshake with host. Error = ~p", [Reason]),
+                    {error, Reason};
+                Error ->
+                    %% failed to exchange handshakes
+                    lager:error("Failed to exchange handshake with host. Error = ~p", [Error]),
+                    {error, Error}
+            end;
+        {error, Reason} ->
+            %% Module:connect_failed(ClientProtocol, {error, Reason}, Args),
+            {error, Reason}
+    end.
+
+try_ssl(Socket, Transport, MyCaps, TheirCaps) ->
+    MySSL = proplists:get_value(ssl_enabled, TheirCaps, false),
+    TheirSSL = proplists:get_value(ssl_enabled, MyCaps, false),
+    MyName = proplists:get_value(clustername, MyCaps),
+    TheirName = proplists:get_value(clustername, TheirCaps),
+    case {MySSL, TheirSSL} of
+        {true, false} ->
+            lager:warning("~p requested SSL, but ~p doesn't support it",
+                [MyName, TheirName]),
+            {error, no_ssl};
+        {false, true} ->
+            lager:warning("~p requested SSL but ~p doesn't support it",
+                [TheirName, MyName]),
+            {error, no_ssl};
+        {false, false} ->
+            lager:info("~p and ~p agreed to not use SSL", [MyName, TheirName]),
+            {Transport, Socket};
+        {true, true} ->
+            lager:info("~p and ~p agreed to use SSL", [MyName, TheirName]),
+            ssl:start(),
+            case riak_core_ssl_util:upgrade_client_to_ssl(Socket, riak_core) of
+                {ok, SSLSocket} ->
+                    {ranch_ssl, SSLSocket};
+                {error, Reason} ->
+                    lager:error("Error negotiating SSL between ~p and ~p: ~p",
+                        [MyName, TheirName, Reason]),
+                    {error, Reason}
+            end
+      end.
+
+
+%% Negotiate the highest common major protocol revision with the connected server.
+%% client -> server : Prefs List = {SubProto, [{Major, Minor}]}
+%% server -> client : selected version = {SubProto, {Major, HostMinor, ClientMinor}}
+%%
+%% returns {ok,{Proto,{Major,ClientMinor},{Major,HostMinor}}} | {error, Reason}
+negotiate_proto_with_server(Socket, Transport, ClientProtocol) ->
+    ?TRACE(?debugFmt("negotiate protocol with host, client proto = ~p", [ClientProtocol])),
+    Transport:send(Socket, erlang:term_to_binary(ClientProtocol)),
+    case Transport:recv(Socket, 0, ?CONNECTION_SETUP_TIMEOUT) of
+        {ok, NegotiatedProtocolBin} ->
+            case erlang:binary_to_term(NegotiatedProtocolBin) of
+                {ok, {Proto,{CommonMajor,HMinor,CMinor}}} ->
+                    {ok, {Proto,{CommonMajor,CMinor},{CommonMajor,HMinor}}};
+                {error, Reason} ->
+                    {error, Reason}
+            end;
+        {error, Reason} ->
+            lager:error("Failed to receive protocol ~p response from server. Reason = ~p",
+                        [ClientProtocol, Reason]),
+            {error, connection_failed}
+    end.

--- a/src/riak_core_connection_mgr.erl
+++ b/src/riak_core_connection_mgr.erl
@@ -24,7 +24,7 @@
 -author("Chris Tilt").
 -behaviour(gen_server).
 
--include_lib("riak_core/include/riak_core_connection.hrl").
+-include("riak_core_connection.hrl").
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/riak_core_service_mgr.erl
+++ b/src/riak_core_service_mgr.erl
@@ -37,7 +37,7 @@
 -author("Chris Tilt").
 -behaviour(gen_server).
 
--include_lib("riak_core/include/riak_core_connection.hrl").
+-include("riak_core_connection.hrl").
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/riak_repl_app.erl
+++ b/src/riak_repl_app.erl
@@ -12,7 +12,7 @@
          cluster_mgr_read_cluster_targets_from_ring/0]).
 
 -include("riak_core_cluster.hrl").
--include_lib("riak_core/include/riak_core_connection.hrl").
+-include("riak_core_connection.hrl").
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/test/riak_core_connection_mgr_tests.erl
+++ b/test/riak_core_connection_mgr_tests.erl
@@ -1,0 +1,252 @@
+%% -------------------------------------------------------------------
+%%
+%% Eunit test cases for the Connection Manager
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_core_connection_mgr_tests).
+-author("Chris Tilt").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(TRACE(Stmt),Stmt).
+%%-define(TRACE(Stmt),ok).
+
+%% internal functions
+-export([testService/5,
+         connected/6, connect_failed/3
+        ]).
+
+%% Locator selector types
+-define(REMOTE_LOCATOR_TYPE, remote).
+-define(ADDR_LOCATOR_TYPE, addr).
+
+%% My cluster
+-define(MY_CLUSTER_NAME, "bob").
+-define(MY_CLUSTER_ADDR, {"127.0.0.1", 4097}).
+
+%% Remote cluster
+-define(REMOTE_CLUSTER_NAME, "betty").
+-define(REMOTE_CLUSTER_ADDR, {"127.0.0.1", 4096}).
+-define(REMOTE_ADDRS, [{"127.0.0.1",5001}, {"127.0.0.1",5002}, {"127.0.0.1",5003},
+                       ?REMOTE_CLUSTER_ADDR]).
+
+-define(MAX_CONS, 2).
+-define(TCP_OPTIONS, [{keepalive, true},
+                      {nodelay, true},
+                      {packet, 4},
+                      {reuseaddr, true},
+                      {active, false}]).
+
+%% Tell the connection manager how to find out "remote" end points.
+%% For testing, we just make up some local addresses.
+register_remote_locator() ->
+    Remotes = orddict:from_list([{?REMOTE_CLUSTER_NAME, ?REMOTE_ADDRS}]),
+    Locator = fun(Name, _Policy) ->
+                      case orddict:find(Name, Remotes) of
+                          false ->
+                              {error, {unknown, Name}};
+                          OKEndpoints ->
+                              OKEndpoints
+                      end
+              end,
+    ok = riak_core_connection_mgr:register_locator(?REMOTE_LOCATOR_TYPE, Locator).
+
+register_addr_locator() ->
+    Locator = fun(Name, _Policy) -> {ok, [Name]} end,
+    ok = riak_core_connection_mgr:register_locator(?ADDR_LOCATOR_TYPE, Locator).
+
+register_empty_locator() ->
+    Locator = fun(_Name, _Policy) -> {ok, []} end,
+    ok = riak_core_connection_mgr:register_locator(?REMOTE_LOCATOR_TYPE, Locator).
+
+connections_test_() ->
+    {timeout, 6000, {setup, fun() ->
+        ok = application:start(ranch),
+        riak_core_ring_events:start_link(),
+        riak_core_ring_manager:start_link(test),
+        {ok, _} = riak_core_service_mgr:start_link(?REMOTE_CLUSTER_ADDR),
+        {ok, _} = riak_core_connection_mgr:start_link()
+    end,
+    fun(_) ->
+        riak_core_connection_mgr:stop(),
+        riak_core_service_mgr:stop(),
+        riak_core_ring_manager:stop(),
+        application:stop(ranch)
+    end,
+    fun(_) -> [
+
+        {"register remote locator", fun() ->
+            register_remote_locator(),
+            Target = {?REMOTE_LOCATOR_TYPE, ?REMOTE_CLUSTER_NAME},
+            Strategy = default,
+            Got = riak_core_connection_mgr:apply_locator(Target, Strategy),
+            ?assertEqual({ok, ?REMOTE_ADDRS}, Got)
+        end},
+
+        {"register locator addr", fun() ->
+            register_addr_locator(),
+            Target = {?ADDR_LOCATOR_TYPE, ?REMOTE_CLUSTER_ADDR},
+            Strategy = default,
+            Got = riak_core_connection_mgr:apply_locator(Target, Strategy),
+            ?assertEqual({ok, [?REMOTE_CLUSTER_ADDR]}, Got)
+        end},
+
+        {"bad locator args", fun() ->
+            register_addr_locator(),
+            %% bad args for 'addr'
+            Target = {?REMOTE_LOCATOR_TYPE, ?REMOTE_CLUSTER_ADDR},
+            Strategy = default,
+            Expected = {error, {bad_target_name_args, remote, ?REMOTE_CLUSTER_ADDR}},
+            Got = riak_core_connection_mgr:apply_locator(Target, Strategy),
+            ?assertEqual(Expected, Got)
+        end},
+
+        {"is paused", ?_assertNot(riak_core_connection_mgr:is_paused())},
+
+        {"pause", fun() ->
+            riak_core_connection_mgr:pause(),
+            ?assert(riak_core_connection_mgr:is_paused())
+        end},
+
+        {"resume", fun() ->
+            riak_core_connection_mgr:resume(),
+            ?assertNot(riak_core_connection_mgr:is_paused())
+        end},
+
+        {"client connection", fun() ->
+            %% start a test service
+            start_service(),
+            %% do async connect via connection_mgr
+            ExpectedArgs = {expectedToPass, [{1,0}, {1,0}]},
+            Target = {?ADDR_LOCATOR_TYPE, ?REMOTE_CLUSTER_ADDR},
+            Strategy = default,
+            riak_core_connection_mgr:connect(Target,
+                                             {{testproto, [{1,0}]},
+                                              {?TCP_OPTIONS, ?MODULE, ExpectedArgs}},
+                                             Strategy),
+            timer:sleep(1000)
+        end},
+
+        {"client connect via cluster name", fun() ->
+            start_service(),
+            %% do async connect via connection_mgr
+            ExpectedArgs = {expectedToPass, [{1,0}, {1,0}]},
+            Target = {?REMOTE_LOCATOR_TYPE, ?REMOTE_CLUSTER_NAME},
+            Strategy = default,
+            riak_core_connection_mgr:connect(Target,
+                                             {{testproto, [{1,0}]},
+                                              {?TCP_OPTIONS, ?MODULE, ExpectedArgs}},
+                                             Strategy),
+            timer:sleep(1000)
+        end},
+
+        {"client retries", fun() ->
+            %% do async connect via connection_mgr
+            ExpectedArgs = {retry_test, [{1,0}, {1,0}]},
+            Target = {?REMOTE_LOCATOR_TYPE, ?REMOTE_CLUSTER_NAME},
+            Strategy = default,
+
+            riak_core_connection_mgr:connect(Target,
+                                             {{testproto, [{1,0}]},
+                                              {?TCP_OPTIONS, ?MODULE, ExpectedArgs}},
+                                             Strategy),
+            %% delay so the client will keep trying
+            ?TRACE(?debugMsg(" ------ sleeping 3 sec")),
+            timer:sleep(3000),
+            %% resume and confirm not paused, which should cause service to start and connection :-)
+            ?TRACE(?debugMsg(" ------ resuming services")),
+            start_service(),
+            %% allow connection to setup
+            ?TRACE(?debugMsg(" ------ sleeping 2 sec")),
+            timer:sleep(1000)
+        end},
+
+        {"empty locator", fun() ->
+            register_empty_locator(), %% replace remote locator with one that returns empty list
+            start_service(),
+            %% do async connect via connection_mgr
+            ExpectedArgs = {expectedToPass, [{1,0}, {1,0}]},
+            Target = {?REMOTE_LOCATOR_TYPE, ?REMOTE_CLUSTER_NAME},
+            Strategy = default,
+            riak_core_connection_mgr:connect(Target,
+                                             {{testproto, [{1,0}]},
+                                              {?TCP_OPTIONS, ?MODULE, ExpectedArgs}},
+                                             Strategy),
+            %% allow conn manager to try and schedule a few retries
+            timer:sleep(1000),
+
+            %% restore the remote locator that gives a good endpoint
+            register_remote_locator(),
+            Got = riak_core_connection_mgr:apply_locator(Target, Strategy),
+            ?assertEqual({ok, ?REMOTE_ADDRS}, Got),
+
+            %% allow enough time for retry mechanism to kick in
+            timer:sleep(2000)
+            %% we should get a connection
+        end}
+
+    ] end} }.
+
+%%------------------------
+%% Helper functions
+%%------------------------
+
+start_service() ->
+    %% start dispatcher
+    ExpectedRevs = [{1,0}, {1,0}],
+    TestProtocol = {{testproto, [{1,0}]}, {?TCP_OPTIONS, ?MODULE, testService, ExpectedRevs}},
+    riak_core_service_mgr:register_service(TestProtocol, {round_robin,10}),
+    ?assert(riak_core_service_mgr:is_registered(testproto) == true).
+
+%% Protocol Service functions
+testService(_Socket, _Transport, {error, _Reason}, _Args, _Props) ->
+    ?assert(false);
+testService(_Socket, _Transport, {ok, {Proto, MyVer, RemoteVer}}, Args, _Props) ->
+    ?TRACE(?debugMsg("testService started")),
+    [ExpectedMyVer, ExpectedRemoteVer] = Args,
+    ?assert(ExpectedMyVer == MyVer),
+    ?assert(ExpectedRemoteVer == RemoteVer),
+    ?assert(Proto == testproto),
+    timer:sleep(2000),
+    {ok, self()}.
+
+%% Client side protocol callbacks
+connected(_Socket, _Transport, {_IP, _Port}, {Proto, MyVer, RemoteVer}, Args, _Props) ->
+    ?TRACE(?debugFmt("testClient started, connected to ~p:~p", [_IP,_Port])),
+    {_TestType, [ExpectedMyVer, ExpectedRemoteVer]} = Args,
+    ?assert(Proto == testproto),
+    ?assert(ExpectedMyVer == MyVer),
+    ?assert(ExpectedRemoteVer == RemoteVer).
+
+connect_failed({_Proto,_Vers}, {error, Reason}, Args) ->
+
+    case Args of
+        expectedToFail ->
+            ?TRACE(?debugFmt("connect_failed: (EXPECTED) when expected to fail: ~p with ~p",
+                             [Reason, Args])),
+            ?assert(Reason == econnrefused);
+        {retry_test, _Stuff} ->
+            ?TRACE(?debugFmt("connect_failed: (EXPECTED) during retry test: ~p",
+                             [Reason])),
+            ok;
+        Other ->
+            ?TRACE(?debugFmt("connect_failed: (UNEXPECTED) ~p with args = ~p",
+                             [Reason, Other])),
+            ?assert(false == Other)
+    end.

--- a/test/riak_core_connection_tests.erl
+++ b/test/riak_core_connection_tests.erl
@@ -1,0 +1,136 @@
+%% -------------------------------------------------------------------
+%%
+%% Eunit test cases for the Conn Manager Connection
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+
+-module(riak_core_connection_tests).
+-author("Chris Tilt").
+-include_lib("eunit/include/eunit.hrl").
+
+-export([test1service/5, connected/6, connect_failed/3]).
+
+-define(TEST_ADDR, { "127.0.0.1", 4097}).
+-define(MAX_CONS, 2).
+-define(TCP_OPTIONS, [{keepalive, true},
+                      {nodelay, true},
+                      {packet, 4},
+                      {reuseaddr, true},
+                      {active, false}]).
+
+%% host service functions
+test1service(_Socket, _Transport, {error, Reason}, Args, _Props) ->
+    ?debugFmt("test1service failed with {error, ~p}", [Reason]),
+    ?assert(Args == failed_host_args),
+    ?assert(Reason == protocol_version_not_supported),
+    {error, Reason};
+test1service(_Socket, _Transport, {ok, {Proto, MyVer, RemoteVer}}, Args, Props) ->
+    [ExpectedMyVer, ExpectedRemoteVer] = Args,
+    RemoteClusterName = proplists:get_value(clustername, Props),
+    ?debugFmt("test1service started with Args ~p Props ~p", [Args, Props]),
+    ?assert(RemoteClusterName == "undefined"),
+    ?assert(ExpectedMyVer == MyVer),
+    ?assert(ExpectedRemoteVer == RemoteVer),
+    ?assert(Proto == test1proto),
+    timer:sleep(2000),
+    {ok, self()}.
+
+%% client connection callbacks
+connected(_Socket, _Transport, {_IP, _Port}, {Proto, MyVer, RemoteVer}, Args, Props) ->
+    [ExpectedMyVer, ExpectedRemoteVer] = Args,
+    RemoteClusterName = proplists:get_value(clustername, Props),
+    ?debugFmt("connected with Args ~p Props ~p", [Args, Props]),
+    ?assert(RemoteClusterName == "undefined"),
+    ?assert(Proto == test1proto),
+    ?assert(ExpectedMyVer == MyVer),
+    ?assert(ExpectedRemoteVer == RemoteVer),
+    timer:sleep(2000).
+
+connect_failed({Proto,_Vers}, {error, Reason}, Args) ->
+    ?debugFmt("connect_failed: Reason = ~p Args = ~p", [Reason, Args]),
+    ?assert(Args == failed_client_args),
+    ?assert(Reason == protocol_version_not_supported),
+    ?assert(Proto == test1protoFailed).
+
+conection_test_() ->
+    {timeout, 60000, {setup, fun() ->
+        riak_core_ring_events:start_link(),
+        riak_core_ring_manager:start_link(test),
+        ok = application:start(ranch),
+        {ok, _} = riak_core_service_mgr:start_link(?TEST_ADDR)
+    end,
+    fun(_) ->
+        riak_core_service_mgr:stop(),
+        riak_core_ring_manager:stop(),
+        application:stop(ranch)
+    end,
+    fun(_) -> [
+
+        {"started", ?_assert(is_pid(whereis(riak_core_service_manager)))},
+
+        {"set and get name", fun() ->
+            riak_core_connection:set_symbolic_clustername("undefined"),
+            Got = riak_core_connection:symbolic_clustername(),
+            ?assertEqual("undefined", Got)
+        end},
+
+        {"register service", fun() ->
+            ExpectedRevs = [{1,0}, {1,1}],
+            ServiceProto = {test1proto, [{2,1}, {1,0}]},
+            ServiceSpec = {ServiceProto, {?TCP_OPTIONS, ?MODULE, test1service, ExpectedRevs}},
+            riak_core_service_mgr:register_service(ServiceSpec, {round_robin,?MAX_CONS}),
+            ?assert(riak_core_service_mgr:is_registered(test1proto))
+        end},
+
+        {"unregister service", fun() ->
+            TestProtocolId = test1proto,
+            riak_core_service_mgr:unregister_service(TestProtocolId),
+            ?assertNot(riak_core_service_mgr:is_registered(TestProtocolId))
+        end},
+
+        {"protocol match", fun() ->
+            ExpectedRevs = [{1,0}, {1,1}],
+            ServiceProto = {test1proto, [{2,1}, {1,0}]},
+            ServiceSpec = {ServiceProto, {?TCP_OPTIONS, ?MODULE, test1service, ExpectedRevs}},
+            riak_core_service_mgr:register_service(ServiceSpec, {round_robin,?MAX_CONS}),
+
+            % test protocol match
+            ClientProtocol = {test1proto, [{0,1},{1,1}]},
+            ClientSpec = {ClientProtocol, {?TCP_OPTIONS, ?MODULE, [{1,1},{1,0}]}},
+            riak_core_connection:connect(?TEST_ADDR, ClientSpec),
+            timer:sleep(1000)
+        end},
+
+        {"failed protocol match", fun() ->
+            %% start service
+            SubProtocol = {{test1protoFailed, [{2,1}, {1,0}]},
+                           {?TCP_OPTIONS, ?MODULE, test1service, failed_host_args}},
+            riak_core_service_mgr:register_service(SubProtocol, {round_robin,?MAX_CONS}),
+            ?assert(riak_core_service_mgr:is_registered(test1protoFailed) == true),
+
+            %% try to connect via a client that speaks 0.1 and 3.1. No Match with host!
+            ClientProtocol = {test1protoFailed, [{0,1},{3,1}]},
+            ClientSpec = {ClientProtocol, {?TCP_OPTIONS, ?MODULE, failed_client_args}},
+            riak_core_connection:connect(?TEST_ADDR, ClientSpec),
+
+            timer:sleep(2000)
+        end}
+
+    ] end } }.

--- a/test/riak_core_service_mgr_tests.erl
+++ b/test/riak_core_service_mgr_tests.erl
@@ -1,0 +1,172 @@
+%% -------------------------------------------------------------------
+%%
+%% Eunit test cases for the Service Manager
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_core_service_mgr_tests).
+-author("Chris Tilt").
+-include_lib("eunit/include/eunit.hrl").
+
+%%-define(TRACE(Stmt),Stmt).
+-define(TRACE(Stmt),ok).
+
+%% internal functions
+-export([testService/5,
+         connected/6, connect_failed/3
+        ]).
+
+%% my name and remote same because I need to talk to myself for testing
+-define(MY_CLUSTER_NAME, "bob").
+-define(REMOTE_CLUSTER_NAME, "bob").
+
+-define(REMOTE_CLUSTER_ADDR, {"127.0.0.1", 4096}).
+-define(TEST_ADDR, {"127.0.0.1", 4097}).
+-define(MAX_CONS, 2).
+-define(TCP_OPTIONS, [{keepalive, true},
+                      {nodelay, true},
+                      {packet, 4},
+                      {reuseaddr, true},
+                      {active, false}]).
+
+service_test_() ->
+    {timeout, 60000, {setup, fun() ->
+        riak_core_ring_events:start_link(),
+        riak_core_ring_manager:start_link(test),
+        ok = application:start(ranch),
+        {ok, _Pid} = riak_core_service_mgr:start_link(?TEST_ADDR)
+    end,
+    fun(_) ->
+        application:stop(ranch),
+        riak_core_ring_manager:stop(),
+        case whereis(riak_core_service_manager) of
+            Pid when is_pid(Pid) ->
+                riak_core_service_mgr:stop(),
+                {ok, _Mon} = erlang:monitor(process, Pid),
+                receive
+                    {'DOWN', _, _, _, _} ->
+                        ok
+                after
+                    1000 ->
+                        ok
+                end;
+            undefined ->
+                ok
+        end
+    end,
+    fun(_) -> [
+
+        {"started", ?_assert(is_pid(whereis(riak_core_service_manager)))},
+
+        {"get services", ?_assertEqual([], gen_server:call(riak_core_service_manager, get_services))},
+
+        {"register service", fun() ->
+            ExpectedRevs = [{1,0}, {1,0}],
+            TestProtocol = {{testproto, [{1,0}]}, {?TCP_OPTIONS, ?MODULE, testService, ExpectedRevs}},
+            riak_core_service_mgr:register_service(TestProtocol, {round_robin,?MAX_CONS}),
+            ?assert(riak_core_service_mgr:is_registered(testproto))
+        end},
+
+        {"unregister service", fun() ->
+            TestProtocolId = testproto,
+            riak_core_service_mgr:unregister_service(TestProtocolId),
+            ?assertNot(riak_core_service_mgr:is_registered(testproto))
+        end},
+
+        {"register stats fun", fun() ->
+            Self = self(),
+            Fun = fun(Stats) ->
+                Self ! Stats
+            end,
+            riak_core_service_mgr:register_stats_fun(Fun),
+            GotStats = receive
+                Term ->
+                    Term
+            after 5500 ->
+                timeout
+            end,
+            ?assertEqual([], GotStats)
+        end},
+
+        {"start service test", fun() ->
+            %% re-register the test protocol and confirm registered
+            TestProtocol = {{testproto, [{1,0}]}, {?TCP_OPTIONS, ?MODULE, testService, [{1,0}, {1,0}]}},
+            riak_core_service_mgr:register_service(TestProtocol, {round_robin, ?MAX_CONS}),
+            ?assert(riak_core_service_mgr:is_registered(testproto)),
+            %register_service_test_d(),
+            %% try to connect via a client that speaks our test protocol
+            ExpectedRevs = {expectedToPass, [{1,0}, {1,0}]},
+            riak_core_connection:connect(?TEST_ADDR, {{testproto, [{1,0}]},
+                                                      {?TCP_OPTIONS, ?MODULE, ExpectedRevs}}),
+            %% allow client and server to connect and make assertions of success/failure
+            timer:sleep(1000),
+            Stats = riak_core_service_mgr:get_stats(),
+            ?assertEqual([{testproto,0}], Stats)
+        end},
+
+        {"pause existing services", fun() ->
+            riak_core_service_mgr:stop(),
+            %% there should be no services running now.
+            %% now start a client and confirm failure to connect
+            ExpectedArgs = expectedToFail,
+            riak_core_connection:connect(?TEST_ADDR, {{testproto, [{1,0}]},
+                                                      {?TCP_OPTIONS, ?MODULE, ExpectedArgs}}),
+            %% allow client and server to connect and make assertions of success/failure
+            timer:sleep(1000)
+        end}
+
+    ] end} }.
+
+%%------------------------
+%% Helper functions
+%%------------------------
+
+%% Protocol Service functions
+testService(_Socket, _Transport, {error, _Reason}, _Args, _Props) ->
+    ?assert(false);
+testService(_Socket, _Transport, {ok, {Proto, MyVer, RemoteVer}}, Args, _Props) ->
+    ?TRACE(?debugMsg("testService started")),
+    [ExpectedMyVer, ExpectedRemoteVer] = Args,
+    ?assertEqual(ExpectedMyVer, MyVer),
+    ?assertEqual(ExpectedRemoteVer, RemoteVer),
+    ?assertEqual(Proto, testproto),
+%%    timer:sleep(2000),
+    {ok, self()}.
+
+%% Client side protocol callbacks
+connected(_Socket, _Transport, {_IP, _Port}, {Proto, MyVer, RemoteVer}, Args, _Props) ->
+    ?TRACE(?debugMsg("testClient started")),
+    {_TestType, [ExpectedMyVer, ExpectedRemoteVer]} = Args,
+    ?assertEqual(Proto, testproto),
+    ?assertEqual(ExpectedMyVer, MyVer),
+    ?assertEqual(ExpectedRemoteVer, RemoteVer),
+    timer:sleep(2000).
+
+connect_failed({_Proto,_Vers}, {error, Reason}, Args) ->
+    case Args of
+        expectedToFail ->
+            ?assertEqual(Reason, econnrefused);
+        {retry_test, _Stuff} ->
+            ?TRACE(?debugFmt("connect_failed: during retry test: ~p", [Reason])),
+            ok;
+        _Other ->
+            ?TRACE(?debugFmt("connect_failed: ~p with args = ~p", [Reason, _Other])),
+            ?assert(false)
+    end,
+    timer:sleep(1000).


### PR DESCRIPTION
Move riak_core_connection, headers and tests back
to riak_repl as it's not needed in riak_core.
