### PR TITLE
Filter consistent objects during fullsync replication

### DIFF
--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -231,7 +231,8 @@ repl_helper_send(Object, C) ->
 fullsync_enabled_for_bucket(Bucket, _C) ->
     case riak_core_bucket:get_bucket(Bucket) of
         {error, _Reason} ->
-            ok;
+            %% Bucket type does not exist so do not enable fullsync
+            false;
         Props ->
             not is_consistent_bucket(Props) andalso is_fullsync_enabled(Props)
     end.


### PR DESCRIPTION
Replication of consistent objects is not supported in Riak 2.0. Add
code to check the bucket properties of an object during fullsync and
prevent replication if the consistent property is set. It is not
necessary to filter realtime write at this time because the postcommit
hook used for realtime is not invoked on the consistent code path.
