### PR TITLE
Use valid API for starting strategy modules in riak_repl_tcp_server

### DIFF
--- a/src/riak_repl_tcp_server.erl
+++ b/src/riak_repl_tcp_server.erl
@@ -282,7 +282,7 @@ handle_peerinfo(#state{sitename=SiteName, transport=Transport, socket=Socket, my
                     lager:info("Using fullsync strategy ~p.", [StratMod]),
                     {ok, WorkDir} = riak_repl_fsm_common:work_dir(Transport, Socket, SiteName),
                     {ok, FullsyncWorker} = StratMod:start_link(SiteName,
-                        Transport, {self(), Socket}, WorkDir, State#state.client),
+                        Transport, {self(), Socket}, WorkDir, State#state.client, {1,0}),
                     %% Set up bounded queue if remote supports it
                     State1 = case proplists:get_bool(bounded_queue, Capability) of
                         true ->


### PR DESCRIPTION
Commit 0b6acd2d introduced a change to the API for starting fullsync strategy modules (The commit was part of PR #520). Specifically, a parameter was added to the `start_link` function for each fullsync strategy module. Change the call in `riak_repl_tcp_server` to start the strategy module to include the additional required parameter. The extra parameter indicates the replication protocol level supported and is set to `{1,0}` in this case since the code is only executed for legacy connections.

This change should resolve the failure of many of the `replication2_pg` tests. The following in particular:
- replication2_pg:test_mixed_pg
- replication2_pg:test_mixed_pg_ssl
- replication2_pg:test_12_pg_mode_repl12_ssl 
- replication2_pg:test_12_pg_mode_repl12 
- replication2_pg:test_12_pg_mode_repl_mixed 
- replication2_pg:test_12_pg_mode_repl_mixed_ssl

In addition to verifying these tests, please also double check the use of `{1,0}` in this change. I believe it is correct, but I would like someone with more history with replication to verify that.
