### PR TITLE
Ensure we retry partitions without trees.

### DIFF
--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -187,6 +187,12 @@ prepare_exchange(start_exchange, State=#state{index=Partition}) ->
                        [?RETRY_AAE_LOCKED_INTERVAL]),
             gen_fsm:send_event_after(?RETRY_AAE_LOCKED_INTERVAL, start_exchange),
             {next_state, prepare_exchange, State};
+        not_built ->
+            %% Hashtree has not been computed yet, defer attempt.
+            lager:info("AAE tree for partition ~p is not_built. Trying again in ~p seconds.",
+                       [?RETRY_AAE_LOCKED_INTERVAL]),
+            gen_fsm:send_event_after(?RETRY_AAE_LOCKED_INTERVAL, start_exchange),
+            {next_state, prepare_exchange, State};
         Error ->
             lager:warning("lock tree for partition ~p failed, got ~p",
                           [Partition, Error]),


### PR DESCRIPTION
In the event of a race where the tree has not beem computed yet,
schedule for retry in the same manner as if the partition was already
locked.

This will need to be ported forward to 2.0 and can be addressed with the
same test as the other AAE fixes.
