### PR TITLE
Gracefully handle the not_built message from the hashtree.

### DIFF
--- a/include/riak_repl.hrl
+++ b/include/riak_repl.hrl
@@ -24,6 +24,8 @@
 -define(DEFAULT_SOURCE_PER_NODE, 1).
 -define(DEFAULT_SOURCE_PER_CLUSTER, 5).
 -define(DEFAULT_MAX_SINKS_NODE, 1).
+%% How many times during a fullsync we should try a partition
+-define(DEFAULT_SOURCE_RETRIES, 5).
 %% 20 seconds. sources should claim within 5 seconds, but give them a little more time
 -define(RESERVATION_TIMEOUT, (20 * 1000)).
 -define(DEFAULT_MAX_FS_BUSIES_TOLERATED, 10).

--- a/src/riak_repl2_fs_node_reserver.erl
+++ b/src/riak_repl2_fs_node_reserver.erl
@@ -55,7 +55,15 @@ reserve(Partition) ->
 -spec unreserve(Partition :: any()) -> 'ok'.
 unreserve(Partition) ->
     Node = get_partition_node(Partition),
-    gen_server:cast({?SERVER, Node}, {unreserve, Partition}).
+    try gen_server:call({?SERVER, Node}, {unreserve, Partition}) of
+        Out ->
+            Out
+    catch
+        exit:{noproc, _} ->
+            down;
+        exit:{{nodedown, _}, _} ->
+            down
+    end.
 
 %% @doc Indicates a reservation has been converted to a running sink. Usually
 %% used by a sink.
@@ -85,25 +93,25 @@ handle_call({reserve, Partition}, _From, State) ->
             Reserved2 = [{Partition, Tref} | State#state.reservations],
             {reply, ok, State#state{reservations = Reserved2}};
         true ->
-            lager:debug("Node busy for partition ~p. running=~p reserved=~p max=~p",
+            lager:info("Node busy for partition ~p. running=~p reserved=~p max=~p",
                         [Partition, Running, Reserved, Max]),
             {reply, busy, State}
     end;
+
+handle_call({unreserve, Partition}, _From, State) ->
+    Reserved2 = cancel_reservation_timeout(Partition, State#state.reservations),
+    {reply, ok, State#state{reservations = Reserved2}};
 
 handle_call(_Request, _From, State) ->
     {reply, ok, State}.
 
 
 %% @hidden
-handle_cast({unreserve, Partition}, State) ->
-    Reserved2 = cancel_reservation_timeout(Partition, State#state.reservations),
-    {noreply, State#state{reservations = Reserved2}};
-
 handle_cast({claim_reservation, Partition}, State) ->
     Reserved2 = cancel_reservation_timeout(Partition, State#state.reservations),
     {noreply, State#state{reservations = Reserved2}};
 
-handle_cast(_Msg, State) ->
+handle_cast(Msg, State) ->
     {noreply, State}.
 
 

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -44,6 +44,7 @@
     running_sources = [],
     successful_exits = 0,
     error_exits = 0,
+    retry_exits = 0,
     pending_fullsync = false,
     dirty_nodes = ordsets:new(),          % these nodes should run fullsync
     dirty_nodes_during_fs = ordsets:new(), % these nodes reported realtime errors
@@ -214,6 +215,7 @@ handle_call(status, _From, State = #state{socket=Socket}) ->
         {starting, length(State#state.whereis_waiting)},
         {successful_exits, State#state.successful_exits},
         {error_exits, State#state.error_exits},
+        {retry_exits, State#state.retry_exits},
         {busy_nodes, sets:size(State#state.busy_nodes)},
         {running_stats, SourceStats},
         {socket, SocketStats},
@@ -303,6 +305,7 @@ handle_cast(start_fullsync,  State) ->
                 retries = dict:new(),
                 successful_exits = 0,
                 error_exits = 0,
+                retry_exits = 0,
                 fullsync_start_time = riak_core_util:moment()
             },
             State3 = start_up_reqs(State2),
@@ -397,18 +400,19 @@ handle_info({'EXIT', Pid, Cause}, State) ->
             NewBusies = sets:del_element(Node, State#state.busy_nodes),
 
             % stats
-            ErrorExits = State#state.error_exits + 1,
             #state{partition_queue = PQueue, retries = Retries0} = State,
 
             RetryLimit = app_helper:get_env(riak_repl, max_fssource_retries,
                                             ?DEFAULT_SOURCE_RETRIES),
-            Retries = dict:increment_counter(Partition, 1, Retries0),
+            Retries = dict:update_counter(Partition, 1, Retries0),
 
             case dict:fetch(Partition, Retries) of
                 N when N > RetryLimit ->
                     lager:warning("fssource dropping partition: ~p, ~p failed"
                                "retries", [Partition, RetryLimit]),
+                    ErrorExits = State#state.error_exits + 1,
                     State2 = State#state{busy_nodes = NewBusies,
+                                         retries = Retries,
                                          running_sources = Running,
                                          error_exits = ErrorExits},
                     State3 = start_up_reqs(State2),
@@ -418,10 +422,12 @@ handle_info({'EXIT', Pid, Cause}, State) ->
                     lager:info("fssource rescheduling partition: ~p",
                                [Partition]),
                     PQueue2 = queue:in(Partition, PQueue),
+                    RetryExits = State#state.retry_exits + 1,
                     State2 = State#state{partition_queue = PQueue2,
+                                         retries = Retries,
                                          busy_nodes = NewBusies,
                                          running_sources = Running,
-                                         error_exits = ErrorExits},
+                                         retry_exits = RetryExits},
                     State3 = start_up_reqs(State2),
                     {noreply, State3}
             end

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -380,8 +380,8 @@ handle_info({'EXIT', Pid, Cause}, State) when Cause =:= normal; Cause =:= shutdo
             end
     end;
 
-handle_info({'EXIT', Pid, _Cause}, State) ->
-    lager:warning("fssource ~p exited abnormally", [Pid]),
+handle_info({'EXIT', Pid, Cause}, State) ->
+    lager:info("fssource ~p exited abnormally: ~p", [Pid, Cause]),
     PartitionEntry = lists:keytake(Pid, 1, State#state.running_sources),
     case PartitionEntry of
         false ->
@@ -398,6 +398,7 @@ handle_info({'EXIT', Pid, _Cause}, State) ->
             #state{partition_queue = PQueue} = State,
 
             % reset for retry later
+            lager:info("fssource rescheduling partition: ~p", [Partition]),
             PQueue2 = queue:in(Partition, PQueue),
             State2 = State#state{partition_queue = PQueue2, busy_nodes = NewBusies,
                 running_sources = Running, error_exits = ErrorExits},

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -402,7 +402,7 @@ handle_info({'EXIT', Pid, Cause}, State) ->
 
             RetryLimit = app_helper:get_env(riak_repl, max_fssource_retries,
                                             ?DEFAULT_SOURCE_RETRIES),
-            Retries = dict:increment_counter(Partition, 1, Retries0),
+            Retries = dict:update_counter(Partition, 1, Retries0),
 
             case dict:fetch(Partition, Retries) of
                 N when N > RetryLimit ->

--- a/src/riak_repl2_fssource.erl
+++ b/src/riak_repl2_fssource.erl
@@ -186,7 +186,7 @@ handle_info({'DOWN', Ref, process, _Pid, Reason}, State) when Reason == normal o
 handle_info({'DOWN', Ref, process, _Pid, Reason}, State=#state{partition=Partition}) ->
     lager:info("Received: ~p, fullsync source stopping; will rety partition ~p later.",
                [Reason, Partition]),
-    {stop, normal, State};
+    {stop, {error, Reason}, State};
 handle_info({Closed, Socket}, State=#state{socket=Socket})
         when Closed == tcp_closed; Closed == ssl_closed ->
     lager:info("Connection for site ~p closed", [State#state.cluster]),

--- a/src/riak_repl2_fssource.erl
+++ b/src/riak_repl2_fssource.erl
@@ -182,6 +182,10 @@ handle_info({'DOWN', Ref, process, _Pid, not_responsible}, State=#state{partitio
         {ok, State2} -> {noreply, State2};
         Error -> Error
     end;
+handle_info({'DOWN', Ref, process, _Pid, Reason}, State) ->
+    erlang:demonitor(Ref),
+    lager:info("Received: ~p, stopping process.", [Reason]),
+    {stop, normal, State};
 handle_info({Closed, Socket}, State=#state{socket=Socket})
         when Closed == tcp_closed; Closed == ssl_closed ->
     lager:info("Connection for site ~p closed", [State#state.cluster]),

--- a/src/riak_repl2_fssource.erl
+++ b/src/riak_repl2_fssource.erl
@@ -62,7 +62,12 @@ init([Partition, IP]) ->
     OurCaps = decide_our_caps(DefaultStrategy),
     SupportedStrategy = proplists:get_value(strategy, OurCaps, DefaultStrategy),
 
-    connect(IP, SupportedStrategy, Partition).
+    case connect(IP, SupportedStrategy, Partition) of
+        {error, Reason} ->
+            {stop, Reason};
+        Other ->
+            Other
+    end.
 
 handle_call({connected, Socket, Transport, _Endpoint, Proto, Props},
             _From, State=#state{ip=IP, partition=Partition, strategy=DefaultStrategy}) ->

--- a/src/riak_repl2_fssource.erl
+++ b/src/riak_repl2_fssource.erl
@@ -170,12 +170,6 @@ handle_cast({connect_failed, _Pid, Reason},
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
-handle_info({'DOWN', _Ref, process, _Pid, Reason}, State) when Reason == normal orelse Reason == shutdown ->
-    {stop, normal, State};
-handle_info({'DOWN', _Ref, process, _Pid, Reason}, State=#state{partition=Partition}) ->
-    lager:info("Received: ~p, fullsync source stopping; will rety partition ~p later.",
-               [Reason, Partition]),
-    {stop, {error, Reason}, State};
 handle_info({Closed, Socket}, State=#state{socket=Socket})
         when Closed == tcp_closed; Closed == ssl_closed ->
     lager:info("Connection for site ~p closed", [State#state.cluster]),

--- a/src/riak_repl_aae_sink.erl
+++ b/src/riak_repl_aae_sink.erl
@@ -122,12 +122,16 @@ code_change(_OldVsn, State, _Extra) ->
 %% replies: ok
 process_msg(?MSG_INIT, Partition, State) ->
     lager:info("MSG_INIT for partition ~p", [Partition]),
-    {ok, TreePid} = riak_kv_vnode:hashtree_pid(Partition),
-    %% monitor the tree and crash if the tree goes away
-    monitor(process, TreePid),
-    %% tell the reservation coordinator that we are taking this partition.
-    riak_repl2_fs_node_reserver:claim_reservation(Partition),
-    send_reply(ok, State#state{partition=Partition, tree_pid=TreePid});
+    case riak_kv_vnode:hashtree_pid(Partition) of
+        {ok, TreePid} ->
+            %% monitor the tree and crash if the tree goes away
+            monitor(process, TreePid),
+            %% tell the reservation coordinator that we are taking this partition.
+            riak_repl2_fs_node_reserver:claim_reservation(Partition),
+            send_reply(ok, State#state{partition=Partition, tree_pid=TreePid});
+        {error, wrong_node} ->
+            {stop, wrong_node, State}
+    end;
 
 process_msg(?MSG_GET_AAE_BUCKET, {Level,BucketNum,IndexN}, State=#state{tree_pid=TreePid}) ->
     ResponseMsg = riak_kv_index_hashtree:exchange_bucket(IndexN, Level, BucketNum, TreePid),

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -221,7 +221,7 @@ update_trees(start_exchange, State=#state{tree_pid=TreePid,
 
 update_trees({not_responsible, Partition, IndexN}, State=#state{owner=Owner}) ->
     lager:info("VNode ~p does not cover preflist ~p", [Partition, IndexN]),
-    Owner ! not_responsible,
+    gen_server:cast(Owner, not_responsible),
     {stop, normal, State};
 update_trees({tree_built, _, _}, State) ->
     Built = State#state.built + 1,

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -113,7 +113,22 @@ handle_info(Error={'DOWN', _, _, _, _}, _StateName, State) ->
     lager:info("Something went down ~p", [Error]),
     send_complete(State),
     {stop, something_went_down, State};
+handle_info({tcp_closed, Socket}, _StateName, State=#state{socket=Socket}) ->
+    lager:info("AAE source connection to ~p closed", [State#state.cluster]),
+    {stop, {tcp_closed, Socket}, State};
+handle_info({tcp_error, Socket, Reason}, _StateName, State) ->
+    lager:error("AAE source connection to ~p closed unexpectedly: ~p",
+                [State#state.cluster, Reason]),
+    {stop, {tcp_error, Socket, Reason}, State};
+handle_info({ssl_closed, Socket}, _StateName, State=#state{socket=Socket}) ->
+    lager:info("AAE source ssl connection to ~p closed", [State#state.cluster]),
+    {stop, {ssl_closed, Socket}, State};
+handle_info({ssl_error, Socket, Reason}, _StateName, State) ->
+    lager:error("AAE source ssl connection to ~p closed unexpectedly with: ~p",
+                [State#state.cluster, Reason]),
+    {stop, {ssl_error, Socket, Reason}, State};
 handle_info(_Info, StateName, State) ->
+    lager:info("ignored handle_info: ~p", [_Info]),
     {next_state, StateName, State}.
 
 terminate(_Reason, _StateName, _State) ->

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -170,8 +170,6 @@ prepare_exchange(start_exchange, State=#state{transport=Transport,
         Error ->
             lager:info("AAE source failed get_lock for partition ~p, got ~p",
                        [Partition, Error]),
-            send_complete(State),
-            throw(Error),
             {stop, Error, State}
     end;
 prepare_exchange(start_exchange, State=#state{index=Partition}) ->

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -148,7 +148,7 @@ code_change(_OldVsn, StateName, State, _Extra) ->
 %%      remote concurrency lock, and remote tree lock. Exchange will
 %%      timeout if locks cannot be acquired in a timely manner.
 prepare_exchange(cancel_fullsync, State) ->
-    larger:info("AAE fullsync source cancelled for partition ~p", [State#state.index]),
+    lager:info("AAE fullsync source cancelled for partition ~p", [State#state.index]),
     send_complete(State),
     {stop, normal, State};
 prepare_exchange(start_exchange, State=#state{transport=Transport,
@@ -198,7 +198,7 @@ prepare_exchange(start_exchange, State=#state{index=Partition}) ->
 %%      continue to finish the update even after the exchange times out,
 %%      a future exchange should eventually make progress.
 update_trees(cancel_fullsync, State) ->
-    larger:info("AAE fullsync source cancelled for partition ~p", [State#state.index]),
+    lager:info("AAE fullsync source cancelled for partition ~p", [State#state.index]),
     send_complete(State),
     {stop, normal, State};
 update_trees(start_exchange, State=#state{indexns=IndexN, owner=Owner}) when IndexN == [] ->
@@ -237,7 +237,7 @@ update_trees({tree_built, _, _}, State) ->
 %% @doc Now that locks have been acquired and both hashtrees have been updated,
 %%      perform a key exchange and trigger replication for any divergent keys.
 key_exchange(cancel_fullsync, State) ->
-    larger:info("AAE fullsync source cancelled for partition ~p", [State#state.index]),
+    lager:info("AAE fullsync source cancelled for partition ~p", [State#state.index]),
     send_complete(State),
     {stop, normal, State};
 key_exchange(start_key_exchange, State=#state{cluster=Cluster,


### PR DESCRIPTION
Ensure that when aae_source dies, we handle the DOWN message and
terminate the fsssource process instead of ignoring the message.

Do not throw the error, or send the complete message to the sink, when
the process dies; both are not necessary.
