### PR TITLE
Remove consistency check for realtime replication and fix fullsync helper function

### DIFF
--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -291,16 +291,9 @@ repl_helper_send([{App, Mod}|T], Object, C, Acc) ->
     end.
 
 repl_helper_send_realtime(Object, C) ->
-    IsConsistentBucket =
-        case riak_core_bucket:get_bucket(riak_object:bucket(Object)) of
-            {ok, Props} ->
-                is_consistent_bucket(Props);
-            {error, _Reason} ->
-                false
-        end,
     case application:get_env(riak_core, repl_helper) of
         undefined -> [];
-        {ok, Mods} when IsConsistentBucket =:= false ->
+        {ok, Mods} ->
             repl_helper_send_realtime(Mods, Object, C, [])
     end.
 

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -260,11 +260,13 @@ is_consistent_bucket(Props) ->
     end.
 
 is_fullsync_enabled(Props) ->
+    %% Default to enabling fullsync for all buckets and only disable
+    %% if explicitly indicated.
     case lists:keyfind(repl, 1, Props) of
-        {repl, Val} when Val==true; Val==fullsync; Val==both; Val==undefined ->
-            true;
+        {repl, Val} when Val =:= false; Val =:= realtime ->
+            false;
         _ ->
-            false
+            true
     end.
 
 repl_helper_send([], _O, _C, Acc) ->


### PR DESCRIPTION
- Refactor the is_fullsync_enabled helper function to more clearly
  enforce the intention that fullsync is enabled for buckets by
  default and must be explicitly disabled by specifying the repl
  property with a value of false or realtime.
- Remove the unnecessary check for a consistent bucket in
  riak_repl_util:repl_helper_send_realtime. It is broken due to a bad
  return value expectation from the call to
  riak_core_bucket:get_bucket and is not needed since the realtime
  postcommit hooks are bypassed by consistent writes.
