### PR TITLE
Add callback annotations to gen_leader.

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -16,6 +16,6 @@ riak_core_connection_mgr.erl:494: The pattern 'ok' can never match the type {'er
 cluster_info:format/3
 cluster_info:register_app/1
 Unknown functions
-gen_leader.erl:933: The call sys:handle_debug(Debug::any(),{'gen_leader', 'print_event'},any(),{'in',_}) breaks the contract (Debug,FormFunc,Extra,Event) -> [dbg_opt()] when is_subtype(Debug,[dbg_opt()]), is_subtype(FormFunc,dbg_fun()), is_subtype(Extra,term()), is_subtype(Event,system_event())
-gen_leader.erl:949: Function system_terminate/4 has no local return
-gen_leader.erl:1112: The call sys:handle_debug(Debug::any(),{'gen_leader', 'print_event'},any(),Event::{'$leader_cast',_} | {'noreply',_} | {'ok',_} | {'out',_,_,_}) breaks the contract (Debug,FormFunc,Extra,Event) -> [dbg_opt()] when is_subtype(Debug,[dbg_opt()]), is_subtype(FormFunc,dbg_fun()), is_subtype(Extra,term()), is_subtype(Event,system_event())
+gen_leader.erl:937: The call sys:handle_debug(Debug::any(),{'gen_leader', 'print_event'},any(),{'in',_}) breaks the contract (Debug,FormFunc,Extra,Event) -> [dbg_opt()] when is_subtype(Debug,[dbg_opt()]), is_subtype(FormFunc,dbg_fun()), is_subtype(Extra,term()), is_subtype(Event,system_event())
+gen_leader.erl:953: Function system_terminate/4 has no local return
+gen_leader.erl:1116: The call sys:handle_debug(Debug::any(),{'gen_leader', 'print_event'},any(),Event::{'$leader_cast',_} | {'noreply',_} | {'ok',_} | {'out',_,_,_}) breaks the contract (Debug,FormFunc,Extra,Event) -> [dbg_opt()] when is_subtype(Debug,[dbg_opt()]), is_subtype(FormFunc,dbg_fun()), is_subtype(Extra,term()), is_subtype(Event,system_event())

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -3,14 +3,10 @@ riak_repl_keylist_client.erl:215: The call application:unset_env('riak_repl',{'p
 riak_repl_keylist_client.erl:264: The call application:unset_env('riak_repl',{'progress',_}) breaks the contract (Application,Par) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom())
 riak_repl_keylist_client.erl:116: The call application:unset_env('riak_repl',{'progress',_}) breaks the contract (Application,Par) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom())
 riak_repl_keylist_client.erl:128: The call application:set_env('riak_repl',{'progress',_},nonempty_maybe_improper_list()) breaks the contract (Application,Par,Val) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom()), is_subtype(Val,term())
-riak_repl_leader_helper.erl:24: Callback info about the gen_leader behaviour is not available
 riak_core_connection.erl:108: Function exchange_handshakes_with/4 has no local return
 riak_core_connection.erl:110: The call ranch_tcp:send(Socket::port(),Hello::binary()) breaks the contract (inet:socket(),iolist()) -> 'ok' | {'error',atom()}
 riak_core_connection.erl:189: Function try_ssl/4 will never be called
 riak_core_connection.erl:225: Function negotiate_proto_with_server/3 will never be called
-gen_leader.erl:939: The call sys:handle_debug(Debug::any(),{'gen_leader', 'print_event'},any(),{'in',_}) breaks the contract (Debug,FormFunc,Extra,Event) -> [dbg_opt()] when is_subtype(Debug,[dbg_opt()]), is_subtype(FormFunc,dbg_fun()), is_subtype(Extra,term()), is_subtype(Event,system_event())
-gen_leader.erl:955: Function system_terminate/4 has no local return
-gen_leader.erl:1118: The call sys:handle_debug(Debug::any(),{'gen_leader', 'print_event'},any(),Event::{'$leader_cast',_} | {'noreply',_} | {'ok',_} | {'out',_,_,_}) breaks the contract (Debug,FormFunc,Extra,Event) -> [dbg_opt()] when is_subtype(Debug,[dbg_opt()]), is_subtype(FormFunc,dbg_fun()), is_subtype(Extra,term()), is_subtype(Event,system_event())
 riak_repl_keylist_client.erl:106: The call application:unset_env('riak_repl',{'progress',_}) breaks the contract (Application,Par) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom())
 riak_repl_keylist_client.erl:216: The call application:unset_env('riak_repl',{'progress',_}) breaks the contract (Application,Par) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom())
 riak_repl_keylist_client.erl:265: The call application:unset_env('riak_repl',{'progress',_}) breaks the contract (Application,Par) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom())
@@ -20,3 +16,6 @@ riak_core_connection_mgr.erl:494: The pattern 'ok' can never match the type {'er
 cluster_info:format/3
 cluster_info:register_app/1
 Unknown functions
+gen_leader.erl:933: The call sys:handle_debug(Debug::any(),{'gen_leader', 'print_event'},any(),{'in',_}) breaks the contract (Debug,FormFunc,Extra,Event) -> [dbg_opt()] when is_subtype(Debug,[dbg_opt()]), is_subtype(FormFunc,dbg_fun()), is_subtype(Extra,term()), is_subtype(Event,system_event())
+gen_leader.erl:949: Function system_terminate/4 has no local return
+gen_leader.erl:1112: The call sys:handle_debug(Debug::any(),{'gen_leader', 'print_event'},any(),Event::{'$leader_cast',_} | {'noreply',_} | {'ok',_} | {'out',_,_,_}) breaks the contract (Debug,FormFunc,Extra,Event) -> [dbg_opt()] when is_subtype(Debug,[dbg_opt()]), is_subtype(FormFunc,dbg_fun()), is_subtype(Extra,term()), is_subtype(Event,system_event())

--- a/src/gen_leader.erl
+++ b/src/gen_leader.erl
@@ -99,13 +99,9 @@
          worker_announce/2
         ]).
 
--export([behaviour_info/1]).
-
 %% Internal exports
--export([init_it/6, 
-         print_event/3
-         %%, safe_send/2
-        ]).
+-export([init_it/6,
+         print_event/3]).
 
 -import(error_logger , [format/2]).
 
@@ -149,22 +145,20 @@
 %%% Interface functions.
 %%% ---------------------------------------------------
 
-%% @hidden
-behaviour_info(callbacks) ->
-    [{init,1},
-     {elected,3},
-     {surrendered,3},
-     {handle_leader_call,4},
-     {handle_leader_cast,3},
-     {from_leader,3},
-     {handle_call,4},
-     {handle_cast,3},
-     {handle_DOWN,3},
-     {handle_info,2},
-     {terminate,2},
-     {code_change,4}];
-behaviour_info(_Other) ->
-    undefined.
+-type state() :: term().
+
+-callback init(list()) -> {ok, state()} | {ignore, term()} | {stop, term()}.
+-callback elected(state(), term(), node()) -> {ok, term(), state()}.
+-callback surrendered(state(), term(), term()) -> {ok, state()}.
+-callback handle_leader_call(term(), pid(), state(), term()) -> {reply, term(), state()} | {reply, term(), term(), state()} | {noreply, state()} | {stop, term(), term(), state()}.
+-callback handle_leader_cast(term(), state(), term()) -> {noreply, state()} | {stop, term(), state()}.
+-callback from_leader(term(), state(), term()) -> {noreply, state()} | {ok, state()} | {stop, term(), state()}.
+-callback handle_call(term(), pid(), state(), term()) -> {reply, term(), state()} | {noreply, state()} | {stop, term(), term(), state()}.
+-callback handle_cast(term(), state(), term()) -> {noreply, state()} | {ok, state()} | {stop, term(), state()}.
+-callback handle_DOWN(node(), state(), term()) -> {ok, state()}.
+-callback handle_info(term(), state()) -> {noreply, state()} | {ok, state()} | {stop, term(), state()}.
+-callback terminate(atom(), state()) -> ok.
+-callback code_change(atom(), state(), term(), term()) -> {ok, state()} | {ok, state(), term()}.
 
 %% @spec (Name::node(), CandidateNodes::[node()],
 %%             OptArgs::leader_options(), Mod::atom(), Arg, Options::list()) ->

--- a/src/gen_leader.erl
+++ b/src/gen_leader.erl
@@ -146,19 +146,23 @@
 %%% ---------------------------------------------------
 
 -type state() :: term().
+-type election() :: term().
+-type msg() :: term().
+-type reason() :: atom().
+-type extra() :: term().
 
 -callback init(list()) -> {ok, state()} | {ignore, term()} | {stop, term()}.
--callback elected(state(), term(), node()) -> {ok, term(), state()}.
--callback surrendered(state(), term(), term()) -> {ok, state()}.
--callback handle_leader_call(term(), pid(), state(), term()) -> {reply, term(), state()} | {reply, term(), term(), state()} | {noreply, state()} | {stop, term(), term(), state()}.
--callback handle_leader_cast(term(), state(), term()) -> {noreply, state()} | {stop, term(), state()}.
--callback from_leader(term(), state(), term()) -> {noreply, state()} | {ok, state()} | {stop, term(), state()}.
--callback handle_call(term(), pid(), state(), term()) -> {reply, term(), state()} | {noreply, state()} | {stop, term(), term(), state()}.
--callback handle_cast(term(), state(), term()) -> {noreply, state()} | {ok, state()} | {stop, term(), state()}.
--callback handle_DOWN(node(), state(), term()) -> {ok, state()}.
--callback handle_info(term(), state()) -> {noreply, state()} | {ok, state()} | {stop, term(), state()}.
--callback terminate(atom(), state()) -> ok.
--callback code_change(atom(), state(), term(), term()) -> {ok, state()} | {ok, state(), term()}.
+-callback elected(state(), election(), node()) -> {ok, term(), state()}.
+-callback surrendered(state(), msg(), election()) -> {ok, state()}.
+-callback handle_leader_call(msg(), pid(), state(), election()) -> {reply, term(), state()} | {reply, term(), term(), state()} | {noreply, state()} | {stop, term(), term(), state()}.
+-callback handle_leader_cast(msg(), state(), election()) -> {noreply, state()} | {stop, term(), state()}.
+-callback from_leader(msg(), state(), election()) -> {noreply, state()} | {ok, state()} | {stop, term(), state()}.
+-callback handle_call(msg(), pid(), state(), election()) -> {reply, term(), state()} | {noreply, state()} | {stop, term(), term(), state()}.
+-callback handle_cast(msg(), state(), election()) -> {noreply, state()} | {ok, state()} | {stop, term(), state()}.
+-callback handle_DOWN(node(), state(), election()) -> {ok, state()}.
+-callback handle_info(msg(), state()) -> {noreply, state()} | {ok, state()} | {stop, term(), state()}.
+-callback terminate(reason(), state()) -> ok.
+-callback code_change(atom(), state(), election(), extra()) -> {ok, state()} | {ok, state(), term()}.
 
 %% @spec (Name::node(), CandidateNodes::[node()],
 %%             OptArgs::leader_options(), Mod::atom(), Arg, Options::list()) ->


### PR DESCRIPTION
Stop ignoring the error, and provide a set of callback annotations for
the gen_leader module.

Addresses #553.
