### PR TITLE
Optimize AAE replication.

### DIFF
--- a/src/riak_repl_aae_fullsync.hrl
+++ b/src/riak_repl_aae_fullsync.hrl
@@ -3,6 +3,7 @@
 -define(MSG_UPDATE_TREE, 3).
 -define(MSG_GET_AAE_BUCKET, 4).
 -define(MSG_GET_AAE_SEGMENT, 5).
+-define(MSG_GET_AAE_BUCKETS, 6).
 -define(MSG_REPLY, 6).
 -define(MSG_PUT_OBJ, 7).
 -define(MSG_GET_OBJ, 8).

--- a/src/riak_repl_aae_fullsync.hrl
+++ b/src/riak_repl_aae_fullsync.hrl
@@ -3,9 +3,9 @@
 -define(MSG_UPDATE_TREE, 3).
 -define(MSG_GET_AAE_BUCKET, 4).
 -define(MSG_GET_AAE_SEGMENT, 5).
--define(MSG_GET_AAE_BUCKETS, 6).
 -define(MSG_REPLY, 6).
 -define(MSG_PUT_OBJ, 7).
 -define(MSG_GET_OBJ, 8).
 -define(MSG_COMPLETE, 9).
+-define(MSG_GET_AAE_BUCKETS, 10).
 -define(AAE_FULLSYNC_REPLY_TIMEOUT, 60000). %% 1 minute to hear from remote sink

--- a/src/riak_repl_aae_sink.erl
+++ b/src/riak_repl_aae_sink.erl
@@ -141,6 +141,10 @@ process_msg(?MSG_GET_AAE_SEGMENT, {SegmentNum,IndexN}, State=#state{tree_pid=Tre
     ResponseMsg = riak_kv_index_hashtree:exchange_segment(IndexN, SegmentNum, TreePid),
     send_reply(ResponseMsg, State);
 
+process_msg(?MSG_GET_AAE_BUCKETS, IndexN, State=#state{tree_pid=TreePid}) ->
+    ResponseMsg = riak_kv_index_hashtree:exchange_buckets(IndexN, TreePid),
+    send_reply(ResponseMsg, State);
+
 %% no reply
 process_msg(?MSG_PUT_OBJ, {fs_diff_obj, BObj}, State) ->
     RObj = riak_repl_util:from_wire(BObj),

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -285,18 +285,7 @@ key_exchange(start_key_exchange, State=#state{cluster=Cluster,
                              ok
                      end;
                 (get_bucket, {L, B}) ->
-                     lager:warning("Bucket request for ~p ~p",
-                                   [L, B]),
-                     case orddict:find({L, B}, Buckets) of
-                         {ok, Value} ->
-                             Value;
-                         error ->
-                             lager:warning("Prefetch miss on ~p ~p",
-                                           [L, B]),
-                             send_synchronous_msg(?MSG_GET_AAE_BUCKET,
-                                                  {L, B, IndexN},
-                                                  State)
-                     end;
+                     orddict:fetch({L, B}, Buckets);
                 (key_hashes, Segment) ->
                      send_synchronous_msg(?MSG_GET_AAE_SEGMENT, {Segment,IndexN}, State);
                 (final, _) ->


### PR DESCRIPTION
Implement a prototype optimization for active anti-entropy replication which front-loads the first two levels of bucket retrieval through one TCP request, instead of 1025 roundtrips.  Futher optimizations include increasing the number of levels which are prefetched.

This is to generally vet the changeset, and explore possible ways of mitigating the protocol fallback and backwards compatability.
