### PR TITLE
Typed Bucket Replication Support

### DIFF
--- a/src/riak_repl.erl
+++ b/src/riak_repl.erl
@@ -6,6 +6,7 @@
 -export([start/0, stop/0]).
 -export([install_hook/0, uninstall_hook/0]).
 -export([fixup/2]).
+-export([conditional_hook/3]).
 
 start() ->
     riak_core_util:start_app_deps(riak_repl),
@@ -16,13 +17,25 @@ stop() ->
     application:stop(riak_repl).
 
 install_hook() ->
+    riak_kv_hooks:add_conditional_postcommit({?MODULE, conditional_hook}),
     riak_core_bucket:append_bucket_defaults([{repl, true}]),
     ok.
 
 uninstall_hook() ->
+    riak_kv_hooks:del_conditional_postcommit({?MODULE, conditional_hook}),
     %% Cannot remove bucket defaults, best we can do is disable
     riak_core_bucket:append_bucket_defaults([{repl, false}]),
     ok.
+
+conditional_hook(_BucketType, _Bucket, BucketProps) ->
+    RTEnabled = app_helper:get_env(riak_repl, rtenabled, false),
+    BucketEnabled = not lists:member({repl, false}, BucketProps),
+    case RTEnabled and BucketEnabled of
+        true ->
+            riak_repl_util:get_hooks_for_modes();
+        false ->
+            false
+    end.
 
 fixup(_Bucket, BucketProps) ->
     CleanPostcommit = strip_postcommit(BucketProps),

--- a/src/riak_repl2_rt.erl
+++ b/src/riak_repl2_rt.erl
@@ -143,15 +143,16 @@ postcommit(RObj) ->
         %% on what the RT source and sink negotiated as the common version).
         Objects0 when is_list(Objects0) ->
             Objects = Objects0 ++ [RObj],
+            Meta = set_bucket_meta(RObj),
             BinObjs = riak_repl_util:to_wire(w1, Objects),
             %% try the proxy first, avoids race conditions with unregister()
             %% during shutdown
             case whereis(riak_repl2_rtq_proxy) of
                 undefined ->
-                    riak_repl2_rtq:push(length(Objects), BinObjs);
+                    riak_repl2_rtq:push(length(Objects), BinObjs, Meta);
                 _ ->
                     %% we're shutting down and repl is stopped or stopping...
-                    riak_repl2_rtq_proxy:push(length(Objects), BinObjs)
+                    riak_repl2_rtq_proxy:push(length(Objects), BinObjs, Meta)
             end;
         cancel -> % repl helper callback requested not to send over realtime
             ok
@@ -208,12 +209,25 @@ terminate(_Reason, _State) ->
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
-
-
 do_ring_trans(F, A) ->
     case riak_core_ring_manager:ring_trans(F, A) of
         {ok, _} ->
             ok;
         ER ->
             ER
+    end.
+
+set_bucket_meta(Obj) ->
+    M = orddict:new(),
+    case riak_object:bucket(Obj) of
+        {Type, _B} ->
+            AllProps = riak_core_bucket_type:get(Type),
+            PropsHash = erlang:phash2(proplists:delete(claimant, AllProps)),
+            lager:debug("typed bucket, setting meta data: Type:~p, HashProps:~p", [Type, PropsHash]),
+            M1 = orddict:store(typed_bucket, true, M),
+            M2 = orddict:store(type, Type, M1),
+            orddict:store(props_hash, PropsHash, M2);
+        _B -> 
+            lager:debug("un-typed bucket, setting typed_bucket to false"),
+            orddict:store(typed_bucket, false, M)
     end.

--- a/src/riak_repl2_rt.erl
+++ b/src/riak_repl2_rt.erl
@@ -221,8 +221,7 @@ set_bucket_meta(Obj) ->
     M = orddict:new(),
     case riak_object:bucket(Obj) of
         {Type, _B} ->
-            AllProps = riak_core_bucket_type:get(Type),
-            PropsHash = erlang:phash2(proplists:delete(claimant, AllProps)),
+            PropsHash = riak_repl_util:get_bucket_props_hash(riak_core_bucket_type:get(Type)),
             lager:debug("typed bucket, setting meta data: Type:~p, HashProps:~p", [Type, PropsHash]),
             M1 = orddict:store(typed_bucket, true, M),
             M2 = orddict:store(type, Type, M1),

--- a/src/riak_repl2_rtframe.erl
+++ b/src/riak_repl2_rtframe.erl
@@ -30,6 +30,12 @@ encode_payload(heartbeat, undefined) ->
     [?MSG_HEARTBEAT].
 
 decode(<<Size:32/unsigned-big-integer, 
+         Size:32/unsigned-big-integer,
+         Msg:Size/binary, % MsgCode is included in size calc
+         Rest/binary>>) ->
+    <<MsgCode:8/unsigned, Payload/binary>> = Msg,
+    {ok, decode_payload(MsgCode, Payload), Rest};
+decode(<<Size:32/unsigned-big-integer, 
          Msg:Size/binary, % MsgCode is included in size calc
          Rest/binary>>) ->
     <<MsgCode:8/unsigned, Payload/binary>> = Msg,

--- a/src/riak_repl2_rtframe.erl
+++ b/src/riak_repl2_rtframe.erl
@@ -30,12 +30,6 @@ encode_payload(heartbeat, undefined) ->
     [?MSG_HEARTBEAT].
 
 decode(<<Size:32/unsigned-big-integer, 
-         Size:32/unsigned-big-integer,
-         Msg:Size/binary, % MsgCode is included in size calc
-         Rest/binary>>) ->
-    <<MsgCode:8/unsigned, Payload/binary>> = Msg,
-    {ok, decode_payload(MsgCode, Payload), Rest};
-decode(<<Size:32/unsigned-big-integer, 
          Msg:Size/binary, % MsgCode is included in size calc
          Rest/binary>>) ->
     <<MsgCode:8/unsigned, Payload/binary>> = Msg,

--- a/src/riak_repl2_rtsink_conn.erl
+++ b/src/riak_repl2_rtsink_conn.erl
@@ -419,13 +419,13 @@ write_object(Meta) ->
                     lager:debug("No properties found for bucket type:~p", [BucketType]),
 	            false;
                 AllProps ->
-                    SinkPropsHash = erlang:phash2(proplists:delete(claimant, AllProps)),
-                    SourcePropsHash = orddict:fetch(props_hash, Meta),
-                    lager:debug("SourcePropsHash:~p, SinkPropsHash:~p", [SourcePropsHash, SinkPropsHash]),
-	            SourcePropsHash =:= SinkPropsHash
+                    Sink = riak_repl_util:get_bucket_props_hash(AllProps),
+                    Source = orddict:fetch(props_hash, Meta),
+                    lager:debug("SourcePropsHash:~p, SinkPropsHash:~p", [Source, Sink]),
+	            Source =:= Sink
 	    end
     end.
-   
+
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_repl2_rtsink_conn.erl
+++ b/src/riak_repl2_rtsink_conn.erl
@@ -407,23 +407,22 @@ get_reactivate_socket_interval() ->
     app_helper:get_env(riak_repl, reactivate_socket_interval_millis, ?REACTIVATE_SOCK_INT_MILLIS).
 
 write_object(Meta) ->
-    case orddict:fetch(typed_bucket, Meta) of 
+    case orddict:fetch(typed_bucket, Meta) of
         false -> true;
         true ->
             BucketType = orddict:fetch(type, Meta),
             case riak_core_bucket_type:get(BucketType) of
-            undefined ->
-                lager:debug("No properties found for bucket type:~p", [BucketType]),    
-	        false; 
-	    {error, _T} ->
-                lager:debug("No properties found for bucket type:~p", [BucketType]),    
-	        false;
-            AllProps ->
-                SinkPropsHash = erlang:phash2(proplists:delete(claimant, AllProps)),
-                SourcePropsHash = orddict:fetch(props_hash, Meta),
-                lager:debug("SourcePropsHash:~p, SinkPropsHash:~p", [SourcePropsHash, SinkPropsHash]),
-	        SourcePropsHash =:= SinkPropsHash
-
+                undefined ->
+                    lager:debug("No properties found for bucket type:~p", [BucketType]),    
+	            false;
+	        {error, _T} ->
+                    lager:debug("No properties found for bucket type:~p", [BucketType]),
+	            false;
+                AllProps ->
+                    SinkPropsHash = erlang:phash2(proplists:delete(claimant, AllProps)),
+                    SourcePropsHash = orddict:fetch(props_hash, Meta),
+                    lager:debug("SourcePropsHash:~p, SinkPropsHash:~p", [SourcePropsHash, SinkPropsHash]),
+	            SourcePropsHash =:= SinkPropsHash
 	    end
     end.
    

--- a/src/riak_repl2_rtsink_conn.erl
+++ b/src/riak_repl2_rtsink_conn.erl
@@ -54,9 +54,9 @@
                 cont = <<>>       %% Continuation from previous TCP buffer
                }).
 
-%% @doc Register with service manager
+%% Register with service manager
 sync_register_service() ->
-    ProtoPrefs = {realtime,[{2,0}, {1,4}, {1,1}, {1,0}]},
+    ProtoPrefs = {realtime,[{2,1}, {2,0}, {1,4}, {1,1}, {1,0}]},
     TcpOptions = [{keepalive, true}, % find out if connection is dead, this end doesn't send
                   {packet, 0},
                   {nodelay, true}],
@@ -258,7 +258,7 @@ make_donefun({Binary, Meta}, Me, Ref, Seq) ->
         gen_server:cast(Me, {ack, Ref, Seq, Skips}),
         maybe_push(Binary, Meta)
     end,
-    {Done, Binary};
+    {Done, Binary, Meta};
 make_donefun(Binary, Me, Ref, Seq) when is_binary(Binary) ->
     Done = fun() ->
         gen_server:cast(Me, {ack, Ref, Seq, 0})
@@ -285,8 +285,17 @@ do_write_objects(Seq, BinObjsMeta, State = #state{max_pending = MaxPending,
                                               acked_seq = AckedSeq,
                                               ver = Ver}) ->
     Me = self(),
-    {DoneFun, BinObjs} = make_donefun(BinObjsMeta, Me, Ref, Seq),
-    riak_repl2_rtsink_helper:write_objects(Helper, BinObjs, DoneFun, Ver),
+    case make_donefun(BinObjsMeta, Me, Ref, Seq) of
+        {DoneFun, BinObjs, Meta} ->
+            case write_object(Meta) of
+            true ->
+                riak_repl2_rtsink_helper:write_objects(Helper, BinObjs, DoneFun, Ver);
+            false ->
+                lager:info("Bucket is of a type that are not equal on both the source and sink; not writing object.")
+            end;
+        {DoneFun, BinObjs} ->
+            riak_repl2_rtsink_helper:write_objects(Helper, BinObjs, DoneFun, Ver)
+    end,
     State2 = case AckedSeq of
                  undefined ->
                      %% Handle first received sequence number
@@ -396,6 +405,28 @@ schedule_reactivate_socket(State = #state{transport = T,
     end.
 get_reactivate_socket_interval() ->
     app_helper:get_env(riak_repl, reactivate_socket_interval_millis, ?REACTIVATE_SOCK_INT_MILLIS).
+
+write_object(Meta) ->
+    case orddict:fetch(typed_bucket, Meta) of 
+        false -> true;
+        true ->
+            BucketType = orddict:fetch(type, Meta),
+            case riak_core_bucket_type:get(BucketType) of
+            undefined ->
+                lager:debug("No properties found for bucket type:~p", [BucketType]),    
+	        false; 
+	    {error, _T} ->
+                lager:debug("No properties found for bucket type:~p", [BucketType]),    
+	        false;
+            AllProps ->
+                SinkPropsHash = erlang:phash2(proplists:delete(claimant, AllProps)),
+                SourcePropsHash = orddict:fetch(props_hash, Meta),
+                lager:debug("SourcePropsHash:~p, SinkPropsHash:~p", [SourcePropsHash, SinkPropsHash]),
+	        SourcePropsHash =:= SinkPropsHash
+
+	    end
+    end.
+   
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -128,7 +128,7 @@ init([Remote]) ->
     % TODO: expand version list or remove comment when we no
     % longer support 1.3.1
     % prefered version list: [{2,0}, {1,5}, {1,1}, {1,0}]
-    ClientSpec = {{realtime,[{2,0}, {1,5}]}, {TcpOptions, ?MODULE, self()}},
+    ClientSpec = {{realtime,[{2,1}, {1,5}]}, {TcpOptions, ?MODULE, self()}},
 
     %% Todo: check for bad remote name
     lager:debug("connecting to remote ~p", [Remote]),
@@ -229,7 +229,8 @@ handle_call({connected, Socket, Transport, EndPoint, Proto}, _From,
                                  address = EndPoint,
                                  proto = Proto,
                                  peername = peername(Transport, Socket),
-                                 helper_pid = HelperPid},
+                                 helper_pid = HelperPid,
+                                 ver = Ver},
             lager:info("Established realtime connection to site ~p address ~s",
                       [Remote, peername(State2)]),
 
@@ -416,7 +417,6 @@ schedule_heartbeat(State = #state{hb_interval_tref = undefined, hb_interval = HB
  
 schedule_heartbeat(State) ->
     State.
-
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_repl2_rtsource_helper.erl
+++ b/src/riak_repl2_rtsource_helper.erl
@@ -124,12 +124,27 @@ maybe_send(Transport, Socket, QEntry, State) ->
             lager:debug("Did not forward to ~p; destination already in routed list", [Remote]),
             State;
         false ->
-            QEntry2 = merge_forwards_and_routed_meta(QEntry, Remote),
-            {Encoded, State2} = encode(QEntry2, State),
-            lager:debug("Forwarding to ~p with new data: ~p derived from ~p", [State#state.remote, QEntry2, QEntry]),
-            Transport:send(Socket, Encoded),
-            State2
+            case State#state.proto of 
+                Ver when Ver =:= {2,1} ->
+                    encode_and_send(QEntry, Remote, Transport, Socket, State);
+		_ ->
+                    case is_bucket_typed(Meta) of
+                        false ->
+                            encode_and_send(QEntry, Remote, Transport, Socket, State);
+                        true ->
+   	                    lager:info("Negotiated protocol version:~p does not support typed buckets, not sending")
+                    end
+            end,
+	    State
     end.
+
+encode_and_send(QEntry, Remote, Transport, Socket, State) ->
+    QEntry2 = merge_forwards_and_routed_meta(QEntry, Remote),
+    {Encoded, State2} = encode(QEntry2, State),
+    lager:debug("Forwarding to ~p with new data: ~p derived from ~p", [State#state.remote, QEntry2, QEntry]),
+    Transport:send(Socket, Encoded),
+    State2.
+
 
 encode({Seq, _NumObjs, BinObjs, Meta}, State = #state{proto = Ver}) when Ver < {2,0} ->
     Skips = orddict:fetch(skip_count, Meta),
@@ -140,11 +155,14 @@ encode({Seq, _NumObjs, BinObjs, Meta}, State = #state{proto = Ver}) when Ver < {
     Encoded = riak_repl2_rtframe:encode(objects, {Seq2, BinObjs2}),
     State2 = State#state{v1_offset = Offset, v1_seq_map = V1Map},
     {Encoded, State2};
-encode({Seq, _NumbOjbs, BinObjs, Meta}, State = #state{proto = {2,0}}) ->
+encode({Seq, _NumbOjbs, BinObjs, Meta}, State = #state{proto = Ver}) when Ver >= {2,0} ->
     {riak_repl2_rtframe:encode(objects_and_meta, {Seq, BinObjs, Meta}), State}.
 
 get_routed(Meta) ->
     meta_get(routed_clusters, [], Meta).
+
+is_bucket_typed(Meta) ->
+    meta_get(typed_bucket, [], Meta).
 
 meta_get(Key, Default, Meta) ->
     case orddict:find(Key, Meta) of

--- a/src/riak_repl_cs.erl
+++ b/src/riak_repl_cs.erl
@@ -58,7 +58,11 @@ skip_common_bucket(Bucket) ->
 
 -spec skip_block_object(riak_object:riak_object()) -> boolean().
 skip_block_object(Object) ->
-    block_bucket(riak_object:bucket(Object)).
+    Bucket = case riak_object:bucket(Object) of
+        {_T, B} -> B;
+        B -> B
+    end,
+    block_bucket(Bucket).
 
 -spec block_bucket(binary()) -> boolean().
 block_bucket(<<?BLOCK_BUCKET_PREFIX, _Rest/binary>>) ->

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -194,7 +194,10 @@ repl_helper_recv([{App, Mod}|T], Object) ->
     end.
 
 repl_helper_send(Object, C) ->
-    B = riak_object:bucket(Object),
+    B = case riak_object:bucket(Object) of
+        {Bucket, _T} -> Bucket;
+        Bucket -> Bucket
+    end,
     case proplists:get_value(repl, C:get_bucket(B)) of
         Val when Val==true; Val==fullsync; Val==both ->
             case application:get_env(riak_core, repl_helper) of
@@ -680,7 +683,10 @@ proxy_get_active() ->
 
 log_dropped_realtime_obj(Obj) ->
     DroppedKey = riak_object:key(Obj),
-    DroppedBucket = riak_object:bucket(Obj),
+    DroppedBucket = case riak_object:bucket(Obj) of
+        {_T, B} -> B;
+        B -> B
+    end,
     lager:info("REPL dropped object: ~p ~p",
                [ DroppedBucket, DroppedKey]).
 
@@ -795,13 +801,24 @@ encode_obj_msg(V, {Cmd, RObj}) ->
             term_to_binary({Cmd, BObj})
     end.
 
+%% @doc Create binary wire formatted replication blob for riak 2.0+, complete with
+%%      possible type, bucket and key for reconstruction on the other end. BinObj should be
+%%      in the new format as obtained from riak_object:to_binary(v1, RObj).
+new_w1({T, B}, K, BinObj) when is_binary(B), is_binary(T), is_binary(K), is_binary(BinObj) ->
+    KLen = byte_size(K),
+    BLen = byte_size(B),
+    TLen = byte_size(T),
+    <<?MAGIC:8/integer, ?W1_VER:8/integer,
+      TLen:32/integer, T:TLen/binary,
+      BLen:32/integer, B:BLen/binary,
+      KLen:32/integer, K:KLen/binary, BinObj/binary>>;
 %% @doc Create a new binary wire formatted replication blob, complete with
 %%      bucket and key for reconstruction on the other end. BinObj should be
 %%      in the new format as obtained from riak_object:to_binary(v1, RObj).
 new_w1(B, K, BinObj) when is_binary(B), is_binary(K), is_binary(BinObj) ->
-    KLen = byte_size(K),
-    BLen = byte_size(B),
-    <<?MAGIC:8/integer, ?W1_VER:8/integer,
+   KLen = byte_size(K),
+   BLen = byte_size(B),
+   <<?MAGIC:8/integer, ?W1_VER:8/integer,
       BLen:32/integer, B:BLen/binary,
       KLen:32/integer, K:KLen/binary, BinObj/binary>>.
 
@@ -826,9 +843,14 @@ to_wire(w1, Objects) when is_list(Objects) ->
     BObjs = [to_wire(w1,O) || O <- Objects],
     term_to_binary(BObjs);
 to_wire(w1, Object) when not is_binary(Object) ->
-    B = riak_object:bucket(Object),
     K = riak_object:key(Object),
-    to_wire(w1, B, K, Object).
+    case riak_object:bucket(Object) of
+        {T, B} -> 
+            lager:debug("encoding typed bucket: t:~p, b:~p, k:~p", [T,B,K]),
+            to_wire(w1, {T, B}, K, Object);
+        B ->
+            to_wire(w1, B, K, Object)
+    end.
 
 %% When the wire format is known and objects are packed in a list of binaries
 from_wire(w0, BinObjList) ->
@@ -836,6 +858,24 @@ from_wire(w0, BinObjList) ->
 from_wire(w1, BinObjList) ->
     BinObjs = binary_to_term(BinObjList),
     [from_wire(BObj) || BObj <- BinObjs].
+
+%% @doc Convert from wire format to non-binary riak_object form
+from_wire(<<131, _Rest/binary>>=BinObjTerm) ->
+    binary_to_term(BinObjTerm);
+from_wire(<<?MAGIC:8/integer, ?W1_VER:8/integer,
+            TLen:32/integer, T:TLen/binary,
+            BLen:32/integer, B:BLen/binary,
+            KLen:32/integer, K:KLen/binary, BinObj/binary>>) ->
+    riak_object:from_binary({T, B}, K, BinObj);
+from_wire(<<?MAGIC:8/integer, ?W1_VER:8/integer,
+            BLen:32/integer, B:BLen/binary,
+            KLen:32/integer, K:KLen/binary, BinObj/binary>>) ->
+    riak_object:from_binary(B, K, BinObj);
+from_wire(X) when is_binary(X) ->
+    lager:error("unknown wire format: ~p", [X]),
+    {error, unknown_wire_format};
+from_wire(RObj) ->
+    RObj.
 
 to_wire(w0, _B, _K, <<131,_/binary>>=Bin) ->
     Bin;
@@ -846,6 +886,8 @@ to_wire(w1, B, K, <<131,_/binary>>=Bin) ->
     to_wire(w0, B, K, Bin);
 to_wire(w1, B, K, <<_/binary>>=Bin) ->
     new_w1(B, K, Bin);
+to_wire(w1, {T,B}, K, RObj) ->
+    new_w1({T,B}, K, riak_object:to_binary(v1, RObj));
 to_wire(w1, B, K, RObj) ->
     new_w1(B, K, riak_object:to_binary(v1, RObj));
 to_wire(_W, _B, _K, _RObj) ->
@@ -854,18 +896,6 @@ to_wire(_W, _B, _K, _RObj) ->
 to_wire(Obj) ->
     to_wire(w0, unused, unused, Obj).
 
-%% @doc Convert from wire format to non-binary riak_object form
-from_wire(<<131, _Rest/binary>>=BinObjTerm) ->
-    binary_to_term(BinObjTerm);
-from_wire(<<?MAGIC:8/integer, ?W1_VER:8/integer,
-            BLen:32/integer, B:BLen/binary,
-            KLen:32/integer, K:KLen/binary, BinObj/binary>>) ->
-    riak_object:from_binary(B, K, BinObj);
-from_wire(X) when is_binary(X) ->
-    lager:error("unknown wire format: ~p", [X]),
-    {error, unknown_wire_format};
-from_wire(RObj) ->
-    RObj.
 
 %% @doc BinObjs are in new riak binary object format. If the remote sink
 %%      is storing older non-binary objects, then we need to downconvert
@@ -996,6 +1026,14 @@ do_non_loopback_interfaces_test() ->
     ?assertEqual(false, proplists:is_defined("lo0", Res)),
     ?assertEqual(true, proplists:is_defined("eth0", Res)).
 
+do_wire_list_w1_bucket_type_test() ->
+    Type = <<"type">>,
+    Bucket = <<"0b:foo">>,
+    Key = <<"key">>,
+    RObj = riak_object:new({Type, Bucket}, Key, <<"val">>),
+    Objs = [RObj],
+    Encoded = to_wire(w1, Objs),
+    Decoded = from_wire(w1, Encoded),
+    ?assert(Decoded == Objs).
+
 -endif.
-
-

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -67,12 +67,14 @@
          from_wire/1,
          from_wire/2,
          maybe_downconvert_binary_objs/2,
-         peer_wire_format/1
+         peer_wire_format/1,
+         get_bucket_props_hash/1
         ]).
 
 %% Defines for Wire format encode/decode
 -define(MAGIC, 42). %% as opposed to 131 for Erlang term_to_binary or 51 for riak_object
 -define(W1_VER, 1). %% first non-just-term-to-binary wire format
+-define(BUCKET_TYPES_PROPS, [consistent, datatype, n_val, allow_mult, last_write_wins]).
 
 make_peer_info() ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
@@ -923,6 +925,12 @@ peer_wire_format(Peer) ->
             %% failed RPC call? Assume lowest format
             w0
     end.
+
+get_bucket_props_hash(Props) ->
+   PB = [{Prop, proplists:get_value(Prop, Props)} || Prop <- ?BUCKET_TYPES_PROPS],
+   lager:info("Bucket types props: ~p", [PB]),
+   erlang:phash2(PB). 
+    
 
 %% Some eunit tests
 -ifdef(TEST).


### PR DESCRIPTION
#### Overview

Riak 2.0 brings with it typed buckets -- the ability to create a type and associate a bucket with that type:

https://github.com/basho/riak/issues/362

In order to successfully replicate a typed object from one cluster to another, the type definition must exist and be equal on both clusters. MDC replication must handle the possibility that the type of a given object exists on the replication source cluster, but not on the sink cluster (repl 2 terminology).

At this time, there is no facility to automatically create type across clusters -- for example, create a type that does not exist on the sink cluster -- to facilitate replication happening seemlessly. This could be an avenue to explore.

Additionally, replication must be extended to properly handle typed buckets. This work is assumed to come along with support for typed-bucket replication. "Default" type buckets (legacy buckets in Riak) continue to be automatically replicated as before.

This document discusses 2 possible options for implementing this in replication:

https://gist.github.com/bowrocker/7f0d9d6879493f1ac0e9

This PR implements the second option.
##### Type Checking on the Sink

This option allows typed buckets to be replicated to the sink cluster without any checking on the source. During the do_repl_put on the sink, the bucket is checked. If it has a type, that type is checked for existence, and if it does not exist, the object is dropped, and an error message is printed, and preferably an alarm of some sort is sent.

This option assumes that types should exist on both source and sink clusters, and that the non-existance of a type is an operational error that the user or CSE should take care of. Once the type is created, object of that type will replicate correctly.
###### Pros
- This is the simplest solution. Very few moving parts, very low impact on operations and performance.
###### Cons
- Bandwidth, RTQ space, and processing is wasted when an object whose type does not exist on the sink cluster is replicated.
- The assumption that all types should exist on both sides.
#### Configuration

No new user configuration is introduced. If the sink is not configured with the type of an object being replicated, an error message is printed. It is the responsibility of the user to provision this type on the sink. 
##### Mixed version replication

A new replication protocol version is introduced for bucket type support: {2,1}. The following is supported for each version:

| Source | Sink | Result |
| --- | :-: | --: |
| {2,1} | {2,1} | "default" and user defined typed buckets replicated |
| {2,1} | {2,0} or less | only "default" buckets replicated |
#### Dependencies

This PR depends upon code in the following riak_kv branch to be merged, or the conditional post-commit hook present will not work:

https://github.com/basho/riak_repl/tree/jdb-conditional-postcommit
#### Original PR

https://github.com/basho/riak_repl/pull/477
