### PR TITLE
Check for consumers before pushing data onto the realtime queue

### DIFF
--- a/src/riak_repl2_rtq.erl
+++ b/src/riak_repl2_rtq.erl
@@ -351,6 +351,8 @@ handle_call({ack_sync, Name, Seq}, _From, State) ->
 handle_cast({push, NumItems, Bin}, State) ->
     handle_cast({push, NumItems, Bin, []}, State);
 
+handle_cast({push, _NumItems, _Bin, _Meta}, State=#state{cs=[]}) ->
+    {noreply, State};
 handle_cast({push, NumItems, Bin, Meta}, State) ->
     State2 = maybe_flip_overload(State),
     {noreply, push(NumItems, Bin, Meta, State2)};


### PR DESCRIPTION
Sink clusters that do not serve as source cluster for other clusters have data
build up on the realtime queue when using the default settings. There are two
factors that contribute to this: the fact that
`realtime_cascades` has a default value of `always` and the fact that there is
no check to ensure there are any realtime queue consumers before data is
pushed onto the queue. If `realtime_cascades` is set to
`always` data is always pushed onto the queue regardless of whether there are
any consumers for it or not.  This change resolves that issues by adding a
check to the handling of data pushes in riak_repl2_rtq. If the list of
consumers is empty the data is not placed on the queue and if the list is
populated the behavior remains the same.
