### PR TITLE
Include a bucket type hash in the message encoding for fullsync

### DIFF
--- a/src/riak_repl_bucket_type_util.erl
+++ b/src/riak_repl_bucket_type_util.erl
@@ -30,8 +30,6 @@ bucket_props_match(Props) ->
 
 -spec bucket_props_match(riak_object:type(), integer()) -> boolean().
 bucket_props_match(Type, RemoteBucketTypeHash) ->
-    lager:info("Local hash: ~p Remoate Hash: ~p", [property_hash(Type),
-                                                   RemoteBucketTypeHash]),
    property_hash(Type) =:= RemoteBucketTypeHash.
 
 -spec is_bucket_typed({error, no_type} | proplists:proplist()) -> boolean().

--- a/src/riak_repl_bucket_type_util.erl
+++ b/src/riak_repl_bucket_type_util.erl
@@ -36,7 +36,6 @@ bucket_props_match(Type, RemoteBucketTypeHash) ->
 is_bucket_typed({error, no_type}) ->
     false;
 is_bucket_typed(Props) ->
-    lager:info("Props: ~p", [Props]),
     prop_get(?BT_META_TYPED_BUCKET, false, Props).
 
 -spec prop_get(binary(), term(), {error, no_type} | proplists:proplist()) -> term().

--- a/src/riak_repl_bucket_type_util.erl
+++ b/src/riak_repl_bucket_type_util.erl
@@ -28,17 +28,11 @@ bucket_props_match(Props) ->
             undefined =:= prop_get(?BT_META_PROPS_HASH, undefined, Props)
     end.
 
--spec bucket_props_match(riak_object:type(), [integer()]) -> boolean().
-bucket_props_match(Type, []) ->
-    property_hash(Type) =:= undefined;
-bucket_props_match(Type, [RemoteBucketTypeHash]) ->
-   property_hash(Type) =:= RemoteBucketTypeHash;
-bucket_props_match(_Type, _HashList) ->
-    %% Do not replicate if the hash list from the riak_object contains
-    %% more than 1 value because the local bucket type hash can never
-    %% match more than a single value. Must wait for the object to be
-    %% resolved and updated on the source side before replicating.
-    false.
+-spec bucket_props_match(riak_object:type(), integer()) -> boolean().
+bucket_props_match(Type, RemoteBucketTypeHash) ->
+    lager:info("Local hash: ~p Remoate Hash: ~p", [property_hash(Type),
+                                                   RemoteBucketTypeHash]),
+   property_hash(Type) =:= RemoteBucketTypeHash.
 
 -spec is_bucket_typed({error, no_type} | proplists:proplist()) -> boolean().
 is_bucket_typed({error, no_type}) ->

--- a/src/riak_repl_bucket_type_util.erl
+++ b/src/riak_repl_bucket_type_util.erl
@@ -38,7 +38,7 @@ is_bucket_typed({error, no_type}) ->
 is_bucket_typed(Props) ->
     prop_get(?BT_META_TYPED_BUCKET, false, Props).
 
--spec prop_get(binary(), term(), {error, no_type} | proplists:proplist()) -> term().
+-spec prop_get(atom() | binary(), term(), {error, no_type} | proplists:proplist()) -> term().
 prop_get(_Key, Default, {error, no_type}) ->
     Default;
 prop_get(Key, Default, Props) ->

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -696,7 +696,7 @@ elapsed_secs(Then) ->
 
 shuffle_partitions(Partitions, Seed) ->
     lager:info("Shuffling partition list using seed ~p", [Seed]),
-    random:seed(Seed),
+    _ = random:seed(Seed),
     [Partition || {Partition, _} <-
         lists:keysort(2, [{Key, random:uniform()} || Key <- Partitions])].
 
@@ -830,10 +830,10 @@ deduce_wire_version_from_proto({_Proto, _Client, _Host}) ->
     w0.
 
 %% Typically, Cmd :: fs_diff_obj | diff_obj
-encode_obj_msg(V, {Cmd, RObj}) when is_tuple(RObj) ->
-    encode_obj_msg(V, {Cmd, RObj}, riak_object:type(RObj));
+encode_obj_msg(V, {Cmd, RObj}) when is_binary(RObj) ->
+    encode_obj_msg(V, {Cmd, RObj}, undefined);
 encode_obj_msg(V, {Cmd, RObj}) ->
-    encode_obj_msg(V, {Cmd, RObj}, undefined).
+    encode_obj_msg(V, {Cmd, RObj}, riak_object:type(RObj)).
 
 encode_obj_msg(V, {Cmd, RObj}, undefined) ->
     case V of


### PR DESCRIPTION
Certain properties of typed buckets need to be identical on the source and sink as a condition for data replication between buckets using those bucket types.. For fullsync replication encode a hash of these bucket type properties in the messages sent from the source.  The sink side performs a comparison of a hash of its local bucket type properties for the corresponding bucket type and only writes the data if the hashes are identical.

This PR is an alternate approach to the path taken in [this](https://github.com/basho/riak_repl/pull/510) PR to address the fullsync + bucket types. The reason is yesterday I realized an omission to the `riak_kv` changes I did as part of [this](https://github.com/basho/riak_kv/pull/823) PR. I only account for the manner in which objects are written via the [PB client](https://github.com/basho/riak_kv/blob/develop/src/riak_kv_pb_object.erl#L234) which does a write with an empty value and then performs and update with the desired content. Any writes that only use `riak_object:new` result in an object that does not record the bucket type hash until that object is updated. This means any such object would be discarded from fullsync due to the bucket type hash not matching that on the sink side until such time as it was updated.

The fix in `riak_object` is straightforward, but adds yet more dependence on the availability of the cluster metadata service. I really dislike that fact and the more I think about it, the less I like having these changes solely designed to support fullsync replication in KV, especially given that this is a quick hack workaround for the 2.0 release that hopefully will be ripped out in favor of something better for 2.1 (see comments towards the end of #510). It is very convenient just having the hash there in the riak_object, but if it is just going to be ripped out maybe it is better to confine the change to riak_repl. 

These changes represent a fairly small difference in the code, but address the problem without needing any modifications to riak_object. My proposal is to use the changes in this PR and to revert the commit from [KV823](https://github.com/basho/riak_kv/pull/823). I have not run all of the replication riak_test modules yet, but all that I have run have passed and the eunit and eqc tests are passing for me (if run with the riak_object changes reverted; otherwise, `do_wire_list_w1_bucket_type_test` fails).
