### PR TITLE
Update strip_postcommit to remove all possible repl hooks.

### DIFF
--- a/src/riak_repl.erl
+++ b/src/riak_repl.erl
@@ -7,6 +7,9 @@
 -export([install_hook/0, uninstall_hook/0]).
 -export([fixup/2]).
 -export([conditional_hook/3]).
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
 
 start() ->
     riak_core_util:start_app_deps(riak_repl),
@@ -66,5 +69,32 @@ strip_postcommit(BucketProps) ->
             CurrentPostcommit=[X]
     end,
     %% Add repl hook - make sure there are not duplicate entries
-    CurrentPostcommit -- riak_repl_util:get_hooks_for_modes().
+    AllHooks = [Hook || {_Mode, Hook} <- ?REPL_MODES],
+    lists:filter(fun(H) -> not lists:member(H, AllHooks) end, CurrentPostcommit).
+
+
+-ifdef(TEST).
+
+-define(MY_HOOK1, {struct,
+                    [{<<"mod">>, <<"mymod1">>},
+                     {<<"fun">>, <<"myhook1">>}]}).
+-define(MY_HOOK2, {struct,
+                    [{<<"mod">>, <<"mymod2">>},
+                     {<<"fun">>, <<"myhook2">>}]}).
+strip_postcommit_test_() ->
+    [?_assertEqual(
+        [], % remember, returns the stipped postcommit from bprops
+        lists:sort(strip_postcommit([{blah, blah}, {postcommit, []}]))),
+     ?_assertEqual(
+        [?MY_HOOK1, ?MY_HOOK2],
+        lists:sort(strip_postcommit([{postcommit, [?REPL_HOOK_BNW,
+                                                   ?MY_HOOK1,
+                                                   ?REPL_HOOK_BNW,
+                                                   ?MY_HOOK2,
+                                                   ?REPL_HOOK12]},
+                                     {blah, blah}])))].
+
+
+
+-endif.
 


### PR DESCRIPTION
Previously only the currently enabled hooks were stripped.
If a custom bucket property contained a hook for a disabled
replication mode, then it would be resurrected whenever fixups ran.

Accidentally pushed fix direct to 1.4 branch.  If any issues with reviewing this we will have to fix there.
