### PR TITLE
Bugfix/mw reduced repl deadlocks

### DIFF
--- a/include/riak_repl.hrl
+++ b/include/riak_repl.hrl
@@ -36,6 +36,9 @@
 -define(BT_META_TYPED_BUCKET, typed_bucket).
 -define(BT_META_TYPE, bucket_type).
 -define(BT_META_PROPS_HASH, properties_hash_val).
+% 5 is arbitrarily chosen to allow other mutators to be defines before,
+% but not be an absurdly large number.
+-define(REPL_REDUCED_PRIORITY, 5).
 
 -type(ip_addr_str() :: string()).
 -type(ip_portnum() :: non_neg_integer()).

--- a/src/riak_repl_reduced.erl
+++ b/src/riak_repl_reduced.erl
@@ -90,7 +90,8 @@ mutate_get(InObject) ->
 
 local_ring_get(InObject, BKey, Partition) ->
     lager:debug("Local ring get for ~p on partition ~p", [BKey, Partition]),
-    {_P, MonitorTarg} = Partition,
+    {Index, _Node} = Partition,
+    {ok, MonitorTarg} = riak_core_vnode_manager:get_vnode_pid(Index, riak_kv_vnode),
     MonRef = erlang:monitor(process, MonitorTarg),
     Preflist = [Partition],
     ReqId = make_ref(),

--- a/src/riak_repl_reduced.erl
+++ b/src/riak_repl_reduced.erl
@@ -106,7 +106,6 @@ local_ring_get(InObject, BKey, Partition, MonitorTarg) ->
     riak_core_vnode_master:command(Preflist, Req, {raw, ReqId, self()}, riak_kv_vnode_master),
     receive
         {ReqId, {r, {ok, RObj}, _, ReqId}} ->
-            %lager:debug("successful get!"),
             RObj;
         {ReqId, {r, {error, notfound}, _, ReqId}} ->
             lager:debug("~p not found, falling back to proxy", [BKey]),
@@ -214,7 +213,7 @@ mutate_put(InMeta, InVal, RevealedMeta, RObj, BucketProps, NumberReals) ->
 
 % the symbolic_clustername functions in riak_core_connection always return
 % a string. However, if the cluster is not named, that string is useless
-% for proxy get. So, rather than do a proxy get that can never succeede
+% for proxy get. So, rather than do a proxy get that can never succeed
 % we check if the cluster is actually named, and if not, return
 % 'undefined' rather than lie.
 get_clustername() ->

--- a/src/riak_repl_reduced.erl
+++ b/src/riak_repl_reduced.erl
@@ -92,6 +92,13 @@ local_ring_get(InObject, BKey, Partition) ->
     lager:debug("Local ring get for ~p on partition ~p", [BKey, Partition]),
     {Index, _Node} = Partition,
     {ok, MonitorTarg} = riak_core_vnode_manager:get_vnode_pid(Index, riak_kv_vnode),
+    local_ring_get(InObject, BKey, Partition, MonitorTarg).
+
+local_ring_get(InObject, BKey, Partition, MonitorTarg) when MonitorTarg == self() ->
+    lager:warning("Something must have changed between preflist detmination for ~p and now, because ~p points to myself", [BKey, element(1, Partition)]),
+    proxy_get(InObject);
+
+local_ring_get(InObject, BKey, Partition, MonitorTarg) ->
     MonRef = erlang:monitor(process, MonitorTarg),
     Preflist = [Partition],
     ReqId = make_ref(),

--- a/src/riak_repl_reduced.erl
+++ b/src/riak_repl_reduced.erl
@@ -105,11 +105,7 @@ local_ring_get(InObject, BKey, Partition) ->
             lager:debug("~p not found, falling back to proxy", [BKey]),
             proxy_get(InObject);
         {'DOWN', MonRef, prcess, MonitorTarg, Wut} ->
-            lager:info("could not get value from target due to exit: ~p", [Wut]),
-            proxy_get(InObject)
-    after
-        ?REPL_FSM_TIMEOUT ->
-            lager:info("timeout"),
+            lager:info("could not get value for ~p from target due to exit: ~p", [BKey, Wut]),
             proxy_get(InObject)
     end.
 

--- a/src/riak_repl_reduced.erl
+++ b/src/riak_repl_reduced.erl
@@ -99,10 +99,10 @@ local_ring_get(InObject, BKey, Partition) ->
     riak_core_vnode_master:command(Preflist, Req, {raw, ReqId, self()}, riak_kv_vnode_master),
     receive
         {ReqId, {r, {ok, RObj}, _, ReqId}} ->
-            lager:debug("successful get!"),
+            %lager:debug("successful get!"),
             RObj;
         {ReqId, {r, {error, notfound}, _, ReqId}} ->
-            lager:debug("not found, falling back to proxy"),
+            lager:debug("~p not found, falling back to proxy", [BKey]),
             proxy_get(InObject);
         {'DOWN', MonRef, prcess, MonitorTarg, Wut} ->
             lager:info("could not get value from target due to exit: ~p", [Wut]),

--- a/src/riak_repl_ring_handler.erl
+++ b/src/riak_repl_ring_handler.erl
@@ -27,6 +27,7 @@ init([]) ->
     riak_repl2_leader:set_candidates(AllNodes, []),
     rt_update_events(Ring),
     pg_update_events(Ring),
+    update_mutator(Ring),
     {ok, #state{ring=Ring}}.
 
 handle_event({ring_update, Ring}, State=#state{ring=Ring}) ->
@@ -38,6 +39,7 @@ handle_event({ring_update, NewRing}, State=#state{ring=OldRing}) ->
     update_leader(FinalRing),
     rt_update_events(FinalRing),
     pg_update_events(FinalRing),
+    update_mutator(FinalRing),
     riak_repl_listener_sup:ensure_listeners(FinalRing),
     case riak_repl_leader:is_leader() of
         true ->
@@ -200,4 +202,13 @@ rt_update_events(Ring) ->
 pg_update_events(Ring) ->
     riak_repl2_pg:ensure_pg(riak_repl_ring:pg_enabled(Ring)).
 
+update_mutator(Ring) ->
+    case riak_core_capability:get({riak_kv, mutators}, false) of
+        false ->
+            lager:debug("unregister repl reduced"),
+            riak_kv_mutator:unregister(riak_repl_reduced);
+        true ->
+            lager:debug("registering repl reduced"),
+            riak_kv_mutator:register(riak_repl_reduced, 5)
+    end.
 

--- a/src/riak_repl_ring_handler.erl
+++ b/src/riak_repl_ring_handler.erl
@@ -209,6 +209,6 @@ update_mutator(_Ring) ->
             riak_kv_mutator:unregister(riak_repl_reduced);
         true ->
             lager:debug("registering repl reduced"),
-            riak_kv_mutator:register(riak_repl_reduced, 5)
+            riak_kv_mutator:register(riak_repl_reduced, ?REPL_REDUCED_PRIORITY)
     end.
 

--- a/src/riak_repl_ring_handler.erl
+++ b/src/riak_repl_ring_handler.erl
@@ -202,7 +202,7 @@ rt_update_events(Ring) ->
 pg_update_events(Ring) ->
     riak_repl2_pg:ensure_pg(riak_repl_ring:pg_enabled(Ring)).
 
-update_mutator(Ring) ->
+update_mutator(_Ring) ->
     case riak_core_capability:get({riak_kv, mutators}, false) of
         false ->
             lager:debug("unregister repl reduced"),


### PR DESCRIPTION
Fixes to the mutate_get for reduced repl to remove several instances that could deadlock a vnode. The problems are apparent when running the repl_reduced:read_repair_interaction riak test as found on https://github.com/basho/riak_test/pull/392 .
