### PR TITLE
Improve active anti-entropy replication.

### DIFF
--- a/include/riak_repl.hrl
+++ b/include/riak_repl.hrl
@@ -25,7 +25,7 @@
 -define(DEFAULT_SOURCE_PER_CLUSTER, 5).
 -define(DEFAULT_MAX_SINKS_NODE, 1).
 %% How many times during a fullsync we should try a partition
--define(DEFAULT_SOURCE_RETRIES, 5).
+-define(DEFAULT_SOURCE_RETRIES, infinity).
 %% 20 seconds. sources should claim within 5 seconds, but give them a little more time
 -define(RESERVATION_TIMEOUT, (20 * 1000)).
 -define(DEFAULT_MAX_FS_BUSIES_TOLERATED, 10).

--- a/include/riak_repl.hrl
+++ b/include/riak_repl.hrl
@@ -24,6 +24,8 @@
 -define(DEFAULT_SOURCE_PER_NODE, 1).
 -define(DEFAULT_SOURCE_PER_CLUSTER, 5).
 -define(DEFAULT_MAX_SINKS_NODE, 1).
+%% How many times during a fullsync we should try a partition
+-define(DEFAULT_SOURCE_RETRIES, 5).
 %% 20 seconds. sources should claim within 5 seconds, but give them a little more time
 -define(RESERVATION_TIMEOUT, (20 * 1000)).
 -define(DEFAULT_MAX_FS_BUSIES_TOLERATED, 10).

--- a/src/riak_repl2_fs_node_reserver.erl
+++ b/src/riak_repl2_fs_node_reserver.erl
@@ -114,7 +114,7 @@ handle_cast({claim_reservation, Partition}, State) ->
     Reserved2 = cancel_reservation_timeout(Partition, State#state.reservations),
     {noreply, State#state{reservations = Reserved2}};
 
-handle_cast(Msg, State) ->
+handle_cast(_Msg, State) ->
     {noreply, State}.
 
 

--- a/src/riak_repl2_fs_node_reserver.erl
+++ b/src/riak_repl2_fs_node_reserver.erl
@@ -52,7 +52,7 @@ reserve(Partition) ->
     end.
 
 %% @doc Release a reservation for the given partition on the correct node.
--spec unreserve(Partition :: any()) -> 'ok'.
+-spec unreserve(Partition :: any()) -> 'ok' | 'busy' | 'down'.
 unreserve(Partition) ->
     Node = get_partition_node(Partition),
     try gen_server:call({?SERVER, Node}, {unreserve, Partition}) of

--- a/src/riak_repl2_fs_node_reserver.erl
+++ b/src/riak_repl2_fs_node_reserver.erl
@@ -101,6 +101,8 @@ handle_call({reserve, Partition}, _From, State) ->
     end;
 
 %% @hidden
+%% This message is a call to prevent unreserve/reserve races, as well as
+%% detect failed processes.
 handle_call({unreserve, Partition}, _From, State) ->
     Reserved2 = cancel_reservation_timeout(Partition, State#state.reservations),
     {reply, ok, State#state{reservations = Reserved2}};

--- a/src/riak_repl2_fs_node_reserver.erl
+++ b/src/riak_repl2_fs_node_reserver.erl
@@ -55,7 +55,15 @@ reserve(Partition) ->
 -spec unreserve(Partition :: any()) -> 'ok'.
 unreserve(Partition) ->
     Node = get_partition_node(Partition),
-    gen_server:cast({?SERVER, Node}, {unreserve, Partition}).
+    try gen_server:call({?SERVER, Node}, {unreserve, Partition}) of
+        Out ->
+            Out
+    catch
+        exit:{noproc, _} ->
+            down;
+        exit:{{nodedown, _}, _} ->
+            down
+    end.
 
 %% @doc Indicates a reservation has been converted to a running sink. Usually
 %% used by a sink.
@@ -85,25 +93,25 @@ handle_call({reserve, Partition}, _From, State) ->
             Reserved2 = [{Partition, Tref} | State#state.reservations],
             {reply, ok, State#state{reservations = Reserved2}};
         true ->
-            lager:debug("Node busy for partition ~p. running=~p reserved=~p max=~p",
+            lager:info("Node busy for partition ~p. running=~p reserved=~p max=~p",
                         [Partition, Running, Reserved, Max]),
             {reply, busy, State}
     end;
+
+handle_call({unreserve, Partition}, _From, State) ->
+    Reserved2 = cancel_reservation_timeout(Partition, State#state.reservations),
+    {reply, ok, State#state{reservations = Reserved2}};
 
 handle_call(_Request, _From, State) ->
     {reply, ok, State}.
 
 
 %% @hidden
-handle_cast({unreserve, Partition}, State) ->
-    Reserved2 = cancel_reservation_timeout(Partition, State#state.reservations),
-    {noreply, State#state{reservations = Reserved2}};
-
 handle_cast({claim_reservation, Partition}, State) ->
     Reserved2 = cancel_reservation_timeout(Partition, State#state.reservations),
     {noreply, State#state{reservations = Reserved2}};
 
-handle_cast(_Msg, State) ->
+handle_cast(Msg, State) ->
     {noreply, State}.
 
 

--- a/src/riak_repl2_fs_node_reserver.erl
+++ b/src/riak_repl2_fs_node_reserver.erl
@@ -51,7 +51,9 @@ reserve(Partition) ->
             down
     end.
 
-%% @doc Release a reservation for the given partition on the correct node.
+%% @doc Release a reservation for the given partition on the correct
+%%      node.  If the node is down or a reservation process is not running,
+%%      `down' is returned.
 -spec unreserve(Partition :: any()) -> 'ok' | 'busy' | 'down'.
 unreserve(Partition) ->
     Node = get_partition_node(Partition),
@@ -98,6 +100,7 @@ handle_call({reserve, Partition}, _From, State) ->
             {reply, busy, State}
     end;
 
+%% @hidden
 handle_call({unreserve, Partition}, _From, State) ->
     Reserved2 = cancel_reservation_timeout(Partition, State#state.reservations),
     {reply, ok, State#state{reservations = Reserved2}};

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -390,7 +390,7 @@ handle_info({'EXIT', Pid, Cause},
             Retries = dict:update_counter(Partition, 1, Retries0),
 
             case dict:fetch(Partition, Retries) of
-                N when N > RetryLimit ->
+                N when N > RetryLimit, is_integer(RetryLimit) ->
                     lager:warning("fssource dropping partition: ~p, ~p failed"
                                "retries", [Partition, RetryLimit]),
                     ErrorExits = State#state.error_exits + 1,

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -38,11 +38,13 @@
     owners = [],
     connection_ref,
     partition_queue = queue:new(),
+    retries = dict:new(),
     whereis_waiting = [],
     busy_nodes = sets:new(),
     running_sources = [],
     successful_exits = 0,
     error_exits = 0,
+    retry_exits = 0,
     pending_fullsync = false,
     dirty_nodes = ordsets:new(),          % these nodes should run fullsync
     dirty_nodes_during_fs = ordsets:new(), % these nodes reported realtime errors
@@ -213,6 +215,7 @@ handle_call(status, _From, State = #state{socket=Socket}) ->
         {starting, length(State#state.whereis_waiting)},
         {successful_exits, State#state.successful_exits},
         {error_exits, State#state.error_exits},
+        {retry_exits, State#state.retry_exits},
         {busy_nodes, sets:size(State#state.busy_nodes)},
         {running_stats, SourceStats},
         {socket, SocketStats},
@@ -299,8 +302,10 @@ handle_cast(start_fullsync,  State) ->
                 largest_n = N,
                 owners = riak_core_ring:all_owners(Ring),
                 partition_queue = queue:from_list(Partitions),
+                retries = dict:new(),
                 successful_exits = 0,
                 error_exits = 0,
+                retry_exits = 0,
                 fullsync_start_time = riak_core_util:moment()
             },
             State3 = start_up_reqs(State2),
@@ -319,6 +324,7 @@ handle_cast(stop_fullsync, State) ->
         largest_n = undefined,
         owners = [],
         partition_queue = queue:new(),
+        retries = dict:new(),
         whereis_waiting = [],
         running_sources = []
     },
@@ -330,7 +336,8 @@ handle_cast(_Msg, State) ->
 
 
 %% @hidden
-handle_info({'EXIT', Pid, Cause}, State) when Cause =:= normal; Cause =:= shutdown ->
+handle_info({'EXIT', Pid, Cause},
+            #state{socket=Socket, transport=Transport}=State) when Cause =:= normal; Cause =:= shutdown ->
     lager:debug("fssource ~p exited normally", [Pid]),
     PartitionEntry = lists:keytake(Pid, 1, State#state.running_sources),
     case PartitionEntry of
@@ -344,44 +351,22 @@ handle_info({'EXIT', Pid, Cause}, State) when Cause =:= normal; Cause =:= shutdo
             {_, _, Node} = Partition,
             NewBusies = sets:del_element(Node, State#state.busy_nodes),
 
+            % ensure we unreserve the partition on the remote node
+            % instead of waiting for a timeout.
+            Transport:send(Socket, term_to_binary({unreserve, Partition})),
+
             % stats
             Sucesses = State#state.successful_exits + 1,
-            State2 = State#state{successful_exits = Sucesses},
+            State2 = State#state{successful_exits = Sucesses,
+                                 busy_nodes = NewBusies},
 
             % are we done?
-            EmptyRunning =  Running == [],
-            QEmpty = queue:is_empty(State#state.partition_queue),
-            Waiting = State#state.whereis_waiting,
-            case {EmptyRunning, QEmpty, Waiting} of
-                {true, true, []} ->
-                    MyClusterName = riak_core_connection:symbolic_clustername(),
-                    lager:info("Fullsync complete from ~s to ~s",
-                               [MyClusterName, State#state.other_cluster]),
-                    % clear the "rt dirty" stat if it's set,
-                    % otherwise, don't do anything
-                    State3 = notify_rt_dirty_nodes(State2),
-                    %% update legacy stats too! some riak_tests depend on them.
-                    riak_repl_stats:server_fullsyncs(),
-                    TotalFullsyncs = State#state.fullsyncs_completed + 1,
-                    Finish = riak_core_util:moment(),
-                    ElapsedSeconds = Finish - State#state.fullsync_start_time,
-                    riak_repl_util:schedule_cluster_fullsync(State#state.other_cluster),
-                    {noreply, State3#state{running_sources = Running,
-                                           busy_nodes = NewBusies,
-                                           fullsyncs_completed = TotalFullsyncs,
-                                           fullsync_start_time = undefined,
-                                           last_fullsync_duration=ElapsedSeconds
-                                          }};
-                _ ->
-                    % there's something waiting for a response.
-                    State3 = start_up_reqs(State2#state{running_sources = Running,
-                                                        busy_nodes = NewBusies}),
-                    {noreply, State3}
-            end
+            maybe_complete_fullsync(Running, State2)
     end;
 
-handle_info({'EXIT', Pid, _Cause}, State) ->
-    lager:warning("fssource ~p exited abnormally", [Pid]),
+handle_info({'EXIT', Pid, Cause},
+            #state{socket=Socket, transport=Transport}=State) ->
+    lager:info("fssource ~p exited abnormally: ~p", [Pid, Cause]),
     PartitionEntry = lists:keytake(Pid, 1, State#state.running_sources),
     case PartitionEntry of
         false ->
@@ -393,16 +378,41 @@ handle_info({'EXIT', Pid, _Cause}, State) ->
             {_, _, Node} = Partition,
             NewBusies = sets:del_element(Node, State#state.busy_nodes),
 
-            % stats
-            ErrorExits = State#state.error_exits + 1,
-            #state{partition_queue = PQueue} = State,
+            % ensure we unreserve the partition on the remote node
+            % instead of waiting for a timeout.
+            Transport:send(Socket, term_to_binary({unreserve, Partition})),
 
-            % reset for retry later
-            PQueue2 = queue:in(Partition, PQueue),
-            State2 = State#state{partition_queue = PQueue2, busy_nodes = NewBusies,
-                running_sources = Running, error_exits = ErrorExits},
-            State3 = start_up_reqs(State2),
-            {noreply, State3}
+            % stats
+            #state{partition_queue = PQueue, retries = Retries0} = State,
+
+            RetryLimit = app_helper:get_env(riak_repl, max_fssource_retries,
+                                            ?DEFAULT_SOURCE_RETRIES),
+            Retries = dict:update_counter(Partition, 1, Retries0),
+
+            case dict:fetch(Partition, Retries) of
+                N when N > RetryLimit ->
+                    lager:warning("fssource dropping partition: ~p, ~p failed"
+                               "retries", [Partition, RetryLimit]),
+                    ErrorExits = State#state.error_exits + 1,
+                    State2 = State#state{busy_nodes = NewBusies,
+                                         retries = Retries,
+                                         running_sources = Running,
+                                         error_exits = ErrorExits},
+                    maybe_complete_fullsync(Running, State2);
+                _ -> %% have not run out of retries yet
+                    % reset for retry later
+                    lager:info("fssource rescheduling partition: ~p",
+                               [Partition]),
+                    PQueue2 = queue:in(Partition, PQueue),
+                    RetryExits = State#state.retry_exits + 1,
+                    State2 = State#state{partition_queue = PQueue2,
+                                         retries = Retries,
+                                         busy_nodes = NewBusies,
+                                         running_sources = Running,
+                                         retry_exits = RetryExits},
+                    State3 = start_up_reqs(State2),
+                    {noreply, State3}
+            end
     end;
 
 handle_info({Partition, whereis_timeout}, State) ->
@@ -750,6 +760,35 @@ is_fullsync_in_progress(State) ->
             false;
         _ ->
             true
+    end.
+
+maybe_complete_fullsync(Running, State) ->
+    EmptyRunning =  Running == [],
+    QEmpty = queue:is_empty(State#state.partition_queue),
+    Waiting = State#state.whereis_waiting,
+    case {EmptyRunning, QEmpty, Waiting} of
+        {true, true, []} ->
+            MyClusterName = riak_core_connection:symbolic_clustername(),
+            lager:info("Fullsync complete from ~s to ~s",
+                       [MyClusterName, State#state.other_cluster]),
+            % clear the "rt dirty" stat if it's set,
+            % otherwise, don't do anything
+            State2 = notify_rt_dirty_nodes(State),
+            %% update legacy stats too! some riak_tests depend on them.
+            riak_repl_stats:server_fullsyncs(),
+            TotalFullsyncs = State#state.fullsyncs_completed + 1,
+            Finish = riak_core_util:moment(),
+            ElapsedSeconds = Finish - State#state.fullsync_start_time,
+            riak_repl_util:schedule_cluster_fullsync(State#state.other_cluster),
+            {noreply, State2#state{running_sources = Running,
+                                   fullsyncs_completed = TotalFullsyncs,
+                                   fullsync_start_time = undefined,
+                                   last_fullsync_duration=ElapsedSeconds
+                                  }};
+        _ ->
+            % there's something waiting for a response.
+            State2 = start_up_reqs(State#state{running_sources = Running}),
+            {noreply, State2}
     end.
 
 % dirty_nodes is the set of nodes that are marked "dirty"

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -344,7 +344,7 @@ handle_info({'EXIT', Pid, Cause},
         false ->
             % late exit or otherwise non-existant
             {noreply, State};
-        {value, {Pid, Partition}, Running} ->
+        {value, {Pid, {Index, _, _}=Partition}, Running} ->
 
             % likely a slot on the remote node opened up, so re-enable that
             % remote node for whereis requests.
@@ -353,7 +353,7 @@ handle_info({'EXIT', Pid, Cause},
 
             % ensure we unreserve the partition on the remote node
             % instead of waiting for a timeout.
-            Transport:send(Socket, term_to_binary({unreserve, Partition})),
+            Transport:send(Socket, term_to_binary({unreserve, Index})),
 
             % stats
             Sucesses = State#state.successful_exits + 1,
@@ -372,7 +372,7 @@ handle_info({'EXIT', Pid, Cause},
         false ->
             % late exit
             {noreply, State};
-        {value, {Pid, Partition}, Running} ->
+        {value, {Pid, {Index, _, _}=Partition}, Running} ->
 
             % even a bad exit opens a slot on the remote node
             {_, _, Node} = Partition,
@@ -380,7 +380,7 @@ handle_info({'EXIT', Pid, Cause},
 
             % ensure we unreserve the partition on the remote node
             % instead of waiting for a timeout.
-            Transport:send(Socket, term_to_binary({unreserve, Partition})),
+            Transport:send(Socket, term_to_binary({unreserve, Index})),
 
             % stats
             #state{partition_queue = PQueue, retries = Retries0} = State,

--- a/src/riak_repl_aae_sink.erl
+++ b/src/riak_repl_aae_sink.erl
@@ -88,18 +88,18 @@ handle_info({'DOWN', _, _, _, _}, State) ->
 
 handle_info({tcp_closed, Socket}, State=#state{socket=Socket}) ->
     lager:info("AAE sink connection to ~p closed", [State#state.clustername]),
-    {stop, normal, State};
-handle_info({tcp_error, _Socket, Reason}, State) ->
+    {stop, {tcp_closed, Socket}, State};
+handle_info({tcp_error, Socket, Reason}, State) ->
     lager:error("AAE sink connection to ~p closed unexpectedly: ~p",
                 [State#state.clustername, Reason]),
-    {stop, normal, State};
+    {stop, {tcp_error, Socket, Reason}, State};
 handle_info({ssl_closed, Socket}, State=#state{socket=Socket}) ->
     lager:info("AAE sink ssl connection to ~p closed", [State#state.clustername]),
-    {stop, normal, State};
-handle_info({ssl_error, _Socket, Reason}, State) ->
+    {stop, {ssl_closed, Socket}, State};
+handle_info({ssl_error, Socket, Reason}, State) ->
     lager:error("AAE sink ssl connection to ~p closed unexpectedly with: ~p",
                 [State#state.clustername, Reason]),
-    {stop, normal, State};
+    {stop, {ssl_error, Socket, Reason}, State};
 handle_info({Error, Socket, Reason},
             State=#state{socket=MySocket}) when Socket == MySocket ->
     lager:info("AAE sink connection to ~p closed unexpectedly: ~p",
@@ -122,12 +122,16 @@ code_change(_OldVsn, State, _Extra) ->
 %% replies: ok
 process_msg(?MSG_INIT, Partition, State) ->
     lager:info("MSG_INIT for partition ~p", [Partition]),
-    {ok, TreePid} = riak_kv_vnode:hashtree_pid(Partition),
-    %% monitor the tree and crash if the tree goes away
-    monitor(process, TreePid),
-    %% tell the reservation coordinator that we are taking this partition.
-    riak_repl2_fs_node_reserver:claim_reservation(Partition),
-    send_reply(ok, State#state{partition=Partition, tree_pid=TreePid});
+    case riak_kv_vnode:hashtree_pid(Partition) of
+        {ok, TreePid} ->
+            %% monitor the tree and crash if the tree goes away
+            monitor(process, TreePid),
+            %% tell the reservation coordinator that we are taking this partition.
+            riak_repl2_fs_node_reserver:claim_reservation(Partition),
+            send_reply(ok, State#state{partition=Partition, tree_pid=TreePid});
+        {error, wrong_node} ->
+            {stop, wrong_node, State}
+    end;
 
 process_msg(?MSG_GET_AAE_BUCKET, {Level,BucketNum,IndexN}, State=#state{tree_pid=TreePid}) ->
     ResponseMsg = riak_kv_index_hashtree:exchange_bucket(IndexN, Level, BucketNum, TreePid),

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -198,14 +198,6 @@ prepare_exchange(start_exchange, State=#state{index=Partition}) ->
     case send_synchronous_msg(?MSG_LOCK_TREE, State) of
         ok ->
             update_trees(start_exchange, State);
-        already_locked ->
-            %% This partition is already locked, probably by a vnode doing a handoff.
-            %% ideally, we would put this back on the queue, but we'll just need to
-            %% wait for a while and try again since we can't unclaim it yet.
-            lager:info("AAE tree for partition ~p is already_locked. Trying again in ~p seconds.",
-                       [?RETRY_AAE_LOCKED_INTERVAL]),
-            gen_fsm:send_event_after(?RETRY_AAE_LOCKED_INTERVAL, start_exchange),
-            {next_state, prepare_exchange, State};
         Error ->
             lager:warning("lock tree for partition ~p failed, got ~p",
                           [Partition, Error]),

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -55,7 +55,7 @@
 -spec start_link(term(), term(), term(), term(), index(), pid())
                 -> {ok,pid()} | ignore | {error, term()}.
 start_link(Cluster, Client, Transport, Socket, Partition, OwnerPid) ->
-    gen_fsm:start(?MODULE, [Cluster, Client, Transport, Socket, Partition, OwnerPid], []).
+    gen_fsm:start_link(?MODULE, [Cluster, Client, Transport, Socket, Partition, OwnerPid], []).
 
 start_exchange(AAESource) ->
     lager:debug("Send start_exchange to AAE fullsync sink worker"),
@@ -73,33 +73,17 @@ init([Cluster, Client, Transport, Socket, Partition, OwnerPid]) ->
     %% for all combined IndexNs and iterate over them. When finished, send
     %% COMPLETE msg to signal sink to die and unlock tree.
 
-    lager:info("AAE fullsync source worker started for partition ~p", [Partition]),
-
-    Timeout = app_helper:get_env(riak_kv,
-                                 anti_entropy_timeout,
-                                 ?DEFAULT_ACTION_TIMEOUT),
-
-    {ok, TreePid} = riak_kv_vnode:hashtree_pid(Partition),
-
-    TreeMref = monitor(process, TreePid),
-
-    %% List of IndexNs to iterate over.
-    IndexNs = riak_kv_util:responsible_preflists(Partition),
-
-    lager:debug("AAE fullsync source partition ~p has Indexes ~p", [Partition, IndexNs]),
+    lager:info("AAE fullsync source worker started for partition ~p",
+               [Partition]),
 
     State = #state{cluster=Cluster,
                    client=Client,
                    transport=Transport,
                    socket=Socket,
                    index=Partition,
-                   indexns=IndexNs,
-                   tree_pid=TreePid,
-                   tree_mref=TreeMref,
-                   timeout=Timeout,
                    built=0,
                    owner=OwnerPid,
-                   wire_ver=w1}, %% future version may change wire format, but w1 for now.
+                   wire_ver=w1},
     {ok, prepare_exchange, State}.
 
 handle_event(_Event, StateName, State) ->
@@ -121,7 +105,7 @@ handle_sync_event(_Event, _From, StateName, State) ->
 
 handle_info({'DOWN', TreeMref, process, Pid, Why}, _StateName, State=#state{tree_mref=TreeMref}) ->
     %% Local hashtree process went down. Stop exchange.
-    lager:info("Monitored pid ~p, AAE Hashtree process went down", [Pid, Why]),
+    lager:info("Monitored pid ~p, AAE Hashtree process went down because: ~p", [Pid, Why]),
     send_complete(State),
     {stop, {aae_hashtree_went_down, Why}, State};
 handle_info(Error={'DOWN', _, _, _, _}, _StateName, State) ->
@@ -129,7 +113,22 @@ handle_info(Error={'DOWN', _, _, _, _}, _StateName, State) ->
     lager:info("Something went down ~p", [Error]),
     send_complete(State),
     {stop, something_went_down, State};
+handle_info({tcp_closed, Socket}, _StateName, State=#state{socket=Socket}) ->
+    lager:info("AAE source connection to ~p closed", [State#state.cluster]),
+    {stop, {tcp_closed, Socket}, State};
+handle_info({tcp_error, Socket, Reason}, _StateName, State) ->
+    lager:error("AAE source connection to ~p closed unexpectedly: ~p",
+                [State#state.cluster, Reason]),
+    {stop, {tcp_error, Socket, Reason}, State};
+handle_info({ssl_closed, Socket}, _StateName, State=#state{socket=Socket}) ->
+    lager:info("AAE source ssl connection to ~p closed", [State#state.cluster]),
+    {stop, {ssl_closed, Socket}, State};
+handle_info({ssl_error, Socket, Reason}, _StateName, State) ->
+    lager:error("AAE source ssl connection to ~p closed unexpectedly with: ~p",
+                [State#state.cluster, Reason]),
+    {stop, {ssl_error, Socket, Reason}, State};
 handle_info(_Info, StateName, State) ->
+    lager:info("ignored handle_info: ~p", [_Info]),
     {next_state, StateName, State}.
 
 terminate(_Reason, _StateName, _State) ->
@@ -148,10 +147,10 @@ code_change(_OldVsn, StateName, State, _Extra) ->
 %%      remote concurrency lock, and remote tree lock. Exchange will
 %%      timeout if locks cannot be acquired in a timely manner.
 prepare_exchange(cancel_fullsync, State) ->
-    larger:info("AAE fullsync source cancelled for partition ~p", [State#state.index]),
+    lager:info("AAE fullsync source cancelled for partition ~p", [State#state.index]),
     send_complete(State),
     {stop, normal, State};
-prepare_exchange(start_exchange, State=#state{transport=Transport,
+prepare_exchange(start_exchange, State0=#state{transport=Transport,
                                               socket=Socket,
                                               index=Partition,
                                               local_lock=Lock}) when Lock == false ->
@@ -163,16 +162,36 @@ prepare_exchange(start_exchange, State=#state{transport=Transport,
     %% try to get local lock of the tree
     lager:debug("Prepare exchange for partition ~p", [Partition]),
     ok = Transport:setopts(Socket, TcpOptions),
-    ok = send_synchronous_msg(?MSG_INIT, Partition, State),
-    case riak_kv_index_hashtree:get_lock(State#state.tree_pid, fullsync_source) of
-        ok ->
-            prepare_exchange(start_exchange, State#state{local_lock=true});
-        Error ->
-            lager:info("AAE source failed get_lock for partition ~p, got ~p",
-                       [Partition, Error]),
-            send_complete(State),
-            throw(Error),
-            {stop, Error, State}
+    ok = send_synchronous_msg(?MSG_INIT, Partition, State0),
+
+    %% Timeout for AAE.
+    Timeout = app_helper:get_env(riak_kv,
+                                 anti_entropy_timeout,
+                                 ?DEFAULT_ACTION_TIMEOUT),
+
+    %% List of IndexNs to iterate over.
+    IndexNs = riak_kv_util:responsible_preflists(Partition),
+
+    lager:debug("AAE fullsync source partition ~p has Indexes ~p",
+                [Partition, IndexNs]),
+
+    case riak_kv_vnode:hashtree_pid(Partition) of
+        {ok, TreePid} ->
+            TreeMref = monitor(process, TreePid),
+            State = State0#state{timeout=Timeout,
+                                 indexns=IndexNs,
+                                 tree_pid=TreePid,
+                                 tree_mref=TreeMref},
+            case riak_kv_index_hashtree:get_lock(TreePid, fullsync_source) of
+                ok ->
+                    prepare_exchange(start_exchange, State#state{local_lock=true});
+                Error ->
+                    lager:info("AAE source failed get_lock for partition ~p, got ~p",
+                               [Partition, Error]),
+                    {stop, Error, State}
+            end;
+        {error, wrong_node} ->
+            {stop, wrong_node, State0}
     end;
 prepare_exchange(start_exchange, State=#state{index=Partition}) ->
     %% try to get the remote lock
@@ -191,7 +210,6 @@ prepare_exchange(start_exchange, State=#state{index=Partition}) ->
             lager:warning("lock tree for partition ~p failed, got ~p",
                           [Partition, Error]),
             send_complete(State),
-            throw({remote,Error}),
             {stop, {remote, Error}, State}
     end.
 
@@ -201,7 +219,7 @@ prepare_exchange(start_exchange, State=#state{index=Partition}) ->
 %%      continue to finish the update even after the exchange times out,
 %%      a future exchange should eventually make progress.
 update_trees(cancel_fullsync, State) ->
-    larger:info("AAE fullsync source cancelled for partition ~p", [State#state.index]),
+    lager:info("AAE fullsync source cancelled for partition ~p", [State#state.index]),
     send_complete(State),
     {stop, normal, State};
 update_trees(start_exchange, State=#state{indexns=IndexN, owner=Owner}) when IndexN == [] ->
@@ -222,11 +240,10 @@ update_trees(start_exchange, State=#state{tree_pid=TreePid,
             update_trees({not_responsible, Partition, IndexN}, State)
     end;
 
-update_trees({not_responsible, Partition, IndexN}, State) ->
+update_trees({not_responsible, Partition, IndexN}, State=#state{owner=Owner}) ->
     lager:info("VNode ~p does not cover preflist ~p", [Partition, IndexN]),
-    send_complete(State),
-%%    throw({not_responsible, Partition, IndexN}),
-    {stop, not_responsible, State};
+    gen_server:cast(Owner, not_responsible),
+    {stop, normal, State};
 update_trees({tree_built, _, _}, State) ->
     Built = State#state.built + 1,
     case Built of
@@ -241,7 +258,7 @@ update_trees({tree_built, _, _}, State) ->
 %% @doc Now that locks have been acquired and both hashtrees have been updated,
 %%      perform a key exchange and trigger replication for any divergent keys.
 key_exchange(cancel_fullsync, State) ->
-    larger:info("AAE fullsync source cancelled for partition ~p", [State#state.index]),
+    lager:info("AAE fullsync source cancelled for partition ~p", [State#state.index]),
     send_complete(State),
     {stop, normal, State};
 key_exchange(start_key_exchange, State=#state{cluster=Cluster,
@@ -578,11 +595,13 @@ send_asynchronous_msg(MsgType, #state{transport=Transport,
 %% states through the fsm. That will allow us to service a status
 %% request without blocking. We could also handle lates messages
 %% without having to die.
-get_reply(#state{transport=Transport, socket=Socket}) ->
+get_reply(State=#state{transport=Transport, socket=Socket}) ->
     %% don't block forever, but if we timeout, then die with reason
     case Transport:recv(Socket, 0, ?AAE_FULLSYNC_REPLY_TIMEOUT) of
         {ok, [?MSG_REPLY|Data]} ->
             binary_to_term(Data);
         {error, Reason} ->
-            throw(Reason)
+            %% This generate a return value that the fssource can
+            %% display and possibly retry the partition from.
+            throw({stop, Reason, State})
     end.

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -69,10 +69,6 @@ cancel_fullsync(Pid) ->
 %%%===================================================================
 
 init([Cluster, Client, Transport, Socket, Partition, OwnerPid]) ->
-    %% Get the list of IndexNs for this partition. We'll lock the tree just once
-    %% for all combined IndexNs and iterate over them. When finished, send
-    %% COMPLETE msg to signal sink to die and unlock tree.
-
     lager:info("AAE fullsync source worker started for partition ~p",
                [Partition]),
 


### PR DESCRIPTION
Provided below is a summary of bugs fixed.

In the event that the tcp connection errors without completing
full-sync, and when the max fssinks is not configured and defaulted to
one, this causes the aae_sink process to terminate normally, but not
propagate errors to the fssink process.  This causes an abandoned fssink
process, which locks out any future reservations for fullsync causing
replication to stall indefinitely on the sink cluster.

In the event that max fssink setting is not configured to one, and
specified at another value, tcp errors can cause available reservation
slots to be depleted over time.

Gracefully handle the not_built message from the hashtree.

Ensure that when aae_source dies, we handle the DOWN message and
terminate the fsssource process instead of ignoring the message.

Do not throw the error, or send the complete message to the sink, when
the process dies; both are not necessary.

Ensure abnormal exits when the aae_source fails.

Remove monitors, handle not_responsible as a independent message instead
of a failure state.

Provide a bound on the number of times a partition will be retried in
the event of failure through the fullsync coodinator proces.  If we
exceed the number of retries for all queued partitions, end the
fullsync.

If ownership transfer is occuring, ensure we bail and nodify the
fscoordinator with an abnormal exit, which will reschedule the
partition.

No longer attempt to gain locks on hashtrees during the initialization
function of a sink process, which, in the event of failure would cause
connection manager to use an exponential backoff, in addition to
invalidating the endpoint preventing other partitions on the same node
from being synchronized.

Ensure that the AAE source process exits if the socket closes.

Ensure we reserve and unreserve partitions when we detect source
processes exiting.
