### PR TITLE
Ensure we update the bloom for object differences.

### DIFF
--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -459,6 +459,7 @@ accumulate_diff(KeyDiff, Bloom, [Count], #state{index=Partition}) ->
                 {Bucket,Key} = binary_to_term(Bin),
                 lager:debug("Keydiff: remote partition ~p different: ~p:~p",
                             [Partition, Bucket, Key]),
+                ebloom:insert(Bloom, <<Bucket/binary, Key/binary>>),
                 1;
             {missing, Bin} ->
                 %% remote has a key we don't have. Ignore it.


### PR DESCRIPTION
Fix a bug where we incremented the count of modified objects, but failed
to update the bloom filter accordingly preventing objects from being
replicated during fullsync.

Let me know if this looks good, and I'll backport the change to Riak 1.4.
