### PR TITLE
Correct stats bug.

### DIFF
--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -206,8 +206,7 @@ handle_call(legacy_status, _From, State = #state{remote = Remote}) ->
         [{node, node()},
          {site, Remote},
          {strategy, realtime},
-         {socket, riak_core_tcp_mon:format_socket_stats(SocketStats, [])}],
-        QStats,
+         {socket, riak_core_tcp_mon:format_socket_stats(SocketStats, [])}] ++ QStats,
     {reply, {status, Status}, State};
 %% Receive connection from connection manager
 handle_call({connected, Socket, Transport, EndPoint, Proto}, _From,


### PR DESCRIPTION
Correct an error where a typo omits collected statistics on the source.
