### PR TITLE
Convert riak_core_cluster_conn to use the OTP gen_fsm behavior

### DIFF
--- a/include/riak_core_connection.hrl
+++ b/include/riak_core_connection.hrl
@@ -31,6 +31,7 @@
 
 
 -define(CONNECTION_SETUP_TIMEOUT, 10000).
+-define(INITIAL_CONNECTION_RESPONSE_TIMEOUT, 15000).
 
 
 
@@ -97,4 +98,3 @@
 
 
 -type(cluster_finder_fun() :: fun(() -> {ok,node()} | {error, term()})).
-

--- a/src/riak_core_cluster_conn.erl
+++ b/src/riak_core_cluster_conn.erl
@@ -7,26 +7,68 @@
 
 -module(riak_core_cluster_conn).
 
+-behavior(gen_fsm).
+
 -include("riak_core_cluster.hrl").
 -include("riak_core_connection.hrl").
 
+
 -ifdef(TEST).
+
 -include_lib("eunit/include/eunit.hrl").
+
+%% Test API
+-export([current_state/1]).
+
 %% For testing, we need to have two different cluster manager services running
 %% on the same node, which is normally not done. The remote cluster service is
 %% the one we're testing, so use a different protocol for the client connection
 %% during eunit testing, which will emulate a cluster manager from the test.
 -define(REMOTE_CLUSTER_PROTO_ID, test_cluster_mgr).
--define(TRACE(Stmt),Stmt).
-%%-define(TRACE(Stmt),ok).
 -else.
 -define(REMOTE_CLUSTER_PROTO_ID, ?CLUSTER_PROTO_ID).
--define(TRACE(Stmt),ok).
 -endif.
 
--export([start_link/1]).
+%% API
+-export([start_link/1,
+         start_link/2,
+         status/1,
+         connected/6,
+         connect_failed/3,
+         stop/1]).
 
--export([connected/6, connect_failed/3, ctrlClientProcess/3]).
+%% gen_fsm callbacks
+-export([init/1,
+         initiating_connection/2,
+         initiating_connection/3,
+         connecting/2,
+         connecting/3,
+         waiting_for_cluster_name/2,
+         waiting_for_cluster_name/3,
+         waiting_for_cluster_members/2,
+         waiting_for_cluster_members/3,
+         connected/2,
+         connected/3,
+         handle_event/3,
+         handle_sync_event/4,
+         handle_info/3,
+         terminate/3,
+         code_change/4]).
+
+-type remote() :: {cluster_by_name, clustername()} | {cluster_by_addr, ip_addr()}.
+-type peer_address() :: {string(), pos_integer()}.
+-record(state, {mode :: atom(),
+                remote :: remote(),
+                socket :: port(),
+                name :: clustername(),
+                previous_name="undefined" :: clustername(),
+                members=[] :: [peer_address()],
+                connection_ref :: reference(),
+                connection_timeout :: timeout(),
+                transport :: atom(),
+                address :: peer_address(),
+                connection_props :: proplist:proplist()}).
+-type state() :: #state{}.
 
 %%%===================================================================
 %%% API
@@ -35,196 +77,318 @@
 %% start a connection with a locator type, either {cluster_by_name, clustername()}
 %% or {cluster_by_addr, ip_addr()}. This is asynchronous. If it dies, the connection
 %% supervisior will restart it.
--spec(start_link(term()) -> {ok,pid()}).
+-spec start_link(remote()) -> {ok, pid()} | {error, term()}.
 start_link(Remote) ->
-    ?TRACE(?debugFmt("connecting to ~p", [Remote])),
-    Members = [],
-    Pid = proc_lib:spawn_link(?MODULE,
-                              ctrlClientProcess,
-                              [Remote, unconnected, Members]),
-    {ok, Pid}.
+    start_link(Remote, normal).
+
+-spec start_link(remote(), atom()) -> {ok, pid()} | {error, term()}.
+start_link(Remote, Mode) ->
+    gen_fsm:start_link(?MODULE, [Remote, Mode], []).
+
+-spec stop(pid()) -> ok.
+stop(Ref) ->
+    gen_fsm:sync_send_all_state_event(Ref, force_stop).
+
+-spec status(pid()) -> term().
+status(Ref) ->
+    gen_fsm:sync_send_event(Ref, status).
+
+-spec connected(port(), atom(), ip_addr(), term(), term(), proplists:proplist()) -> ok.
+connected(Socket,
+          Transport,
+          Addr,
+          {?REMOTE_CLUSTER_PROTO_ID, _MyVer, _RemoteVer},
+          {_Remote, Client},
+          Props) ->
+    %% give control over the socket to the `Client' process.
+    %% tell client we're connected and to whom
+    Transport:controlling_process(Socket, Client),
+    gen_fsm:send_event(Client,
+                       {connected_to_remote, Socket, Transport, Addr, Props}).
+
+-spec connect_failed({term(), term()}, {error, term()}, {_, atom() | pid() | port() | {atom(), _} | {via, _, _}}) -> ok.
+connect_failed({_Proto, _Vers}, {error, _}=Error, {_Remote, Client}) ->
+    %% increment stats for "client failed to connect"
+    riak_repl_stats:client_connect_errors(),
+    %% tell client we bombed and why
+    gen_fsm:send_event(Client, {connect_failed, Error}).
 
 %%%===================================================================
-%% private
+%%% gen_fsm callbacks
 %%%===================================================================
 
-%% request a connection from connection manager. When connected, our
-%% module's "connected" function will be called, which sends a message
-%% "connected_to_remote", which we forward to the cluster manager. Dying
-%% is ok; we'll get restarted by a supervisor.
-ctrlClientProcess(Remote, unconnected, Members0) ->
-    Args = {Remote, self()},
-    {ok,_Ref} = riak_core_connection_mgr:connect(
-                  Remote,
-                  {{?REMOTE_CLUSTER_PROTO_ID, [{1,0}]},
-                   {?CTRL_OPTIONS, ?MODULE, Args}},
-                  default),
-    ctrlClientProcess(Remote, connecting, Members0);
-%% We're trying to connect via the connection manager now
-ctrlClientProcess(Remote, connecting, Members0) ->
-    %% wait a long-ish time for the connection to establish
-    receive
-        {From, status} ->
-            %% someone wants our status. Don't do anything that blocks!
-            From ! {self(), connecting, Remote},
-            ctrlClientProcess(Remote, connecting, Members0);
-        {_From, {connect_failed, Error}} ->
-            ?TRACE(?debugFmt("ClusterManager Client: connect_failed to ~p because ~p. Will retry.", [Remote, Error])),
-            lager:warning("ClusterManager Client: connect_failed to ~p because ~p. Will retry.",
-                          [Remote, Error]),
-            %% This is fatal! We are being supervised by conn_sup and if we
-            %% die, it will restart us.
-            {error, Error};
-        {_From, {connected_to_remote, Socket, Transport, Addr, Props}} ->
-            RemoteName = proplists:get_value(clustername, Props),
-            ?TRACE(?debugFmt("Cluster Manager control channel client connected to remote ~p at ~p named ~p", [Remote, Addr, RemoteName])),
-            lager:debug("Cluster Manager control channel client connected to remote ~p at ~p named ~p",
-                       [Remote, Addr, RemoteName]),
-            %% ask it's name and member list, even if it's a previously
-            %% resolved cluster. Then we can sort everything out in the
-            %% gen_server. If the name or members fails, these matches
-            %% will fail and the connection will get restarted.
-            case ask_cluster_name(Socket, Transport, Remote) of
-                {ok, Name} ->
-                    case ask_member_ips(Socket, Transport, Addr, Remote) of
-                        {ok, Members} ->
-                            %% This is the first time we're updating the cluster manager
-                            %% with the name of this cluster, so it's old name is undefined.
-                            OldName = "undefined",
-                            gen_server:cast(?CLUSTER_MANAGER_SERVER,
-                                            {cluster_updated, OldName, Name, Members, Addr, Remote}),
-                            ctrlClientProcess(Remote, {Name, Socket, Transport, Addr}, Members);
-                        {error, closed} ->
-                            {error, connection_closed};
-                        Error ->
-                            Error
-                    end;
-                {error, closed} ->
-                    {error, connection_closed};
-                Error ->
-                    Error
-            end;
-        {_From, poll_cluster} ->
-            %% cluster manager doesn't know we haven't connected yet.
-            %% just ignore this while we're waiting to connect or fail
-            ctrlClientProcess(Remote, connecting, Members0);
-        Other ->
-            lager:error("cluster_conn: client got unexpected msg from remote: ~p, ~p",
-                        [Remote, Other]),
-            ctrlClientProcess(Remote, connecting, Members0)
-    after (?CONNECTION_SETUP_TIMEOUT + 5000) ->
-            %% die with error once we've passed the timeout period that the
-            %% core_connection module will expire. Go round and let the connection
-            %% manager keep trying.
-            lager:debug("cluster_conn: client timed out waiting for ~p", [Remote]),
-            ctrlClientProcess(Remote, connecting, Members0)
-    end;
-ctrlClientProcess(Remote, {Name, Socket, Transport, Addr}, Members0) ->
-    %% trade our time between checking for updates from the remote cluster
-    %% and commands from our local cluster manager. TODO: what if the name
-    %% of the remote cluster changes?
-    receive
-        %% cluster manager asking us to poll the remove cluster
-        {_From, poll_cluster} ->
-            case ask_cluster_name(Socket, Transport, Remote) of
-                {ok, NewName} ->
-                    case ask_member_ips(Socket, Transport, Addr, Remote) of
-                        {ok, Members} ->
-                            gen_server:cast(?CLUSTER_MANAGER_SERVER,
-                                            {cluster_updated, Name, NewName, Members, Addr, Remote}),
-                            ctrlClientProcess(Remote, {NewName, Socket, Transport, Addr}, Members);
-                        {error, closed} ->
-                            {error, connection_closed};
-                        Error ->
-                            Error
-                    end;
-                {error, closed} ->
-                    {error, connection_closed};
-                Error ->
-                    Error
-            end;
-        %% request for our connection status
-        {From, status} ->
-            %% don't try talking to the remote cluster; we don't want to stall our status
-            Status = {Addr, Transport, Name, Members0},
-            From ! {self(), status, Status},
-            ctrlClientProcess(Remote, {Name, Socket, Transport, Addr}, Members0)
-    after 1000 ->
-            %% check for push notifications from remote cluster about member changes
-            Members1 =
-                case Transport:recv(Socket, 0, 250) of
-                    {ok, {cluster_members_changed, BinMembers}} ->
-                        Members = {ok, binary_to_term(BinMembers)},
-                        gen_server:cast(?CLUSTER_MANAGER_SERVER,
-                                        {cluster_updated, Name, Name, Members, Addr, Remote}),
-                        Members;
-                    {ok, Other} ->
-                        lager:error("cluster_conn: client got unexpected msg from remote: ~p, ~p",
-                                    [Remote, Other]),
-                        Members0;
-                    {error, timeout} ->
-                        %% timeouts are ok; we'll just go round and try again
-                        Members0;
-                    {error, closed} ->
-                        %%erlang:exit(connection_closed);
-                        {error, connection_closed};
-                    {error, ebadf} ->
-                        %% like a closed file descriptor
-                        {error, connection_closed};
-                    {error, Reason} ->
-                        lager:error("cluster_conn: client got error from remote: ~p, ~p",
-                                    [Remote, Reason]),
-                        {error, Reason}
-                end,
-            ctrlClientProcess(Remote, {Name, Socket, Transport, Addr}, Members1)
-    end.
+-spec init([remote() | atom()]) -> {ok, initiating_connection, state(), timeout()}.
+init([Remote, test]) ->
+    _ = lager:debug("connecting to ~p", [Remote]),
+    State = #state{connection_timeout=infinity,
+                   mode=test,
+                   remote=Remote},
+    {ok, initiating_connection, State};
+init([Remote, Mode]) ->
+    _ = lager:debug("connecting to ~p", [Remote]),
+    State = #state{connection_timeout=?INITIAL_CONNECTION_RESPONSE_TIMEOUT,
+                   mode=Mode,
+                   remote=Remote},
+    {ok, initiating_connection, State, 0}.
 
-ask_cluster_name(Socket, Transport, Remote) ->
-    Transport:send(Socket, ?CTRL_ASK_NAME),
-    case Transport:recv(Socket, 0, ?CONNECTION_SETUP_TIMEOUT) of
-        {ok, BinName} ->
-            {ok, binary_to_term(BinName)};
-        {error, closed} ->
-            %% the other side hung up. Stop quietly.
-            {error, closed};
-        Error ->
-            lager:error("cluster_conn: failed to recv name from remote cluster at ~p because ~p",
-                        [Remote, Error]),
-            Error
-    end.
+%% Async message handling for the `initiating_connection' state
+initiating_connection(timeout, State) ->
+    UpdState = initiate_connection(State),
+    {next_state, connecting, UpdState, ?CONNECTION_SETUP_TIMEOUT + 5000};
+initiating_connection(_, State) ->
+    {next_state, initiating_connection, State}.
 
-ask_member_ips(Socket, Transport, _Addr, Remote) ->
+%% Sync message handling for the `initiating_connection' state
+initiating_connection(status, _From, _State) ->
+    {reply, initiating_connection, initiating_connection, _State};
+initiating_connection(_, _From, _State) ->
+    {reply, ok, initiating_connection, _State}.
+
+%% Async message handling for the `connecting' state
+connecting(timeout, State=#state{remote=Remote}) ->
+    %% @TODO Original comment below says we want to die, but code was
+    %% implemented to loop in the same function. Determine which is
+    %% the better choice. Stopping for now.
+
+    %% die with error once we've passed the timeout period that the
+    %% core_connection module will expire. Go round and let the connection
+    %% manager keep trying.
+    _ = lager:debug("cluster_conn: client timed out waiting for ~p", [Remote]),
+    {stop, giving_up, State};
+connecting({connect_failed, Error}, State=#state{remote=Remote}) ->
+    _ = lager:debug("ClusterManager Client: connect_failed to ~p because ~p."
+                    " Will retry.",
+                    [Remote, Error]),
+    _ = lager:warning("ClusterManager Client: connect_failed to ~p because ~p."
+                      " Will retry.",
+                      [Remote, Error]),
+    %% This is fatal! We are being supervised by conn_sup and if we
+    %% die, it will restart us.
+    {stop, Error, State};
+connecting({connected_to_remote, Socket, Transport, Addr, Props}, State) ->
+    RemoteName = proplists:get_value(clustername, Props),
+    _ = lager:debug("Cluster Manager control channel client connected to"
+                    " remote ~p at ~p named ~p",
+                    [State#state.remote, Addr, RemoteName]),
+    _ = lager:debug("Cluster Manager control channel client connected to"
+                    " remote ~p at ~p named ~p",
+                    [State#state.remote, Addr, RemoteName]),
+    UpdState = State#state{socket=Socket,
+                           transport=Transport,
+                           address=Addr,
+                           connection_props=Props},
+    _ = request_cluster_name(UpdState),
+    {next_state, waiting_for_cluster_name, UpdState, ?CONNECTION_SETUP_TIMEOUT};
+connecting(poll_cluster, State) ->
+    %% cluster manager doesn't know we haven't connected yet.
+    %% just ignore this while we're waiting to connect or fail
+    {next_state, connecting, State};
+connecting(Other, State=#state{remote=Remote}) ->
+    _ = lager:error("cluster_conn: client got unexpected "
+                    "msg from remote: ~p, ~p",
+                    [Remote, Other]),
+    {next_state, connecting, State}.
+
+%% Sync message handling for the `connecting' state
+connecting(status, _From, State) ->
+    {reply, connecting, connecting, State};
+connecting(_, _From, _State) ->
+    {reply, ok, connecting, _State}.
+
+%% Async message handling for the `waiting_for_cluster_name' state
+waiting_for_cluster_name({cluster_name, NewName}, State=#state{previous_name="undefined"}) ->
+    UpdState = State#state{name=NewName},
+    _ = request_member_ips(UpdState),
+    {next_state, waiting_for_cluster_members, UpdState, ?CONNECTION_SETUP_TIMEOUT};
+waiting_for_cluster_name({cluster_name, NewName}, State=#state{name=Name}) ->
+    UpdState = State#state{name=NewName, previous_name=Name},
+    _ = request_member_ips(UpdState),
+    {next_state, waiting_for_cluster_members, UpdState, ?CONNECTION_SETUP_TIMEOUT};
+waiting_for_cluster_name(_, _State) ->
+    {next_state, waiting_for_cluster_name, _State}.
+
+%% Sync message handling for the `waiting_for_cluster_name' state
+waiting_for_cluster_name(status, _From, State) ->
+    {reply, waiting_for_cluster_name, waiting_for_cluster_name, State};
+waiting_for_cluster_name(_, _From, _State) ->
+    {reply, ok, waiting_for_cluster_name, _State}.
+
+%% Async message handling for the `waiting_for_cluster_members' state
+waiting_for_cluster_members({cluster_members, Members}, State) ->
+    #state{address=Addr,
+           name=Name,
+           previous_name=PreviousName,
+           remote=Remote} = State,
+    %% This is the first time we're updating the cluster manager
+    %% with the name of this cluster, so it's old name is undefined.
+    ClusterUpdatedMsg = {cluster_updated,
+                         PreviousName,
+                         Name,
+                         Members,
+                         Addr,
+                         Remote},
+    gen_server:cast(?CLUSTER_MANAGER_SERVER, ClusterUpdatedMsg),
+    {next_state, connected, State#state{members=Members}};
+waiting_for_cluster_members(_, _State) ->
+    {next_state, waiting_for_cluster_members, _State}.
+
+%% Sync message handling for the `waiting_for_cluster_members' state
+waiting_for_cluster_members(status, _From, State) ->
+    {reply, waiting_for_cluster_members, waiting_for_cluster_members, State};
+waiting_for_cluster_members(_, _From, _State) ->
+    {reply, ok, waiting_for_cluster_members, _State}.
+
+%% Async message handling for the `connected' state
+connected(poll_cluster, State) ->
+    _ = request_cluster_name(State),
+    {next_state, waiting_for_cluster_name, State};
+connected(_, State) ->
+    {next_state, connected, State}.
+
+%% Sync message handling for the `connected' state
+connected(status, _From, State) ->
+    #state{address=Addr,
+           name=Name,
+           members=Members,
+           transport=Transport} = State,
+    %% request for our connection status
+    %% don't try talking to the remote cluster; we don't want to stall our status
+    Status = {Addr, Transport, Name, Members},
+    {reply, {self(), status, Status}, connected, State};
+connected(_, _From, _State) ->
+    {reply, ok, connected, _State}.
+
+handle_event(_Event, StateName, State) ->
+    {next_state, StateName, State}.
+
+handle_sync_event(current_state, _From, StateName, State) ->
+    Reply = {StateName, State},
+    {reply, Reply, StateName, State};
+handle_sync_event(force_stop, _From, _StateName, State) ->
+    {stop, normal, ok, State};
+handle_sync_event(_Event, _From, StateName, State) ->
+    Reply = ok,
+    {reply, Reply, StateName, State}.
+
+%% @doc Handle any non-fsm messages
+handle_info({tcp, Socket, {cluster_members_changed, BinMembers}},
+            StateName,
+            State=#state{address=Addr,
+                         name=Name,
+                         remote=Remote,
+                         socket=Socket}) ->
+    Members = binary_to_term(BinMembers),
+    ClusterUpdMsg = {cluster_updated, Name, Name, Members, Addr, Remote},
+    gen_server:cast(?CLUSTER_MANAGER_SERVER, ClusterUpdMsg),
+    _ = inet:setopts(Socket, [{active, once}]),
+    {next_state, StateName, State#state{members=Members}};
+handle_info({tcp, Socket, Name},
+            waiting_for_cluster_name,
+            State=#state{socket=Socket}) ->
+    gen_fsm:send_event(self(), {cluster_name, binary_to_term(Name)}),
+    _ = inet:setopts(Socket, [{active, once}]),
+    {next_state, waiting_for_cluster_name, State};
+handle_info({tcp, Socket, Members},
+            waiting_for_cluster_members,
+            State=#state{socket=Socket}) ->
+    gen_fsm:send_event(self(), {cluster_members, binary_to_term(Members)}),
+    _ = inet:setopts(Socket, [{active, once}]),
+    {next_state, waiting_for_cluster_members, State};
+handle_info({tcp, Socket, Other},
+            StateName,
+            State=#state{remote=Remote,
+                         socket=Socket}) ->
+    _ = lager:error("cluster_conn: client got unexpected "
+                    "msg from remote: ~p, ~p",
+                    [Remote, Other]),
+    _ = inet:setopts(Socket, [{active, once}]),
+    {next_state, StateName, State};
+handle_info({tcp_error, Socket, Error},
+            waiting_for_cluster_members,
+            State=#state{remote=Remote,
+                         socket=Socket}) ->
+    _ = lager:error("cluster_conn: failed to recv "
+                    "members from remote cluster at ~p because ~p",
+                    [Remote, Error]),
+    {stop, Error, State};
+handle_info({tcp_error, Socket, Error},
+            waiting_for_cluster_name,
+            State=#state{remote=Remote,
+                         socket=Socket}) ->
+    _ = lager:error("cluster_conn: failed to recv name from "
+                    "remote cluster at ~p because ~p",
+                    [Remote, Error]),
+    {stop, Error, State};
+handle_info({tcp_error, Socket, Err},
+            _StateName,
+            State=#state{socket=Socket}) ->
+    {stop, Err, State};
+handle_info({tcp_closed, Socket},
+            _StateName,
+            State=#state{socket=Socket}) ->
+    {stop, normal, State};
+handle_info({tcp, _, _}, StateName, State=#state{socket=Socket}) ->
+    _ = inet:setopts(Socket, [{active, once}]),
+    {next_state, StateName, State};
+handle_info({tcp_error, _, _Err}, StateName, State=#state{socket=Socket}) ->
+    _ = inet:setopts(Socket, [{active, once}]),
+    {next_state, StateName, State};
+handle_info({tcp_closed, _}, StateName, State=#state{socket=Socket}) ->
+    _ = inet:setopts(Socket, [{active, once}]),
+    {next_state, StateName, State};
+handle_info(_, StateName, State) ->
+    {next_state, StateName, State}.
+
+terminate(_Reason, _StateName, _State) ->
+    ok.
+
+%% @doc this fsm has no special upgrade process
+code_change(_OldVsn, StateName, State, _Extra) ->
+    {ok, StateName, State}.
+
+%%%===================================================================
+%% Internal functions
+%%%===================================================================
+
+-spec request_cluster_name(state()) -> ok | {error, term()}.
+request_cluster_name(#state{mode=test}) ->
+    ok;
+request_cluster_name(#state{socket=Socket, transport=Transport}) ->
+    _ = inet:setopts(Socket, [{active, once}]),
+    Transport:send(Socket, ?CTRL_ASK_NAME).
+
+-spec request_member_ips(state()) -> ok | {error, term()}.
+request_member_ips(#state{mode=test}) ->
+    ok;
+request_member_ips(#state{socket=Socket, transport=Transport}) ->
     Transport:send(Socket, ?CTRL_ASK_MEMBERS),
     %% get the IP we think we've connected to
     {ok, {PeerIP, PeerPort}} = Transport:peername(Socket),
     %% make it a string
     PeerIPStr = inet_parse:ntoa(PeerIP),
-    Transport:send(Socket, term_to_binary({PeerIPStr, PeerPort})),
-    case Transport:recv(Socket, 0, ?CONNECTION_SETUP_TIMEOUT) of
-        {ok, BinMembers} ->
-            {ok, binary_to_term(BinMembers)};
-        {error, closed} ->
-            %% the other side hung up. Stop quietly.
-            {error, closed};
-        Error ->
-            lager:error("cluster_conn: failed to recv members from remote cluster at ~p because ~p",
-                        [Remote, Error]),
-            Error
-    end.
+    Transport:send(Socket, term_to_binary({PeerIPStr, PeerPort})).
 
-connected(Socket, Transport, Addr,
-          {?REMOTE_CLUSTER_PROTO_ID, _MyVer, _RemoteVer},
-          {_Remote,Client},
-          Props) ->
-    %% give control over the socket to the Client process.
-    %% tell client we're connected and to whom
-    Transport:controlling_process(Socket, Client),
-    Client ! {self(), {connected_to_remote, Socket, Transport, Addr, Props}},
-    ok.
+initiate_connection(State=#state{mode=test}) ->
+    State;
+initiate_connection(State=#state{remote=Remote}) ->
+    %% Dialyzer complains about this call because the spec for
+    %% `riak_core_connection_mgr::connect/4' is incorrect.
+    {ok, Ref} = riak_core_connection_mgr:connect(
+                  Remote,
+                  {{?REMOTE_CLUSTER_PROTO_ID, [{1,0}]},
+                   {?CTRL_OPTIONS, ?MODULE, {Remote, self()}}},
+                  default),
+    State#state{connection_ref=Ref}.
 
-connect_failed({_Proto,_Vers}, {error, _Reason}=Error, {_Remote,Client}) ->
-    %% tell client we bombed and why
-    Client ! {self(), {connect_failed, Error}},
-    %% increment stats for "client failed to connect"
-    riak_repl_stats:client_connect_errors(),
-    ok.
+%% ===================================================================
+%% Test API
+%% ===================================================================
+
+-ifdef(TEST).
+
+%% @doc Get the current state of the fsm for testing inspection
+-spec current_state(pid()) -> {atom(), #state{}} | {error, term()}.
+current_state(Pid) ->
+    gen_fsm:sync_send_all_state_event(Pid, current_state).
+
+-endif.

--- a/test/riak_core_cluster_conn_eqc.erl
+++ b/test/riak_core_cluster_conn_eqc.erl
@@ -1,0 +1,244 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+%% @doc Quickcheck test module for `riak_core_cluster_conn'.
+
+-module(riak_core_cluster_conn_eqc).
+
+-ifdef(EQC).
+-include_lib("eqc/include/eqc.hrl").
+-include_lib("eqc/include/eqc_fsm.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%% eqc properties
+-export([prop_cluster_conn_state_transition/0]).
+
+%% States
+-export([connecting/1,
+         waiting_for_cluster_name/1,
+         waiting_for_cluster_members/1,
+         connected/1]).
+
+%% eqc_fsm callbacks
+-export([initial_state/0,
+         initial_state_data/0,
+         next_state_data/5,
+         precondition/4,
+         postcondition/5]).
+
+%% Helpers
+-export([test/0,
+         test/1]).
+
+-compile(export_all).
+
+-define(QC_OUT(P),
+        eqc:on_output(fun(Str, Args) ->
+                              io:format(user, Str, Args) end, P)).
+
+-define(TEST_ITERATIONS, 500).
+-define(TEST_MODULE, riak_core_cluster_conn).
+
+-define(P(EXPR), PPP = (EXPR), case PPP of true -> ok; _ -> io:format(user, "PPP ~p at line ~p\n", [PPP, ?LINE]) end, PPP).
+
+-record(ccst_state, {current_state :: atom(),
+                     previous_state :: atom()}).
+
+%%====================================================================
+%% Eunit tests
+%%====================================================================
+
+eqc_test_() ->
+    {setup,
+     fun setup/0,
+     fun cleanup/1,
+     {spawn,
+      [
+       {timeout, 60, ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(30, ?QC_OUT(prop_cluster_conn_state_transition()))))}
+      ]
+     }}.
+
+setup() ->
+    error_logger:tty(false),
+    ok.
+
+cleanup(_) ->
+    ok.
+
+%% ====================================================================
+%% EQC Properties
+%% ====================================================================
+
+%% This property is designed to exercise the state transitions of
+%% `riak_core_cluster_conn'. The goal is to ensure that the reception
+%% of expected and unexpected events results in the expected state
+%% transition behavior. It is not intended to verify any of the side
+%% effects that may occur in any particular state and those are
+%% avoided by starting the fsm in `test' mode.
+prop_cluster_conn_state_transition() ->
+    ?FORALL(Cmds,
+            commands(?MODULE),
+            begin
+                {ok, Pid} = ?TEST_MODULE:start_link("FARFARAWAY", test),
+                {H, {_F, _S}, Res} =
+                    run_commands(?MODULE, Cmds, [{fsm_pid, Pid}]),
+                aggregate(zip(state_names(H), command_names(Cmds)),
+                          ?WHENFAIL(
+                             begin
+                                 ?debugFmt("\nCmds: ~p~n",
+                                           [zip(state_names(H),
+                                                command_names(Cmds))]),
+                                 ?debugFmt("\nResult: ~p~n", [Res]),
+                                 ?debugFmt("\nHistory: ~p~n", [H])
+                             end,
+                             equals(ok, Res)))
+            end).
+
+%%====================================================================
+%% eqc_fsm callbacks
+%%====================================================================
+
+initiating_connection(_S) ->
+    [
+     {history, {call, ?MODULE, poll_cluster, [{var, fsm_pid}]}},
+     {history, {call, ?MODULE, garbage_event, [{var, fsm_pid}]}},
+     {history, {call, ?TEST_MODULE, status, [{var, fsm_pid}]}},
+     {connecting, {call, ?MODULE, send_timeout, [{var, fsm_pid}]}}
+    ].
+
+connecting(_S) ->
+    [
+     {history, {call, ?MODULE, poll_cluster, [{var, fsm_pid}]}},
+     {history, {call, ?MODULE, garbage_event, [{var, fsm_pid}]}},
+     {history, {call, ?TEST_MODULE, status, [{var, fsm_pid}]}},
+     {waiting_for_cluster_name, {call, ?MODULE, connected_to_remote, [{var, fsm_pid}]}}
+    ].
+
+waiting_for_cluster_name(_S) ->
+    [
+     {history, {call, ?MODULE, poll_cluster, [{var, fsm_pid}]}},
+     {history, {call, ?MODULE, garbage_event, [{var, fsm_pid}]}},
+     {history, {call, ?TEST_MODULE, status, [{var, fsm_pid}]}},
+     {waiting_for_cluster_members, {call, ?MODULE, cluster_name, [{var, fsm_pid}]}}
+    ].
+
+waiting_for_cluster_members(_S) ->
+    [
+     {history, {call, ?MODULE, poll_cluster, [{var, fsm_pid}]}},
+     {history, {call, ?MODULE, garbage_event, [{var, fsm_pid}]}},
+     {history, {call, ?TEST_MODULE, status, [{var, fsm_pid}]}},
+     {connected, {call, ?MODULE, cluster_members, [{var, fsm_pid}]}}
+    ].
+
+connected(_S) ->
+    [
+     {history, {call, ?MODULE, garbage_event, [{var, fsm_pid}]}},
+     {history, {call, ?TEST_MODULE, status, [{var, fsm_pid}]}},
+     {waiting_for_cluster_name, {call, ?MODULE, poll_cluster, [{var, fsm_pid}]}},
+     {stopped, {call, ?TEST_MODULE, stop, [{var, fsm_pid}]}}
+    ].
+
+stopped(_S) ->
+    [].
+
+initial_state() ->
+    initiating_connection.
+
+initial_state_data() ->
+    #ccst_state{}.
+
+next_state_data(_From, _To, S, _R, _C) ->
+    S.
+
+precondition(_From, _To, _S, _C) ->
+    true.
+
+postcondition(initiating_connection, connecting, _S, {call, ?MODULE, send_timeout, [Pid]}, _R) ->
+    ?P(?MODULE:current_fsm_state(Pid) =:= connecting);
+postcondition(connected, connected, _S ,{call, ?MODULE, status, _}, R) ->
+    ExpectedStatus = {fake_socket,
+                      gen_netbeui,
+                      "overtherainbow",
+                      [{clustername, "FARFARAWAY"}]},
+    {_, status, Status} = R,
+    ?P(Status =:= ExpectedStatus);
+postcondition(State, State, _S ,{call, ?MODULE, status, [Pid]}, R) ->
+    ?P(R =:= State andalso ?MODULE:current_fsm_state(Pid) =:= State);
+postcondition(State, State, _S ,{call, ?MODULE, garbage_event, [Pid]}, _R) ->
+    ?P(?MODULE:current_fsm_state(Pid) =:= State);
+postcondition(connected, waiting_for_cluster_name, _S, {call, ?MODULE, poll_cluster, [Pid]}, _R) ->
+    ?P(?MODULE:current_fsm_state(Pid) =:= waiting_for_cluster_name);
+postcondition(State, State, _S, {call, ?MODULE, poll_cluster, [Pid]}, _R) ->
+    ?P(?MODULE:current_fsm_state(Pid) =:= State);
+postcondition(connecting, waiting_for_cluster_name, _S, {call, ?MODULE, connected_to_remote, [Pid]}, _R) ->
+    ?P(?MODULE:current_fsm_state(Pid) =:= waiting_for_cluster_name);
+postcondition(waiting_for_cluster_name, waiting_for_cluster_members, _S, {call, ?MODULE, cluster_name, [Pid]}, _R) ->
+    ?P(?MODULE:current_fsm_state(Pid) =:= waiting_for_cluster_members);
+postcondition(waiting_for_cluster_members, connected, _S, {call, ?MODULE, cluster_members, [Pid]}, _R) ->
+    ?P(?MODULE:current_fsm_state(Pid) =:= connected);
+postcondition(connected, stopped, _S ,{call, ?TEST_MODULE, stop, [Pid]}, _R) ->
+    ?P(is_process_alive(Pid) =:= false);
+%% Catch all
+postcondition(_From, _To, _S , _C, _R) ->
+    true.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+test() ->
+    test(500).
+
+test(Iterations) ->
+    eqc:quickcheck(eqc:numtests(Iterations, prop_cluster_conn_state_transition())).
+
+current_fsm_state(Pid) ->
+    {CurrentState, _} = ?TEST_MODULE:current_state(Pid),
+    CurrentState.
+
+send_timeout(Pid) ->
+    gen_fsm:send_event(Pid, timeout).
+
+poll_cluster(Pid) ->
+    gen_fsm:send_event(Pid, poll_cluster).
+
+garbage_event(Pid) ->
+    gen_fsm:send_event(Pid, slartibartfast).
+
+connected_to_remote(Pid) ->
+    Event = {connected_to_remote,
+             fake_socket,
+             gen_netbeui,
+             "overtherainbow",
+             [{clustername, "FARFARAWAY"}]},
+    gen_fsm:send_event(Pid, Event).
+
+cluster_name(Pid) ->
+    Event = {cluster_name, "FARFARAWAY"},
+    gen_fsm:send_event(Pid, Event).
+
+cluster_members(Pid) ->
+    Event = {cluster_members,
+             [{"fake-address-1", 1},
+              {"fake-address-2", 2}
+             ]},
+    gen_fsm:send_event(Pid, Event).
+
+-endif.


### PR DESCRIPTION
Convert `riak_core_cluster_conn` to use the OTP `gen_fsm` behavior. The changes affect the internal operation of the module, but the API is unchanged. Also add an eqc property to exercise the fsm state transitions.
### Review checklist
- [ ] manual verification of code
- [ ] eunit (w/ gist of output)
- [ ] EQC (w/ gist of output)
- [ ] riak_test (w/ gist of output)
- [ ] Dialyzer
- [ ] XRef
- [ ] Coverage reports
- [ ] internal docs (design docs)
- [ ] man pages
