### PR TITLE
Bugfix/mw/safer rpc

### DIFF
--- a/src/riak_repl2_rtq_proxy.erl
+++ b/src/riak_repl2_rtq_proxy.erl
@@ -126,7 +126,7 @@ get_peer_wire_versions(Nodes) ->
 
 get_peer_meta_support(Nodes) ->
     GetSupport = fun(Node) ->
-        case rpc:call(Node, riak_core_capability, get, [{riak_repl, rtq_meta}, false]) of
+        case riak_core_util:safe_rpc(Node, riak_core_capability, get, [{riak_repl, rtq_meta}, false]) of
             Bool when is_boolean(Bool) ->
                 {Node, Bool};
             LolWut ->

--- a/src/riak_repl_app.erl
+++ b/src/riak_repl_app.erl
@@ -216,7 +216,7 @@ maybe_retry_ip_rpc(Results, Nodes, BadNodes, Args) ->
     Zipped = lists:zip(Results, Nodes2),
     MaybeRetry = fun
         ({{badrpc, {'EXIT', {undef, _StrackTrace}}}, Node}) ->
-            RPCResult = rpc:call(Node, riak_repl_app, get_matching_address, Args),
+            RPCResult = riak_core_util:safe_rpc(Node, riak_repl_app, get_matching_address, Args),
             lager:debug("rpc to get_matching_address: ~p", [RPCResult]),
             RPCResult;
         ({Result, _Node}) ->

--- a/src/riak_repl_leader.erl
+++ b/src/riak_repl_leader.erl
@@ -498,9 +498,9 @@ ensure_sites(Leader) ->
                         Site <- dict:fetch(sites, ReplConfig)],
                     {ToStop, ToStart} = balance_clients(CurrentConfig,
                         ConfiguredSites),
-                    _ = [rpc:call(Node, riak_repl_client_sup, stop_site, [Site])
+                    _ = [riak_core_util:safe_rpc(Node, riak_repl_client_sup, stop_site, [Site])
                         || {Node, Site} <- ToStop],
-                    _ = [rpc:call(Node, riak_repl_client_sup, start_site, [Site])
+                    _ = [riak_core_util:safe_rpc(Node, riak_repl_client_sup, start_site, [Site])
                         || {Node, Site} <- ToStart],
                     ok
             end

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -1019,7 +1019,7 @@ maybe_downconvert_binary_objs(BinObjs, SinkVer) ->
 
 %% return the wire format supported by the peer node: w0 | w1
 peer_wire_format(Peer) ->
-    case rpc:call(Peer, riak_core_capability, get, [{riak_kv, object_format}]) of
+    case riak_core_util:safe_rpc(Peer, riak_core_capability, get, [{riak_kv, object_format}]) of
         {unknown_capability,{riak_kv,object_format}} ->
             w0;
         v1 ->


### PR DESCRIPTION
Creates a helper function that wraps rpc:call/4's in a try/catch. This is to catch the times when the rex process is not running on the remote node.

Addresses #585.
