### PR TITLE
Fixes monitor leak for realtime objects (#204).

### DIFF
--- a/src/riak_repl2_rtsink_helper.erl
+++ b/src/riak_repl2_rtsink_helper.erl
@@ -15,8 +15,14 @@
          write_objects/3]).
 
 %% gen_server callbacks
--export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3]).
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-behavior(gen_server).
 
 -record(state, {parent           %% Parent process
                }).
@@ -32,7 +38,6 @@ write_objects(Pid, BinObjs, DoneFun) ->
 
 %% Callbacks
 init([Parent]) ->
-    %% TODO: Share pool between all rtsinks to bound total RT work
     {ok, #state{parent = Parent}}.
 
 handle_call(stop, _From, State) ->
@@ -40,13 +45,16 @@ handle_call(stop, _From, State) ->
 
 handle_cast({write_objects, BinObjs, DoneFun}, State) ->
     do_write_objects(BinObjs, DoneFun),
+    {noreply, State};
+handle_cast({unmonitor, Ref}, State) ->
+    demonitor(Ref),
     {noreply, State}.
 
 handle_info({'DOWN', _MRef, process, _Pid, Reason}, State)
   when Reason == normal; Reason == shutdown ->
     {noreply, State};
 handle_info({'DOWN', _MRef, process, Pid, Reason}, State) ->
-    %% TODO: Log worker failure
+    %% TODO: Log failure worker
     %% TODO: Needs graceful way to let rtsink know so it can die
     {stop, {worker_died, {Pid, Reason}}, State}.
 
@@ -60,5 +68,7 @@ code_change(_OldVsn, State, _Extra) ->
 %% Receive TCP data - decode framing and dispatch
 do_write_objects(BinObjs, DoneFun) ->
     Worker = poolboy:checkout(riak_repl2_rtsink_pool, true, infinity),
-    monitor(process, Worker),
-    ok = riak_repl_fullsync_worker:do_binputs(Worker, BinObjs, DoneFun, riak_repl2_rtsink_pool).
+    MRef = monitor(process, Worker),
+    Me = self(),
+    WrapperFun = fun() -> DoneFun(), gen_server:cast(Me, {unmonitor, MRef}) end,
+    ok = riak_repl_fullsync_worker:do_binputs(Worker, BinObjs, WrapperFun, riak_repl2_rtsink_pool).


### PR DESCRIPTION
The rtsink_helper uses a pool of riak_repl_fullsync_workers called
riak_repl2_rtsink_pool.  Fullsync punts on checking if the object
was written as it will catch it on the next sync.  Realtime uses
a monitor to make sure the put completes before it acks back to
the rtsource, unfortunately it neglects to demonitor.

Interestingly, the impact for this is mitigated by the poolboy
configuration in use.  The default pool size is 5 processes
in the rtsink_pool bursting to 100.  If the number of concurrent
puts stays below the initial 5, those 5 processes will be reused
and the monitors will grow indefinitely.  If more than 5 concurrent
puts are used, additional processes will be created and when
checked back in, all but the last 5 processes checked in will exit,
cleaning up the monitors.  Even with rtsink_pool_max set to min,
poolboy recycles processes so the monitors are eventually cleared.

When those processes happen to have had a lot of monitors built up
against them, they'll keep the scheduler busy when they die on walking
the proc->monitors structure, locking the remote process and sending
a message per monitor.

Alternative fix to #574, which doesn't try and reuse monitors.
