### PR TITLE
Integrate fullsync with the background manager

### DIFF
--- a/priv/riak_repl.schema
+++ b/priv/riak_repl.schema
@@ -127,10 +127,10 @@
 %% @doc By default, fullsync replication will try to coordinate with other
 %% riak subsystems that may be contending for the same resources. This will help
 %% to prevent system response degradation under times of heavy load from multiple
-%% background tasks. To disable background coordination, set this parameter to true.
+%% background tasks. To disable background coordination, set this parameter to false.
 %% Enterprise 2.0+.
-{mapping, "mdc.fullsync.skip_bg_manager", "riak_repl.fullsync_skip_background_manager", [
+{mapping, "mdc.fullsync.use_bg_manager", "riak_repl.fullsync_use_background_manager", [
     {datatype, {enum, [true, false]}},
     {level, advanced},
-    {default, false}
+    {default, true}
 ]}.

--- a/priv/riak_repl.schema
+++ b/priv/riak_repl.schema
@@ -131,5 +131,6 @@
 %% Enterprise 2.0+.
 {mapping, "mdc.fullsync.skip_bg_manager", "riak_repl.fullsync_skip_background_manager", [
     {datatype, {enum, [true, false]}},
+    {level, advanced},
     {default, false}
 ]}.

--- a/priv/riak_repl.schema
+++ b/priv/riak_repl.schema
@@ -123,3 +123,13 @@
     {datatype, {duration, s}},
     {default, "15s"}
 ]}.
+
+%% @doc By default, fullsync replication will try to coordinate with other
+%% riak subsystems that may be contending for the same resources. This will help
+%% to prevent system response degradation under times of heavy load from multiple
+%% background tasks. To disable background coordination, set this parameter to true.
+%% Enterprise 2.0+.
+{mapping, "mdc.fullsync.skip_bg_manager", "riak_repl.fullsync_skip_background_manager", [
+    {datatype, {enum, [true, false]}},
+    {default, false}
+]}.

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -688,6 +688,10 @@ start_fssource(Partition2={Partition,_,_} = PartitionVal, Ip, Port, State) ->
                     lager:notice("A fullsync for partition ~p is already in"
                         " progress for ~p", [Partition,
                             riak_repl2_fssource:cluster_name(OtherPid)]);
+                {{max_concurrency, Lock},_ChildSpec} ->
+                    lager:notice("Fullsync for partition ~p postponed"
+                                 " because ~p is at max_concurrency",
+                                 [Partition, Lock]);
                 _ ->
                     lager:error("Failed to start fullsync for partition ~p :"
                         " ~p", [Partition, Reason])

--- a/src/riak_repl2_fssource.erl
+++ b/src/riak_repl2_fssource.erl
@@ -1,6 +1,6 @@
 -module(riak_repl2_fssource).
 -include("riak_repl.hrl").
--include_lib("riak_core/include/riak_core_locks.hrl").
+-include_lib("riak_kv/include/riak_kv_vnode.hrl").
 
 -behaviour(gen_server).
 %% API
@@ -311,26 +311,14 @@ connect(IP, Strategy, Partition) ->
     end.
 
 %% @private
-%% @doc Return true iff neither of the "skip background manager" configuration
-%%      settings are defined as anything other than false. 'skip_background_manager'
-%%      turns off all use of bg-mgr. 'fullsync_skip_background_manager' only stops
-%%      fullsync from using bg-mgr.
--spec use_bg_mgr() -> boolean().
-use_bg_mgr() ->
-    %% note we're tolerant here of any non-boolean value as well. Iff it's 'false', we don't skip.
-    GlobalSkip = app_helper:get_env(riak_core, skip_background_manager, false) =/= false,
-    FSSkip = app_helper:get_env(riak_repl, fullsync_skip_background_manager, false) =/= false,
-    not (GlobalSkip orelse FSSkip).
-
-%% @private
 %% @doc Unless skipping the background manager, try to acquire the per-vnode lock.
-%%      Sets our task meta-data in the lock as 'aae_rebuild', which is useful for
+%%      Sets our task meta-data in the lock as 'repl_fullsync', which is useful for
 %%      seeing what's holding the lock via @link riak_core_background_mgr:ps/0.
 -spec maybe_get_vnode_lock(SrcPartition::integer()) -> ok | {error, Reason::term()}.
 maybe_get_vnode_lock(SrcPartition) ->
-    Lock = ?VNODE_LOCK(riak_kv_vnode, SrcPartition),
-    case use_bg_mgr() of
+    case riak_core_bg_manager:use_bg_mgr(riak_repl, fullsync_use_background_manager) of
         true  ->
+            Lock = ?VNODE_LOCK(SrcPartition),
             case riak_core_bg_manager:get_lock(Lock, self(), [{task, repl_fullsync}]) of
                 {ok, _Ref} ->
                     ok;
@@ -339,6 +327,5 @@ maybe_get_vnode_lock(SrcPartition) ->
                     {error, Reason}
             end;
         false ->
-            lager:debug("AAE tree rebuild is skipping the background manager vnode lock: ~p", [Lock]),
             ok
     end.

--- a/src/riak_repl_keylist_server.erl
+++ b/src/riak_repl_keylist_server.erl
@@ -160,20 +160,31 @@ wait_for_partition({partition, Partition}, State=#state{work_dir=WorkDir}) ->
     lager:info("Full-sync with site ~p; doing fullsync for ~p",
         [State#state.sitename, Partition]),
 
-    lager:info("Full-sync with site ~p; building keylist for ~p",
-        [State#state.sitename, Partition]),
-    %% client wants keylist for this partition
-    TheirKeyListFn = riak_repl_util:keylist_filename(WorkDir, Partition, theirs),
-    KeyListFn = riak_repl_util:keylist_filename(WorkDir, Partition, ours),
-    {ok, KeyListPid} = riak_repl_fullsync_helper:start_link(self()),
-    {ok, KeyListRef} = riak_repl_fullsync_helper:make_keylist(KeyListPid,
-                                                                 Partition,
-                                                                 KeyListFn),
-    {next_state, build_keylist, State#state{kl_pid=KeyListPid,
-            kl_ref=KeyListRef, kl_fn=KeyListFn,
-            partition=Partition, partition_start=os:timestamp(), stage_start=os:timestamp(),
-            pending_acks=0, generator_paused=false,
-            their_kl_fn=TheirKeyListFn, their_kl_fh=undefined}};
+    %% Possibly try to obtain the per-vnode lock before connecting.
+    %% If we return error, we expect the coordinator to start us again later.
+    case riak_repl_util:maybe_get_vnode_lock(Partition) of
+        ok ->
+            lager:info("Full-sync with site ~p; building keylist for ~p",
+                       [State#state.sitename, Partition]),
+            %% client wants keylist for this partition
+            TheirKeyListFn = riak_repl_util:keylist_filename(WorkDir, Partition, theirs),
+            KeyListFn = riak_repl_util:keylist_filename(WorkDir, Partition, ours),
+            {ok, KeyListPid} = riak_repl_fullsync_helper:start_link(self()),
+            {ok, KeyListRef} = riak_repl_fullsync_helper:make_keylist(KeyListPid,
+                                                                      Partition,
+                                                                      KeyListFn),
+            {next_state, build_keylist, State#state{kl_pid=KeyListPid,
+                                                    kl_ref=KeyListRef, kl_fn=KeyListFn,
+                                                    partition=Partition,
+                                                    partition_start=os:timestamp(),
+                                                    stage_start=os:timestamp(),
+                                                    pending_acks=0, generator_paused=false,
+                                                    their_kl_fn=TheirKeyListFn,
+                                                    their_kl_fh=undefined}};
+        {error, Reason} ->
+            %% the vnode is probably busy. Quit all the way back.
+            {stop, Reason, state}
+    end;
 %% Unknown event (ignored)
 wait_for_partition(Event, State) ->
     lager:debug("Full-sync with site ~p; ignoring event ~p",

--- a/src/riak_repl_keylist_server.erl
+++ b/src/riak_repl_keylist_server.erl
@@ -183,7 +183,7 @@ wait_for_partition({partition, Partition}, State=#state{work_dir=WorkDir}) ->
                                                     their_kl_fh=undefined}};
         {error, Reason} ->
             %% the vnode is probably busy. Quit all the way back.
-            {stop, Reason, state}
+            {stop, Reason, State}
     end;
 %% Unknown event (ignored)
 wait_for_partition(Event, State) ->

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -958,6 +958,10 @@ maybe_get_vnode_lock(SrcPartition) ->
                 {ok, _Ref} ->
                     ok;
                 max_concurrency ->
+                    lager:debug("max_concurrency for lock ~p: info ~p locks ~p",
+                                [SrcPartition,
+                                 riak_core_bg_manager:lock_info(Lock),
+                                 riak_core_bg_manager:all_locks(Lock)]),
                     Reason = {max_concurrency, Lock},
                     {error, Reason}
             end;


### PR DESCRIPTION
NOTE: DO NOT MERGE YET. requires two additional PR from riak_core...

The riak_core background manager PR is here: https://github.com/basho/riak_core/pull/475

The riak_core integration with handoff and AAE is here: https://github.com/basho/riak_core/pull/484

The background manager allows subsystems to coordinate with locks (and tokens) in a non-blocking API when desired. In our case, we've seen several customer support issues related to a production cluster being overloaded by the combined weight of MDC fullsync replication in combination with either handoff, or AAE tree rebuilds (or all three!).

Each of these subsystems is being taught, for 2.0, to "take" a lock on the kv vnode/partition before it does a fold over that partition. Locks are returned when the process dies or exists normally. Each subsystem (at this point in time) is coded to keep working on other partitions if one partition is denied a lock via the return value of max_concurrency, which means progress is made even when one partition is busy.

The fullsync coordinator is tolerant of fullsync source processes "crashing" if they return the right kind of error. This PR adds another error code that signals it's busy; the coodinator will just move that partition to the end of the TODO list and try it later. This applies to both key_list and aae strategies because ultimately they both fold over the vnode after creating a bloom filter.

Use of this feature can be bypassed in production. Besides a global skill switch on the background manager itself, the MDC configuration supports a new parameter: fullsync.skip_bg_manager, which defaults to false. Setting it to true will not call the background manager and proceed like it used to.
