### PR TITLE
Add logic to clear cancelled connection requests

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -12,7 +12,7 @@ riak_repl_keylist_client.erl:216: The call application:unset_env('riak_repl',{'p
 riak_repl_keylist_client.erl:265: The call application:unset_env('riak_repl',{'progress',_}) breaks the contract (Application,Par) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom())
 riak_repl_keylist_client.erl:118: The call application:unset_env('riak_repl',{'progress',_}) breaks the contract (Application,Par) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom())
 riak_repl_keylist_client.erl:130: The call application:set_env('riak_repl',{'progress',_},nonempty_maybe_improper_list()) breaks the contract (Application,Par,Val) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom()), is_subtype(Val,term())
-riak_core_connection_mgr.erl:494: The pattern 'ok' can never match the type {'error',atom()}
+riak_core_connection_mgr.erl:546: The pattern 'ok' can never match the type {'error',atom()}
 cluster_info:format/3
 cluster_info:register_app/1
 Unknown functions

--- a/src/riak_core_connection_mgr.erl
+++ b/src/riak_core_connection_mgr.erl
@@ -234,6 +234,9 @@ handle_call({connect, Target, ClientSpec, Strategy}, _From, State) ->
                                                   State#state.pending,
                                                   Request)},
     lager:debug("Starting connect request to ~p, ref is ~p", [Target, Reference]),
+    %% reset backoff for all endpoints to expedite connection against
+    %% existing endpoint
+    ok = reset_backoff(),
     {reply, {ok, Reference}, start_request(Request, State2)};
 
 handle_call({get_endpoint_backoff, Addr}, _From, State) ->


### PR DESCRIPTION
This branch adds logic to clear cancelled connections from the
riak_core_connection_manager Pending state. I have also added a few
helper functions to give a better view into request
states(get_request_states) and connection
errors(get_connection_errrors).

Connections are cancelled only when a user runs `riak-repl disconnect
NAME/[IP,PORT]`. I’ve added logic to this path to  call
remove_cancelled_connections after waiting cm_cancellation_interval.
This interval must either be an integer or the atom never.

This logic only makes one attempt to remove the cancelled connection.
It might be nice to have a helper function that we can call to manually
clear the connections but currently this can be done by re-trying
`riak-repl disconnect`.

The riak_test showing this issue is `replication2_connections.erl` and
the issue can be demonstrated with this code by setting the
`cm_cancellation_interval` to `never`.
