### PR TITLE
Typed Bucket Replication Support

### DIFF
--- a/include/riak_repl.hrl
+++ b/include/riak_repl.hrl
@@ -32,6 +32,10 @@
 -define(RETRY_AAE_LOCKED_INTERVAL, 1000).
 -define(DEFAULT_FULLSYNC_STRATEGY, keylist). %% keylist | aae
 -define(LOG_USER_CMD(Msg, Params), lager:notice("[user] " ++ Msg, Params)).
+%% the following are keys for bucket types related meta data
+-define(BT_META_TYPED_BUCKET, typed_bucket).
+-define(BT_META_TYPE, bucket_type).
+-define(BT_META_PROPS_HASH, properties_hash_val).
 
 -type(ip_addr_str() :: string()).
 -type(ip_portnum() :: non_neg_integer()).

--- a/include/riak_repl.hrl
+++ b/include/riak_repl.hrl
@@ -57,7 +57,11 @@
 %% Also see analagous binary_version() in riak_object, which is carried
 %% inside the wire format in "BinObj". w0 implies v0. w1 imples v1.
 -type(wire_version() :: w0   %% simple term_to_binary() legacy encoding
-                      | w1). %% <<?MAGIC:8/integer, 1:8/integer,
+                      | w1   %% <<?MAGIC:8/integer, 1:8/integer,
+                             %% BLen:32/integer, B:BLen/binary,
+                             %% KLen:32/integer, K:KLen/binary, BinObj/binary>>.
+                      | w2). %% <<?MAGIC:8/integer, ?W2_VER:8/integer,
+                             %% TLen:32/integer, T:TLen/binary,
                              %% BLen:32/integer, B:BLen/binary,
                              %% KLen:32/integer, K:KLen/binary, BinObj/binary>>.
 

--- a/include/riak_repl.hrl
+++ b/include/riak_repl.hrl
@@ -56,6 +56,8 @@
 %% the to_wire() and from_wire() operations, see riak_repl_util.erl.
 %% Also see analagous binary_version() in riak_object, which is carried
 %% inside the wire format in "BinObj". w0 implies v0. w1 imples v1.
+%% w2 still uses v1, but supports encoding the type information
+%% for bucket types.
 -type(wire_version() :: w0   %% simple term_to_binary() legacy encoding
                       | w1   %% <<?MAGIC:8/integer, 1:8/integer,
                              %% BLen:32/integer, B:BLen/binary,

--- a/src/riak_repl.erl
+++ b/src/riak_repl.erl
@@ -6,6 +6,7 @@
 -export([start/0, stop/0]).
 -export([install_hook/0, uninstall_hook/0]).
 -export([fixup/2]).
+-export([conditional_hook/3]).
 
 start() ->
     riak_core_util:start_app_deps(riak_repl),
@@ -16,13 +17,25 @@ stop() ->
     application:stop(riak_repl).
 
 install_hook() ->
+    riak_kv_hooks:add_conditional_postcommit({?MODULE, conditional_hook}),
     riak_core_bucket:append_bucket_defaults([{repl, true}]),
     ok.
 
 uninstall_hook() ->
+    riak_kv_hooks:del_conditional_postcommit({?MODULE, conditional_hook}),
     %% Cannot remove bucket defaults, best we can do is disable
     riak_core_bucket:append_bucket_defaults([{repl, false}]),
     ok.
+
+conditional_hook(_BucketType, _Bucket, BucketProps) ->
+    RTEnabled = app_helper:get_env(riak_repl, rtenabled, false),
+    BucketEnabled = not lists:member({repl, false}, BucketProps),
+    case RTEnabled and BucketEnabled of
+        true ->
+            riak_repl_util:get_hooks_for_modes();
+        false ->
+            false
+    end.
 
 fixup(_Bucket, BucketProps) ->
     CleanPostcommit = strip_postcommit(BucketProps),

--- a/src/riak_repl2_rt.erl
+++ b/src/riak_repl2_rt.erl
@@ -151,10 +151,8 @@ postcommit(RObj) ->
             
             BinObjs = case orddict:fetch(?BT_META_TYPED_BUCKET, Meta) of
                 false ->
-                    lager:debug("encoding w1 format object"),
                     riak_repl_util:to_wire(w1, Objects);
                 true ->
-                    lager:debug("encoding w2 format object"),
                     riak_repl_util:to_wire(w2, Objects)
             end,
             %% try the proxy first, avoids race conditions with unregister()
@@ -234,11 +232,9 @@ set_bucket_meta(Obj) ->
     case riak_object:bucket(Obj) of
         {Type, _B} ->
             PropsHash = riak_repl_util:get_bucket_props_hash(riak_core_bucket_type:get(Type)),
-            lager:debug("typed bucket, setting meta data: Type:~p, HashProps:~p", [Type, PropsHash]),
             M1 = orddict:store(?BT_META_TYPED_BUCKET, true, M),
             M2 = orddict:store(?BT_META_TYPE, Type, M1),
             orddict:store(?BT_META_PROPS_HASH, PropsHash, M2);
         _B -> 
-            lager:debug("un-typed bucket, setting typed_bucket to false"),
             orddict:store(?BT_META_TYPED_BUCKET, false, M)
     end.

--- a/src/riak_repl2_rt.erl
+++ b/src/riak_repl2_rt.erl
@@ -2,6 +2,8 @@
 %% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
 -module(riak_repl2_rt).
 
+-include("riak_repl.hrl").
+
 %% @doc Realtime replication
 %%
 %% High level responsibility...
@@ -15,6 +17,8 @@
          terminate/2, code_change/3]).
 
 -define(SERVER, ?MODULE).
+
+
 -record(state, {sinks = []}).
 
 %% API - is there any state? who watches ring events?
@@ -223,10 +227,10 @@ set_bucket_meta(Obj) ->
         {Type, _B} ->
             PropsHash = riak_repl_util:get_bucket_props_hash(riak_core_bucket_type:get(Type)),
             lager:debug("typed bucket, setting meta data: Type:~p, HashProps:~p", [Type, PropsHash]),
-            M1 = orddict:store(typed_bucket, true, M),
-            M2 = orddict:store(type, Type, M1),
-            orddict:store(props_hash, PropsHash, M2);
+            M1 = orddict:store(?BT_META_TYPED_BUCKET, true, M),
+            M2 = orddict:store(?BT_META_TYPE, Type, M1),
+            orddict:store(?BT_META_PROPS_HASH, PropsHash, M2);
         _B -> 
             lager:debug("un-typed bucket, setting typed_bucket to false"),
-            orddict:store(typed_bucket, false, M)
+            orddict:store(?BT_META_TYPED_BUCKET, false, M)
     end.

--- a/src/riak_repl2_rt.erl
+++ b/src/riak_repl2_rt.erl
@@ -151,11 +151,11 @@ postcommit(RObj) ->
             
             BinObjs = case orddict:fetch(?BT_META_TYPED_BUCKET, Meta) of
                 false ->
-                     lager:debug("encoding w1 format object"),
-                     riak_repl_util:to_wire(w1, Objects);
+                    lager:debug("encoding w1 format object"),
+                    riak_repl_util:to_wire(w1, Objects);
                 true ->
-                     lager:debug("encoding w2 format object"),
-                     riak_repl_util:to_wire(w2, Objects)
+                    lager:debug("encoding w2 format object"),
+                    riak_repl_util:to_wire(w2, Objects)
             end,
             %% try the proxy first, avoids race conditions with unregister()
             %% during shutdown

--- a/src/riak_repl2_rt.erl
+++ b/src/riak_repl2_rt.erl
@@ -148,7 +148,15 @@ postcommit(RObj) ->
         Objects0 when is_list(Objects0) ->
             Objects = Objects0 ++ [RObj],
             Meta = set_bucket_meta(RObj),
-            BinObjs = riak_repl_util:to_wire(w1, Objects),
+            
+            BinObjs = case orddict:fetch(?BT_META_TYPED_BUCKET, Meta) of
+                false ->
+                     lager:debug("encoding w1 format object"),
+                     riak_repl_util:to_wire(w1, Objects);
+                true ->
+                     lager:debug("encoding w2 format object"),
+                     riak_repl_util:to_wire(w2, Objects)
+            end,
             %% try the proxy first, avoids race conditions with unregister()
             %% during shutdown
             case whereis(riak_repl2_rtq_proxy) of

--- a/src/riak_repl2_rtsink_conn.erl
+++ b/src/riak_repl2_rtsink_conn.erl
@@ -246,7 +246,6 @@ recv(TcpBin, State = #state{transport = T, socket = S}) ->
             send_heartbeat(T, S),
             recv(Cont, State#state{hb_last = os:timestamp()});
         {ok, {objects_and_meta, {Seq, BinObjs, Meta}}, Cont} ->
-            lager:info("get objects_and_meta"),
             recv(Cont, do_write_objects(Seq, {BinObjs, Meta}, State));
         {error, Reason} ->
             %% TODO: Log Something bad happened

--- a/src/riak_repl2_rtsink_conn.erl
+++ b/src/riak_repl2_rtsink_conn.erl
@@ -56,8 +56,8 @@
 
 %% Register with service manager
 sync_register_service() ->
-    %% version {2,1} supports typed bucket replication
-    ProtoPrefs = {realtime,[{2,1}, {2,0}, {1,4}, {1,1}, {1,0}]},
+    %% version {3,0} supports typed bucket replication
+    ProtoPrefs = {realtime,[{3,0}, {2,0}, {1,4}, {1,1}, {1,0}]},
     TcpOptions = [{keepalive, true}, % find out if connection is dead, this end doesn't send
                   {packet, 0},
                   {nodelay, true}],
@@ -246,6 +246,7 @@ recv(TcpBin, State = #state{transport = T, socket = S}) ->
             send_heartbeat(T, S),
             recv(Cont, State#state{hb_last = os:timestamp()});
         {ok, {objects_and_meta, {Seq, BinObjs, Meta}}, Cont} ->
+            lager:info("get objects_and_meta"),
             recv(Cont, do_write_objects(Seq, {BinObjs, Meta}, State));
         {error, Reason} ->
             %% TODO: Log Something bad happened

--- a/src/riak_repl2_rtsink_conn.erl
+++ b/src/riak_repl2_rtsink_conn.erl
@@ -416,7 +416,7 @@ write_object(Meta) ->
             case riak_core_bucket_type:get(BucketType) of
                 undefined ->
                     lager:debug("No properties found for bucket type:~p", [BucketType]),    
-	            false;
+                    false;
                 {error, _T} ->
                     lager:debug("No properties found for bucket type:~p", [BucketType]),
                     false;
@@ -425,7 +425,7 @@ write_object(Meta) ->
                     Source = orddict:fetch(?BT_META_PROPS_HASH, Meta),
                     lager:debug("SourcePropsHash:~p, SinkPropsHash:~p", [Source, Sink]),
                     Source == Sink
-	    end
+            end
     end.
 
 

--- a/src/riak_repl2_rtsink_conn.erl
+++ b/src/riak_repl2_rtsink_conn.erl
@@ -289,10 +289,10 @@ do_write_objects(Seq, BinObjsMeta, State = #state{max_pending = MaxPending,
     case make_donefun(BinObjsMeta, Me, Ref, Seq) of
         {DoneFun, BinObjs, Meta} ->
             case maybe_write_object(Meta) of
-            true ->
-                riak_repl2_rtsink_helper:write_objects(Helper, BinObjs, DoneFun, Ver);
-            false ->
-                lager:info("Bucket is of a type that is not equal on both the source and sink; not writing object.")
+                true ->
+                    riak_repl2_rtsink_helper:write_objects(Helper, BinObjs, DoneFun, Ver);
+                false ->
+                    lager:info("Bucket is of a type that is not equal on both the source and sink; not writing object.")
             end;
         {DoneFun, BinObjs} ->
             %% this is for backwards compatibility with Repl version before metadata support (> 1.4)
@@ -413,6 +413,7 @@ maybe_write_object(Meta) ->
         false -> true;
         true ->
             BucketType = orddict:fetch(?BT_META_TYPE, Meta),
+            lager:info("Bucket type on sink:~p", [BucketType]),
             case riak_core_bucket_type:get(BucketType) of
                 undefined ->
                     false;

--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -128,7 +128,7 @@ init([Remote]) ->
     % TODO: expand version list or remove comment when we no
     % longer support 1.3.1
     % prefered version list: [{2,0}, {1,5}, {1,1}, {1,0}]
-    ClientSpec = {{realtime,[{2,0}, {1,5}]}, {TcpOptions, ?MODULE, self()}},
+    ClientSpec = {{realtime,[{2,1}, {1,5}]}, {TcpOptions, ?MODULE, self()}},
 
     %% Todo: check for bad remote name
     lager:debug("connecting to remote ~p", [Remote]),
@@ -229,7 +229,8 @@ handle_call({connected, Socket, Transport, EndPoint, Proto}, _From,
                                  address = EndPoint,
                                  proto = Proto,
                                  peername = peername(Transport, Socket),
-                                 helper_pid = HelperPid},
+                                 helper_pid = HelperPid,
+                                 ver = Ver},
             lager:info("Established realtime connection to site ~p address ~s",
                       [Remote, peername(State2)]),
 
@@ -416,7 +417,6 @@ schedule_heartbeat(State = #state{hb_interval_tref = undefined, hb_interval = HB
  
 schedule_heartbeat(State) ->
     State.
-
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -128,7 +128,7 @@ init([Remote]) ->
     % TODO: expand version list or remove comment when we no
     % longer support 1.3.1
     % prefered version list: [{2,0}, {1,5}, {1,1}, {1,0}]
-    ClientSpec = {{realtime,[{2,1}, {1,5}]}, {TcpOptions, ?MODULE, self()}},
+    ClientSpec = {{realtime,[{3,0}, {2,0}, {1,5}]}, {TcpOptions, ?MODULE, self()}},
 
     %% Todo: check for bad remote name
     lager:debug("connecting to remote ~p", [Remote]),

--- a/src/riak_repl2_rtsource_helper.erl
+++ b/src/riak_repl2_rtsource_helper.erl
@@ -125,16 +125,15 @@ maybe_send(Transport, Socket, QEntry, State) ->
             State;
         false ->
             case State#state.proto of 
-                Ver when Ver =:= {2,1} ->
+                Ver when Ver =:= {3,0} ->
                     encode_and_send(QEntry, Remote, Transport, Socket, State);
 		_ ->
                     case is_bucket_typed(Meta) of
                         false ->
-                            State2 = encode_and_send(QEntry, Remote, Transport, Socket, State),
-                            State2;
+                            encode_and_send(QEntry, Remote, Transport, Socket, State);
                         true ->
    	                    lager:debug("Negotiated protocol version:~p does not support typed buckets, not sending"),
-			    State
+                            State
                     end
             end
     end.
@@ -142,7 +141,7 @@ maybe_send(Transport, Socket, QEntry, State) ->
 encode_and_send(QEntry, Remote, Transport, Socket, State) ->
     QEntry2 = merge_forwards_and_routed_meta(QEntry, Remote),
     {Encoded, State2} = encode(QEntry2, State),
-    lager:debug("Forwarding to ~p with new data: ~p derived from ~p", [State#state.remote, QEntry2, QEntry]),
+    lager:info("Forwarding to ~p with new data: ~p derived from ~p", [State#state.remote, QEntry2, QEntry]),
     Transport:send(Socket, Encoded),
     State2.
 

--- a/src/riak_repl2_rtsource_helper.erl
+++ b/src/riak_repl2_rtsource_helper.erl
@@ -130,12 +130,13 @@ maybe_send(Transport, Socket, QEntry, State) ->
 		_ ->
                     case is_bucket_typed(Meta) of
                         false ->
-                            encode_and_send(QEntry, Remote, Transport, Socket, State);
+                            State2 = encode_and_send(QEntry, Remote, Transport, Socket, State),
+                            State2;
                         true ->
-   	                    lager:info("Negotiated protocol version:~p does not support typed buckets, not sending")
+   	                    lager:debug("Negotiated protocol version:~p does not support typed buckets, not sending"),
+			    State
                     end
-            end,
-	    State
+            end
     end.
 
 encode_and_send(QEntry, Remote, Transport, Socket, State) ->
@@ -162,7 +163,7 @@ get_routed(Meta) ->
     meta_get(routed_clusters, [], Meta).
 
 is_bucket_typed(Meta) ->
-    meta_get(typed_bucket, [], Meta).
+    meta_get(?BT_META_TYPED_BUCKET, [], Meta).
 
 meta_get(Key, Default, Meta) ->
     case orddict:find(Key, Meta) of

--- a/src/riak_repl2_rtsource_helper.erl
+++ b/src/riak_repl2_rtsource_helper.erl
@@ -125,7 +125,7 @@ maybe_send(Transport, Socket, QEntry, State) ->
             State;
         false ->
             case State#state.proto of 
-                Ver when Ver =:= {3,0} ->
+                {Major, _Minor} when Major >= 3 ->
                     encode_and_send(QEntry, Remote, Transport, Socket, State);
                 _ ->
                     case is_bucket_typed(Meta) of

--- a/src/riak_repl2_rtsource_helper.erl
+++ b/src/riak_repl2_rtsource_helper.erl
@@ -124,12 +124,27 @@ maybe_send(Transport, Socket, QEntry, State) ->
             lager:debug("Did not forward to ~p; destination already in routed list", [Remote]),
             State;
         false ->
-            QEntry2 = merge_forwards_and_routed_meta(QEntry, Remote),
-            {Encoded, State2} = encode(QEntry2, State),
-            lager:debug("Forwarding to ~p with new data: ~p derived from ~p", [State#state.remote, QEntry2, QEntry]),
-            Transport:send(Socket, Encoded),
-            State2
+            case State#state.proto of 
+                Ver when Ver =:= {2,1} ->
+                    encode_and_send(QEntry, Remote, Transport, Socket, State);
+		_ ->
+                    case is_bucket_typed(Meta) of
+                        false ->
+                            encode_and_send(QEntry, Remote, Transport, Socket, State);
+                        true ->
+   	                    lager:info("Negotiated protocol version:~p does not support typed buckets, not sending")
+                    end
+            end,
+	    State
     end.
+
+encode_and_send(QEntry, Remote, Transport, Socket, State) ->
+    QEntry2 = merge_forwards_and_routed_meta(QEntry, Remote),
+    {Encoded, State2} = encode(QEntry2, State),
+    lager:debug("Forwarding to ~p with new data: ~p derived from ~p", [State#state.remote, QEntry2, QEntry]),
+    Transport:send(Socket, Encoded),
+    State2.
+
 
 encode({Seq, _NumObjs, BinObjs, Meta}, State = #state{proto = Ver}) when Ver < {2,0} ->
     Skips = orddict:fetch(skip_count, Meta),
@@ -140,11 +155,14 @@ encode({Seq, _NumObjs, BinObjs, Meta}, State = #state{proto = Ver}) when Ver < {
     Encoded = riak_repl2_rtframe:encode(objects, {Seq2, BinObjs2}),
     State2 = State#state{v1_offset = Offset, v1_seq_map = V1Map},
     {Encoded, State2};
-encode({Seq, _NumbOjbs, BinObjs, Meta}, State = #state{proto = {2,0}}) ->
+encode({Seq, _NumbOjbs, BinObjs, Meta}, State = #state{proto = Ver}) when Ver >= {2,0} ->
     {riak_repl2_rtframe:encode(objects_and_meta, {Seq, BinObjs, Meta}), State}.
 
 get_routed(Meta) ->
     meta_get(routed_clusters, [], Meta).
+
+is_bucket_typed(Meta) ->
+    meta_get(typed_bucket, [], Meta).
 
 meta_get(Key, Default, Meta) ->
     case orddict:find(Key, Meta) of

--- a/src/riak_repl2_rtsource_helper.erl
+++ b/src/riak_repl2_rtsource_helper.erl
@@ -127,12 +127,12 @@ maybe_send(Transport, Socket, QEntry, State) ->
             case State#state.proto of 
                 Ver when Ver =:= {3,0} ->
                     encode_and_send(QEntry, Remote, Transport, Socket, State);
-		_ ->
+                _ ->
                     case is_bucket_typed(Meta) of
                         false ->
                             encode_and_send(QEntry, Remote, Transport, Socket, State);
                         true ->
-   	                    lager:debug("Negotiated protocol version:~p does not support typed buckets, not sending"),
+                            lager:debug("Negotiated protocol version:~p does not support typed buckets, not sending"),
                             State
                     end
             end
@@ -141,7 +141,7 @@ maybe_send(Transport, Socket, QEntry, State) ->
 encode_and_send(QEntry, Remote, Transport, Socket, State) ->
     QEntry2 = merge_forwards_and_routed_meta(QEntry, Remote),
     {Encoded, State2} = encode(QEntry2, State),
-    lager:info("Forwarding to ~p with new data: ~p derived from ~p", [State#state.remote, QEntry2, QEntry]),
+    lager:debug("Forwarding to ~p with new data: ~p derived from ~p", [State#state.remote, QEntry2, QEntry]),
     Transport:send(Socket, Encoded),
     State2.
 

--- a/src/riak_repl_cs.erl
+++ b/src/riak_repl_cs.erl
@@ -58,10 +58,7 @@ skip_common_bucket(Bucket) ->
 
 -spec skip_block_object(riak_object:riak_object()) -> boolean().
 skip_block_object(Object) ->
-    Bucket = case riak_object:bucket(Object) of
-        {_T, B} -> B;
-        B -> B
-    end,
+    Bucket = riak_object:bucket(Object),
     block_bucket(Bucket).
 
 -spec block_bucket(binary()) -> boolean().

--- a/src/riak_repl_cs.erl
+++ b/src/riak_repl_cs.erl
@@ -58,7 +58,11 @@ skip_common_bucket(Bucket) ->
 
 -spec skip_block_object(riak_object:riak_object()) -> boolean().
 skip_block_object(Object) ->
-    block_bucket(riak_object:bucket(Object)).
+    Bucket = case riak_object:bucket(Object) of
+        {_T, B} -> B;
+        B -> B
+    end,
+    block_bucket(Bucket).
 
 -spec block_bucket(binary()) -> boolean().
 block_bucket(<<?BLOCK_BUCKET_PREFIX, _Rest/binary>>) ->

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -111,10 +111,7 @@ get_partitions(Ring) ->
             riak_core_ring:all_owners(riak_core_ring:upgrade(Ring))]).
 
 do_repl_put(Object) ->
-    B = case riak_object:bucket(Object) of
-        {_Type, Bucket} -> Bucket;
-        Bucket -> Bucket
-    end,
+    B = riak_object:bucket(Object),
     K = riak_object:key(Object),
     case repl_helper_recv(Object) of
         ok ->
@@ -198,10 +195,7 @@ repl_helper_recv([{App, Mod}|T], Object) ->
     end.
 
 repl_helper_send(Object, C) ->
-    B = case riak_object:bucket(Object) of
-        {_T, Bucket} -> Bucket;
-        Bucket -> Bucket
-    end,
+    B = riak_object:bucket(Object),
     case proplists:get_value(repl, C:get_bucket(B)) of
         Val when Val==true; Val==fullsync; Val==both ->
             case application:get_env(riak_core, repl_helper) of
@@ -687,10 +681,7 @@ proxy_get_active() ->
 
 log_dropped_realtime_obj(Obj) ->
     DroppedKey = riak_object:key(Obj),
-    DroppedBucket = case riak_object:bucket(Obj) of
-        {_T, B} -> B;
-        B -> B
-    end,
+    DroppedBucket = riak_object:bucket(Obj),
     lager:info("REPL dropped object: ~p ~p",
                [ DroppedBucket, DroppedKey]).
 

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -67,12 +67,14 @@
          from_wire/1,
          from_wire/2,
          maybe_downconvert_binary_objs/2,
-         peer_wire_format/1
+         peer_wire_format/1,
+         get_bucket_props_hash/1
         ]).
 
 %% Defines for Wire format encode/decode
 -define(MAGIC, 42). %% as opposed to 131 for Erlang term_to_binary or 51 for riak_object
 -define(W1_VER, 1). %% first non-just-term-to-binary wire format
+-define(BUCKET_TYPES_PROPS, [consistent, datatype, n_val, allow_mult, last_write_wins]).
 
 make_peer_info() ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
@@ -194,7 +196,10 @@ repl_helper_recv([{App, Mod}|T], Object) ->
     end.
 
 repl_helper_send(Object, C) ->
-    B = riak_object:bucket(Object),
+    B = case riak_object:bucket(Object) of
+        {Bucket, _T} -> Bucket;
+        Bucket -> Bucket
+    end,
     case proplists:get_value(repl, C:get_bucket(B)) of
         Val when Val==true; Val==fullsync; Val==both ->
             case application:get_env(riak_core, repl_helper) of
@@ -680,7 +685,10 @@ proxy_get_active() ->
 
 log_dropped_realtime_obj(Obj) ->
     DroppedKey = riak_object:key(Obj),
-    DroppedBucket = riak_object:bucket(Obj),
+    DroppedBucket = case riak_object:bucket(Obj) of
+        {_T, B} -> B;
+        B -> B
+    end,
     lager:info("REPL dropped object: ~p ~p",
                [ DroppedBucket, DroppedKey]).
 
@@ -795,13 +803,24 @@ encode_obj_msg(V, {Cmd, RObj}) ->
             term_to_binary({Cmd, BObj})
     end.
 
+%% @doc Create binary wire formatted replication blob for riak 2.0+, complete with
+%%      possible type, bucket and key for reconstruction on the other end. BinObj should be
+%%      in the new format as obtained from riak_object:to_binary(v1, RObj).
+new_w1({T, B}, K, BinObj) when is_binary(B), is_binary(T), is_binary(K), is_binary(BinObj) ->
+    KLen = byte_size(K),
+    BLen = byte_size(B),
+    TLen = byte_size(T),
+    <<?MAGIC:8/integer, ?W1_VER:8/integer,
+      TLen:32/integer, T:TLen/binary,
+      BLen:32/integer, B:BLen/binary,
+      KLen:32/integer, K:KLen/binary, BinObj/binary>>;
 %% @doc Create a new binary wire formatted replication blob, complete with
 %%      bucket and key for reconstruction on the other end. BinObj should be
 %%      in the new format as obtained from riak_object:to_binary(v1, RObj).
 new_w1(B, K, BinObj) when is_binary(B), is_binary(K), is_binary(BinObj) ->
-    KLen = byte_size(K),
-    BLen = byte_size(B),
-    <<?MAGIC:8/integer, ?W1_VER:8/integer,
+   KLen = byte_size(K),
+   BLen = byte_size(B),
+   <<?MAGIC:8/integer, ?W1_VER:8/integer,
       BLen:32/integer, B:BLen/binary,
       KLen:32/integer, K:KLen/binary, BinObj/binary>>.
 
@@ -826,9 +845,14 @@ to_wire(w1, Objects) when is_list(Objects) ->
     BObjs = [to_wire(w1,O) || O <- Objects],
     term_to_binary(BObjs);
 to_wire(w1, Object) when not is_binary(Object) ->
-    B = riak_object:bucket(Object),
     K = riak_object:key(Object),
-    to_wire(w1, B, K, Object).
+    case riak_object:bucket(Object) of
+        {T, B} -> 
+            lager:debug("encoding typed bucket: t:~p, b:~p, k:~p", [T,B,K]),
+            to_wire(w1, {T, B}, K, Object);
+        B ->
+            to_wire(w1, B, K, Object)
+    end.
 
 %% When the wire format is known and objects are packed in a list of binaries
 from_wire(w0, BinObjList) ->
@@ -836,6 +860,27 @@ from_wire(w0, BinObjList) ->
 from_wire(w1, BinObjList) ->
     BinObjs = binary_to_term(BinObjList),
     [from_wire(BObj) || BObj <- BinObjs].
+
+%% @doc Convert from wire format to non-binary riak_object form
+from_wire(<<131, _Rest/binary>>=BinObjTerm) ->
+    binary_to_term(BinObjTerm);
+from_wire(<<?MAGIC:8/integer, ?W1_VER:8/integer,
+            TLen:32/integer, T:TLen/binary,
+            BLen:32/integer, B:BLen/binary,
+            KLen:32/integer, K:KLen/binary, BinObj/binary>>) ->
+    case T of
+        <<>> -> 
+            lager:debug("Found zero-length type, decoding default bucket-type"),
+            riak_object:from_binary(B, K, BinObj);
+        _ -> 
+            lager:debug("Found non-zero-length type, decoding non-default bucket-type:~p", [T]),
+            riak_object:from_binary({T, B}, K, BinObj)
+    end;
+from_wire(X) when is_binary(X) ->
+    lager:error("unknown wire format: ~p", [X]),
+    {error, unknown_wire_format};
+from_wire(RObj) ->
+    RObj.
 
 to_wire(w0, _B, _K, <<131,_/binary>>=Bin) ->
     Bin;
@@ -846,26 +891,16 @@ to_wire(w1, B, K, <<131,_/binary>>=Bin) ->
     to_wire(w0, B, K, Bin);
 to_wire(w1, B, K, <<_/binary>>=Bin) ->
     new_w1(B, K, Bin);
+to_wire(w1, {T,B}, K, RObj) ->
+    new_w1({T,B}, K, riak_object:to_binary(v1, RObj));
 to_wire(w1, B, K, RObj) ->
-    new_w1(B, K, riak_object:to_binary(v1, RObj));
+    new_w1({<<>>, B}, K, riak_object:to_binary(v1, RObj));
 to_wire(_W, _B, _K, _RObj) ->
     {error, unsupported_wire_version}.
 
 to_wire(Obj) ->
     to_wire(w0, unused, unused, Obj).
 
-%% @doc Convert from wire format to non-binary riak_object form
-from_wire(<<131, _Rest/binary>>=BinObjTerm) ->
-    binary_to_term(BinObjTerm);
-from_wire(<<?MAGIC:8/integer, ?W1_VER:8/integer,
-            BLen:32/integer, B:BLen/binary,
-            KLen:32/integer, K:KLen/binary, BinObj/binary>>) ->
-    riak_object:from_binary(B, K, BinObj);
-from_wire(X) when is_binary(X) ->
-    lager:error("unknown wire format: ~p", [X]),
-    {error, unknown_wire_format};
-from_wire(RObj) ->
-    RObj.
 
 %% @doc BinObjs are in new riak binary object format. If the remote sink
 %%      is storing older non-binary objects, then we need to downconvert
@@ -893,6 +928,12 @@ peer_wire_format(Peer) ->
             %% failed RPC call? Assume lowest format
             w0
     end.
+
+get_bucket_props_hash(Props) ->
+   PB = [{Prop, proplists:get_value(Prop, Props)} || Prop <- ?BUCKET_TYPES_PROPS],
+   lager:debug("Bucket types props: ~p", [PB]),
+   erlang:phash2(PB). 
+    
 
 %% Some eunit tests
 -ifdef(TEST).
@@ -996,6 +1037,14 @@ do_non_loopback_interfaces_test() ->
     ?assertEqual(false, proplists:is_defined("lo0", Res)),
     ?assertEqual(true, proplists:is_defined("eth0", Res)).
 
+do_wire_list_w1_bucket_type_test() ->
+    Type = <<"type">>,
+    Bucket = <<"0b:foo">>,
+    Key = <<"key">>,
+    RObj = riak_object:new({Type, Bucket}, Key, <<"val">>),
+    Objs = [RObj],
+    Encoded = to_wire(w1, Objs),
+    Decoded = from_wire(w1, Encoded),
+    ?assert(Decoded == Objs).
+
 -endif.
-
-

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -197,7 +197,7 @@ repl_helper_recv([{App, Mod}|T], Object) ->
 
 repl_helper_send(Object, C) ->
     B = case riak_object:bucket(Object) of
-        {Bucket, _T} -> Bucket;
+        {_T, Bucket} -> Bucket;
         Bucket -> Bucket
     end,
     case proplists:get_value(repl, C:get_bucket(B)) of
@@ -877,7 +877,7 @@ from_wire(<<?MAGIC:8/integer, ?W1_VER:8/integer,
             riak_object:from_binary({T, B}, K, BinObj)
     end;
 from_wire(X) when is_binary(X) ->
-    lager:error("unknown wire format: ~p", [X]),
+    lager:error("An unknown replicaion wire format has been detected: ~p", [X]),
     {error, unknown_wire_format};
 from_wire(RObj) ->
     RObj.
@@ -932,6 +932,8 @@ peer_wire_format(Peer) ->
 get_bucket_props_hash(Props) ->
    PB = [{Prop, proplists:get_value(Prop, Props)} || Prop <- ?BUCKET_TYPES_PROPS],
    lager:debug("Bucket types props: ~p", [PB]),
+   %% Returning a hash of the properties to avoid sending the whole term over the wire.
+   %% A hash will be taken on the sink side of the sink's bucket type, and compared
    erlang:phash2(PB). 
     
 

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -874,10 +874,8 @@ from_wire(<<?MAGIC:8/integer, ?W2_VER:8/integer,
             KLen:32/integer, K:KLen/binary, BinObj/binary>>) ->
     case T of
         <<>> -> 
-            lager:debug("Found zero-length type, decoding default bucket-type"),
             riak_object:from_binary(B, K, BinObj);
         _ -> 
-            lager:debug("Found non-zero-length type, decoding non-default bucket-type:~p", [T]),
             riak_object:from_binary({T, B}, K, BinObj)
     end;
 from_wire(<<?MAGIC:8/integer, ?W1_VER:8/integer,
@@ -941,7 +939,6 @@ peer_wire_format(Peer) ->
 
 get_bucket_props_hash(Props) ->
    PB = [{Prop, proplists:get_value(Prop, Props)} || Prop <- ?BUCKET_TYPES_PROPS],
-   lager:debug("Bucket types props: ~p", [PB]),
    %% Returning a hash of the properties to avoid sending the whole term over the wire.
    %% A hash will be taken on the sink side of the sink's bucket type, and compared
    erlang:phash2(PB). 

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -850,14 +850,9 @@ to_wire(w2, Objects) when is_list(Objects) ->
     BObjs = [to_wire(w2,O) || O <- Objects],
     term_to_binary(BObjs);
 to_wire(w2, Object) when not is_binary(Object) ->
+    B = riak_object:bucket(Object),
     K = riak_object:key(Object),
-    case riak_object:bucket(Object) of
-        {T, B} -> 
-            lager:debug("encoding typed bucket: t:~p, b:~p, k:~p", [T,B,K]),
-            to_wire(w2, {T, B}, K, Object);
-        B ->
-            to_wire(w2, B, K, Object)
-    end.
+    to_wire(w2, B, K, Object).
 
 %% When the wire format is known and objects are packed in a list of binaries
 from_wire(w0, BinObjList) ->
@@ -906,10 +901,6 @@ to_wire(w1, B, K, <<_/binary>>=Bin) ->
     new_w1(B, K, Bin);
 to_wire(w1, B, K, RObj) ->
     new_w1(B, K, riak_object:to_binary(v1, RObj));
-to_wire(w2, {T, B}, K, <<131,_/binary>>=Bin) ->
-    new_w2({T,B}, K, Bin);
-to_wire(w2, B, K, <<131,_/binary>>=Bin) ->
-    to_wire(w2, B, K, Bin);
 to_wire(w2, {T,B}, K, RObj) ->
     new_w2({T,B}, K, riak_object:to_binary(v1, RObj));
 to_wire(w2, B, K, RObj) ->


### PR DESCRIPTION
#### Overview

Riak 2.0 brings with it typed buckets -- the ability to create a type and associate a bucket with that type:

https://github.com/basho/riak/issues/362

In order to successfully replicate a typed object from one cluster to another, the type definition must exist and be equal on both clusters. MDC replication must handle the possibility that the type of a given object exists on the replication source cluster, but not on the sink cluster (repl 2 terminology).

At this time, there is no facility to automatically create type across clusters -- for example, create a type that does not exist on the sink cluster -- to facilitate replication happening seemlessly. This could be an avenue to explore.

Additionally, replication must be extended to properly handle typed buckets. This work is assumed to come along with support for typed-bucket replication. "Default" type buckets (legacy buckets in Riak) continue to be automatically replicated as before.

This document discusses 2 possible options for implementing this in replication:

https://gist.github.com/bowrocker/7f0d9d6879493f1ac0e9

This PR implements the second option.
##### Type Checking on the Sink

This option allows typed buckets to be replicated to the sink cluster without any checking on the source. During the do_repl_put on the sink, the bucket is checked. If it has a type, that type is checked for existence, and if it does not exist, the object is dropped, and an error message is printed, and preferably an alarm of some sort is sent.

This option assumes that types should exist on both source and sink clusters, and that the non-existance of a type is an operational error that the user or CSE should take care of. Once the type is created, object of that type will replicate correctly.
###### Pros
- This is the simplest solution. Very few moving parts, very low impact on operations and performance.
###### Cons
- Bandwidth, RTQ space, and processing is wasted when an object whose type does not exist on the sink cluster is replicated.
- The assumption that all types should exist on both sides.
#### Configuration

No new user configuration is introduced. If the sink is not configured with the type of an object being replicated, an error message is printed. It is the responsibility of the user to provision this type on the sink. 
##### Mixed version replication

A new replication protocol version is introduced for bucket type support: {2,1}. The following is supported for each version:

| Source | Sink | Result |
| --- | :-: | --: |
| {3,0} | {3,0} | "default" and user defined typed buckets replicated |
| {3,0} | {2,0} or less | only "default" buckets replicated |
#### Dependencies

This PR depends upon code in the following riak_kv branch to be merged, or the conditional post-commit hook present will not work:

https://github.com/basho/riak_kv/tree/jdb-conditional-postcommit
https://github.com/basho/riak_repl/tree/jdb-conditional-postcommit
#### Previous PR

https://github.com/basho/riak_repl/pull/486
#### Riak Test

https://github.com/basho/riak_test/pull/477
