### PR TITLE
Don't write empty clusters to the ring, ever

### DIFF
--- a/src/riak_repl_ring.erl
+++ b/src/riak_repl_ring.erl
@@ -274,6 +274,9 @@ set_clusterIpAddrs(Ring, {ClusterName, Addrs}) ->
                            _Addrs ->
                                lists:keyreplace(ClusterName, 1, OldClusters, Cluster)
                        end;
+                   _ when Addrs == [] ->
+                       %% New cluster has no members, don't add it to the ring
+                       OldClusters;
                    _ ->
                        [Cluster | OldClusters]
                end,


### PR DESCRIPTION
Before, if the cluster already existed in the ring and the new
memberlist was empty, it would be deleted from the ring. However if you
tried to disconnect an unconnected cluster it would try to delete it
from the ring by writing the member list as [], but since it was not in
the ring before, instead of deleting it, the cluster would be written
with a empty memberlist. The connection manager would then, as part of
ensuring a connection to all configured clusters, try to connect to it
and block any legitimate connection attempts to that cluster.

This patch treats a write of an empty member list when the cluster is
not in the ring as a no-op.
