### PR TITLE
Prevent sink cluster fullsync stalls with tcp errors.

### DIFF
--- a/src/riak_repl_aae_sink.erl
+++ b/src/riak_repl_aae_sink.erl
@@ -88,18 +88,18 @@ handle_info({'DOWN', _, _, _, _}, State) ->
 
 handle_info({tcp_closed, Socket}, State=#state{socket=Socket}) ->
     lager:info("AAE sink connection to ~p closed", [State#state.clustername]),
-    {stop, normal, State};
-handle_info({tcp_error, _Socket, Reason}, State) ->
+    {stop, {tcp_closed, Socket}, State};
+handle_info({tcp_error, Socket, Reason}, State) ->
     lager:error("AAE sink connection to ~p closed unexpectedly: ~p",
                 [State#state.clustername, Reason]),
-    {stop, normal, State};
+    {stop, {tcp_error, Socket, Reason}, State};
 handle_info({ssl_closed, Socket}, State=#state{socket=Socket}) ->
     lager:info("AAE sink ssl connection to ~p closed", [State#state.clustername]),
-    {stop, normal, State};
-handle_info({ssl_error, _Socket, Reason}, State) ->
+    {stop, {ssl_closed, Socket}, State};
+handle_info({ssl_error, Socket, Reason}, State) ->
     lager:error("AAE sink ssl connection to ~p closed unexpectedly with: ~p",
                 [State#state.clustername, Reason]),
-    {stop, normal, State};
+    {stop, {ssl_error, Socket, Reason}, State};
 handle_info({Error, Socket, Reason},
             State=#state{socket=MySocket}) when Socket == MySocket ->
     lager:info("AAE sink connection to ~p closed unexpectedly: ~p",


### PR DESCRIPTION
In the event that the tcp connection errors without completing
full-sync, and when the max fssinks is not configured and defaulted to
one, this causes the aae_sink process to terminate normally, but not
propagate errors to the fssink process.  This causes an abandoned fssink
process, which locks out any future reservations for fullsync causing
replication to stall indefinitely on the sink cluster.

In the event that max fssink setting is not configured to one, and
specified at another value, tcp errors can cause available reservation
slots to be depleted over time.

This problem was discovered with repl_aae_fullsync in riak_test and
should be forward ported to the 2.0 release in addition to the test.

This could also be part of the issue observed by OpenX, in addition to the
not_built handling.

cc: @bsparrow435 @jcapricebasho 
