### PR TITLE
Improved, pipelined AAE fullsync

### DIFF
--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -345,10 +345,11 @@ key_exchange(start_key_exchange, State=#state{cluster=Cluster,
     %% always starts as the empty list. KeyDiffs is a list of hashtree::keydiff()
     Bloom = State#state.bloom,
     Count0 = State#state.diff_cnt,
+    Limit = app_helper:get_env(riak_repl, fullsync_direct, ?GET_OBJECT_LIMIT),
     AccFun = fun(KeyDiffs, Acc0) ->
             Count = case Acc0 of [C] when is_integer(C) -> C; _ -> 0 end,
             FoldFun =
-              case (Count0+Count) > ?GET_OBJECT_LIMIT of
+              case (Count0+Count) > Limit of
                   %% Gather diff keys into a bloom filter
                   true  -> fun(KeyDiff, AccIn) ->
                                    accumulate_diff(KeyDiff, Bloom, AccIn, State)

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -45,11 +45,16 @@
                 local_lock = false :: boolean(),
                 owner       :: pid(),
                 proto       :: term(),
-                bloom       :: reference() %% ebloom
+                bloom       :: reference(), %% ebloom
+                diff_cnt=0  :: non_neg_integer()
                }).
 
 %% Per state transition timeout used by certain transitions
 -define(DEFAULT_ACTION_TIMEOUT, 300000). %% 5 minutes
+
+%% the first this many differences are not put in the bloom
+%% filter, but simply sent to the remote site directly.
+-define(GET_OBJECT_LIMIT, 1000).
 
 %%%===================================================================
 %%% API
@@ -221,7 +226,7 @@ update_trees(start_exchange, State=#state{indexns=IndexN, owner=Owner}) when Ind
 update_trees(start_exchange, State=#state{tree_pid=TreePid,
                                           index=Partition,
                                           indexns=[IndexN|_IndexNs]}) ->
-    lager:debug("Start exchange for partition,IndexN ~p,~p", [Partition, IndexN]),
+    lager:info("Start exchange for partition,IndexN ~p,~p", [Partition, IndexN]),
     update_request(TreePid, {Partition, undefined}, IndexN),
     case send_synchronous_msg(?MSG_UPDATE_TREE, IndexN, State) of
         ok ->
@@ -339,22 +344,36 @@ key_exchange(start_key_exchange, State=#state{cluster=Cluster,
     %% keys that differed. We can't prime the accumulator. It
     %% always starts as the empty list. KeyDiffs is a list of hashtree::keydiff()
     Bloom = State#state.bloom,
+    Count0 = State#state.diff_cnt,
     AccFun = fun(KeyDiffs, Acc0) ->
-            %% Gather diff keys into a bloom filter
-            lists:foldl(fun(KeyDiff, AccIn) ->
-                        accumulate_diff(KeyDiff, Bloom, AccIn, State) end,
-                        Acc0,
-                        KeyDiffs)
+            Count = case Acc0 of [C] when is_integer(C) -> C; _ -> 0 end,
+            FoldFun =
+              case (Count0+Count) > ?GET_OBJECT_LIMIT of
+                  %% Gather diff keys into a bloom filter
+                  true  -> fun(KeyDiff, AccIn) ->
+                                   accumulate_diff(KeyDiff, Bloom, AccIn, State)
+                           end;
+
+                  %% Replicate diffs directly
+                  false -> fun(KeyDiff, AccIn) ->
+                                   replicate_diff(KeyDiff, AccIn, State)
+                           end
+              end,
+
+            lists:foldl(FoldFun, Acc0, KeyDiffs)
     end,
 
     %% TODO: Add stats for AAE
     lager:debug("Starting compare for partition ~p", [Partition]),
     spawn_link(fun() ->
                        StageStart=os:timestamp(),
-                       riak_kv_index_hashtree:compare(IndexN, Remote, AccFun, TreePid),
-                       lager:info("Full-sync with site ~p; fullsync difference generator for ~p complete (completed in ~p secs)",
-                                  [State#state.cluster, Partition, riak_repl_util:elapsed_secs(StageStart)]),
-                       gen_fsm:send_event(SourcePid, {'$aae_src', done, Bloom})
+                       case riak_kv_index_hashtree:compare(IndexN, Remote, AccFun, TreePid) of
+                           [N] when is_integer(N) -> Count=N;
+                           _                      -> Count=0
+                       end,
+                       lager:info("Full-sync with site ~p; fullsync difference generator for ~p/~p complete (~p differences, completed in ~p secs)",
+                                  [State#state.cluster, Partition, IndexN, Count, riak_repl_util:elapsed_secs(StageStart)]),
+                       gen_fsm:send_event(SourcePid, {'$aae_src', done, Bloom, Count})
                end),
 
     %% wait for differences from bloom_folder or to be done
@@ -384,22 +403,25 @@ compute_differences({'$aae_src', worker_pid, WorkerPid},
     WorkerPid ! {'$aae_src', ready, self()},
     {next_state, compute_differences, State};
 
-compute_differences({'$aae_src', done, Bloom}, State=#state{ indexns=IndexNs, bloom=Bloom })
+compute_differences({'$aae_src', done, Bloom, Count}, State=#state{ indexns=IndexNs, bloom=Bloom, diff_cnt=Count0 })
   when length(IndexNs) =< 1 ->
     %% we just finished diffing the *last* IndexN, so we go to the vnode fold / bloom state
+
+    State2 = State#state{ diff_cnt=Count0+Count },
 
     %% if we have anything in our bloom filter, start sending them now.
     %% this will start a worker process, which will tell us it's done with
     %% diffs_done once all differences are sent.
-    _ = finish_sending_differences(Bloom, State),
+    _ = finish_sending_differences(Bloom, State2),
 
     %% wait for differences from bloom_folder or to be done
-    {next_state, send_diffs, State};
+    {next_state, send_diffs, State2};
 
-compute_differences({'$aae_src', done, _}, State=#state{ indexns=[_|IndexNs] }) ->
+compute_differences({'$aae_src', done, _, Count}, State=#state{ indexns=[_|IndexNs], diff_cnt=Count0 }) ->
     %% re-start for next indexN
+
     gen_fsm:send_event(self(), start_exchange),
-    {next_state, update_trees, State#state{built=0, indexns=IndexNs}}.
+    {next_state, update_trees, State#state{built=0, indexns=IndexNs, diff_cnt=Count0+Count }}.
 
 %% state send_diffs is where we wait for diff_obj messages from the bloom folder
 %% and send them to the sink for each diff_obj. We eventually finish upon receipt

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -392,7 +392,7 @@ key_exchange(start_key_exchange, State=#state{cluster=Cluster,
                        Exchange2 = riak_kv_index_hashtree:compare(IndexN, Remote, AccFun, Exchange, TreePid),
                        lager:info("Full-sync with site ~p; fullsync difference generator for ~p complete (completed in ~p secs)",
                                   [State#state.cluster, Partition, riak_repl_util:elapsed_secs(StageStart)]),
-                       gen_fsm:send_event(SourcePid, {'$aae_src', Exchange2, done})
+                       gen_fsm:send_event(SourcePid, {'$aae_src', done, Exchange2})
                end),
 
     %% wait for differences from bloom_folder or to be done
@@ -422,7 +422,7 @@ compute_differences({'$aae_src', worker_pid, WorkerPid},
     WorkerPid ! {'$aae_src', ready, self()},
     {next_state, compute_differences, State};
 
-compute_differences({'$aae_src', Exchange, done}, State) ->
+compute_differences({'$aae_src', done, Exchange}, State) ->
     %% Just move on to the next tree exchange since we accumulate
     %% differences across all trees.
     State2 = State#state{exchange=Exchange},

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -561,7 +561,7 @@ send_missing(RObj, State=#state{client=Client, wire_ver=Ver, proto=Proto}) ->
     end.
 
 send_missing(Bucket, Key, State=#state{client=Client, wire_ver=Ver, proto=Proto}) ->
-    case Client:get(Bucket, Key, 1, ?REPL_FSM_TIMEOUT) of
+    case Client:get(Bucket, Key, [{r, 1}, {timeout, ?REPL_FSM_TIMEOUT}, {n_val, 1}]) of
         {ok, RObj} ->
             %% we don't actually have the vclock to compare, so just send the
             %% key and let the other side sort things out.

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -44,7 +44,8 @@
                 diff_batch_size = 1000 :: non_neg_integer(),
                 local_lock = false :: boolean(),
                 owner       :: pid(),
-                proto       :: term()
+                proto       :: term(),
+                bloom       :: reference() %% ebloom
                }).
 
 %% Per state transition timeout used by certain transitions
@@ -74,6 +75,9 @@ init([Cluster, Client, Transport, Socket, Partition, OwnerPid, Proto]) ->
     lager:info("AAE fullsync source worker started for partition ~p",
                [Partition]),
 
+    NumKeys = 1000000,
+    {ok, Bloom} = ebloom:new(NumKeys, 0.01, random:uniform(1000)),
+
     State = #state{cluster=Cluster,
                    client=Client,
                    transport=Transport,
@@ -82,7 +86,8 @@ init([Cluster, Client, Transport, Socket, Partition, OwnerPid, Proto]) ->
                    built=0,
                    owner=OwnerPid,
                    wire_ver=w1,
-                   proto=Proto},
+                   proto=Proto,
+                   bloom=Bloom },
     {ok, prepare_exchange, State}.
 
 handle_event(_Event, StateName, State) ->
@@ -333,8 +338,7 @@ key_exchange(start_key_exchange, State=#state{cluster=Cluster,
     %% accumulates a list of one element that is the count of
     %% keys that differed. We can't prime the accumulator. It
     %% always starts as the empty list. KeyDiffs is a list of hashtree::keydiff()
-    NumKeys = 10000000,
-    {ok, Bloom} = ebloom:new(NumKeys, 0.01, random:uniform(1000)),
+    Bloom = State#state.bloom,
     AccFun = fun(KeyDiffs, Acc0) ->
             %% Gather diff keys into a bloom filter
             lists:foldl(fun(KeyDiff, AccIn) ->
@@ -379,7 +383,10 @@ compute_differences({'$aae_src', worker_pid, WorkerPid},
     ok = Transport:controlling_process(Socket, WorkerPid),
     WorkerPid ! {'$aae_src', ready, self()},
     {next_state, compute_differences, State};
-compute_differences({'$aae_src', done, Bloom}, State) ->
+
+compute_differences({'$aae_src', done, Bloom}, State=#state{ indexns=IndexNs, bloom=Bloom })
+  when length(IndexNs) =< 1 ->
+    %% we just finished diffing the *last* IndexN, so we go to the vnode fold / bloom state
 
     %% if we have anything in our bloom filter, start sending them now.
     %% this will start a worker process, which will tell us it's done with
@@ -387,7 +394,12 @@ compute_differences({'$aae_src', done, Bloom}, State) ->
     _ = finish_sending_differences(Bloom, State),
 
     %% wait for differences from bloom_folder or to be done
-    {next_state, send_diffs, State}.
+    {next_state, send_diffs, State};
+
+compute_differences({'$aae_src', done, _}, State=#state{ indexns=[_|IndexNs] }) ->
+    %% re-start for next indexN
+    gen_fsm:send_event(self(), start_exchange),
+    {next_state, update_trees, State#state{built=0, indexns=IndexNs}}.
 
 %% state send_diffs is where we wait for diff_obj messages from the bloom folder
 %% and send them to the sink for each diff_obj. We eventually finish upon receipt
@@ -399,14 +411,9 @@ send_diffs({diff_obj, RObj}, _From, State) ->
 
 %% All indexes in this Partition are done.
 %% Note: recv'd from an async send event
-send_diffs(diff_done, State=#state{indexns=[]}) ->
+send_diffs(diff_done, State) ->
     gen_fsm:send_event(self(), start_exchange),
-    {next_state, update_trees, State#state{built=0, indexns=[]}};
-%% IndexN is done, restart for remaining
-send_diffs(diff_done, State=#state{indexns=[_IndexN|IndexNs]}) ->
-    %% re-start for next indexN
-    gen_fsm:send_event(self(), start_exchange),
-    {next_state, update_trees, State#state{built=0, indexns=IndexNs}}.
+    {next_state, update_trees, State#state{built=0, indexns=[]}}.
 
 %%%===================================================================
 %%% Internal functions

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -262,7 +262,9 @@ key_exchange(start_key_exchange, State=#state{cluster=Cluster,
     %% allow us to pass control of the TCP socket around. This is needed so
     %% that the process needing to send/receive on that socket has ownership
     %% of it.
-    Remote = fun(init, _) ->
+    %%
+    %% Old, non-pipelined verison
+    TestR1 = fun(init, _) ->
                      %% cause control of the socket to be given to AAE so that
                      %% the get_bucket and key_hashes can send messages via the
                      %% socket (with correct ownership). We'll send a 'ready'
@@ -274,12 +276,52 @@ key_exchange(start_key_exchange, State=#state{cluster=Cluster,
                              ok
                      end;
                 (get_bucket, {L, B}) ->
-                     send_synchronous_msg(?MSG_GET_AAE_BUCKET, {L,B,IndexN}, State);
+                     async_get_bucket(L, B, IndexN, State),
+                     wait_get_bucket(L, B, IndexN, State);
                 (key_hashes, Segment) ->
-                     send_synchronous_msg(?MSG_GET_AAE_SEGMENT, {Segment,IndexN}, State);
+                     async_get_segment(Segment, IndexN, State),
+                     wait_get_segment(Segment, IndexN, State);
+                (start_exchange_level, {_Level, _Buckets}) ->
+                     ok;
+                (start_exchange_segments, _Segments) ->
+                     ok;
                 (final, _) ->
                      %% give ourself control of the socket again
                      ok = Transport:controlling_process(Socket, SourcePid)
+             end,
+
+    %% Pipelined verison
+    TestR2 = fun(init, _) ->
+                     %% cause control of the socket to be given to AAE so that
+                     %% the get_bucket and key_hashes can send messages via the
+                     %% socket (with correct ownership). We'll send a 'ready'
+                     %% back here once the socket ownership is transfered and
+                     %% we are ready to proceed with the compare.
+                     gen_fsm:send_event(SourcePid, {'$aae_src', worker_pid, self()}),
+                     receive
+                         {'$aae_src', ready, SourcePid} ->
+                             ok
+                     end;
+                (get_bucket, {L, B}) ->
+                     wait_get_bucket(L, B, IndexN, State);
+                (key_hashes, Segment) ->
+                     wait_get_segment(Segment, IndexN, State);
+                (start_exchange_level, {Level, Buckets}) ->
+                     _ = [async_get_bucket(Level, B, IndexN, State) || B <- Buckets],
+                     ok;
+                (start_exchange_segments, Segments) ->
+                     _ = [async_get_segment(Segment, IndexN, State) || Segment <- Segments],
+                     ok;
+                (final, _) ->
+                     %% give ourself control of the socket again
+                     ok = Transport:controlling_process(Socket, SourcePid)
+             end,
+
+    Remote = case app_helper:get_env(riak_repl, fullsync_pipeline, false) of
+                 false ->
+                     TestR1;
+                 true ->
+                     TestR2
              end,
 
     %% Unclear if we should allow exchange to run indefinitely or enforce
@@ -313,6 +355,24 @@ key_exchange(start_key_exchange, State=#state{cluster=Cluster,
 
     %% wait for differences from bloom_folder or to be done
     {next_state, compute_differences, State}.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+async_get_bucket(Level, Bucket, IndexN, State) ->
+    send_asynchronous_msg(?MSG_GET_AAE_BUCKET, {Level,Bucket,IndexN}, State).
+
+wait_get_bucket(_Level, _Bucket, _IndexN, State) ->
+    Reply = get_reply(State),
+    Reply.
+
+async_get_segment(Segment, IndexN, State) ->
+    send_asynchronous_msg(?MSG_GET_AAE_SEGMENT, {Segment,IndexN}, State).
+
+wait_get_segment(_Segment, _IndexN, State) ->
+    Reply = get_reply(State),
+    Reply.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 compute_differences({'$aae_src', worker_pid, WorkerPid},
                     #state{transport=Transport, socket=Socket} = State) ->
@@ -569,7 +629,10 @@ send_synchronous_msg(MsgType, State=#state{transport=Transport,
 %% Async message send with tag and (binary or term data).
 send_asynchronous_msg(MsgType, Data, #state{transport=Transport,
                                             socket=Socket}) when is_binary(Data) ->
-    ok = Transport:send(Socket, <<MsgType:8, Data/binary>>).
+    ok = Transport:send(Socket, <<MsgType:8, Data/binary>>);
+send_asynchronous_msg(MsgType, Msg, State) ->
+    Data = term_to_binary(Msg),
+    send_asynchronous_msg(MsgType, Data, State).
 
 %% send a message with type tag only, no data
 send_asynchronous_msg(MsgType, #state{transport=Transport,


### PR DESCRIPTION
This pull-request includes multiple improves to AAE fullsync, including:
1. Making AAE exchange pipelined. This is the most significant change, since non-pipelined AAE is sensitive to network latency. And in the worst case was shown to take weeks to complete, even for a trivial exchange. The new pipelined approach is designed to handle high latency links.
2. Ensuring AAE fullsync only does at most 1 bloom fold per partition. Previously, the implementation did a bloom fold per AAE tree per partition.
3. Directly sending up to a configurable threshold of key differences, thus avoiding the bloom fold entirely when clusters are mostly in sync.
4. Using the internal `n_val=1` get option when retrieving objects to send. This sends only a single request to a single vnode, therefore reducing cluster load during a fullsync.

Preliminary test result can be found [here](https://gist.github.com/jtuple/92e0fe300579ed24ef80). More testing is underway/planned.

Sibling pull-requests: basho/riak_core#628, basho/riak_kv#1023
