### PR TITLE
Added a worker pool for fullsync sinks.

### DIFF
--- a/src/riak_repl2_fssink_pool.erl
+++ b/src/riak_repl2_fssink_pool.erl
@@ -1,0 +1,28 @@
+%% Fullsync pool to be shared by all sinks.  Globally bounded in size in case multiple
+%% fullsyncs are running.
+
+-module(riak_repl2_fssink_pool).
+-export([start_link/0, status/0, bin_put/1]).
+
+start_link() ->
+    MinPool = app_helper:get_env(riak_repl, fssink_min_workers, 5),
+    MaxPool = app_helper:get_env(riak_repl, fssink_max_workers, 100),
+    PoolArgs = [{name, {local, ?MODULE}},
+                {worker_module, riak_repl_fullsync_worker},
+                {worker_args, []},
+                {size, MinPool}, {max_overflow, MaxPool}],
+    poolboy:start_link(PoolArgs).
+
+%% @doc Return the poolboy status
+status() ->
+    {StateName, WorkerQueueLen, Overflow, NumMonitors} = poolboy:status(?MODULE),
+    [{statename, StateName},
+     {worker_queue_len, WorkerQueueLen},
+     {overflow, Overflow},
+     {num_monitors, NumMonitors}].
+
+%% @doc Send a replication wire-encoded binary to the worker pool
+%% for running a put against.  No guarantees of completion.
+bin_put(BinObj) ->
+    Pid = poolboy:checkout(?MODULE, true, infinity),
+    riak_repl_fullsync_worker:do_binput(Pid, BinObj, ?MODULE).

--- a/src/riak_repl_aae_sink.erl
+++ b/src/riak_repl_aae_sink.erl
@@ -141,9 +141,9 @@ process_msg(?MSG_GET_AAE_SEGMENT, {SegmentNum,IndexN}, State=#state{tree_pid=Tre
 
 %% no reply
 process_msg(?MSG_PUT_OBJ, {fs_diff_obj, BObj}, State) ->
-    RObj = riak_repl_util:from_wire(BObj),
-    %% do the put
-    riak_repl_util:do_repl_put(RObj),
+    %% may block on worker pool, ok return means work was submitted
+    %% to pool, not that put FSM completed successfully.
+    ok = riak_repl2_fssink_pool:bin_put(BObj),
     {noreply, State};
 
 %% replies: ok | not_responsible

--- a/src/riak_repl_sup.erl
+++ b/src/riak_repl_sup.erl
@@ -48,6 +48,9 @@ init([]) ->
                  {riak_repl2_fssource_sup, {riak_repl2_fssource_sup, start_link, []},
                   permanent, infinity, supervisor, [riak_repl2_fssource_sup]},
 
+                 {riak_repl2_fssink_pool, {riak_repl2_fssink_pool, start_link, []},
+                  permanent, 5000, worker, [riak_repl2_fssink_pool, poolboy]},
+
                  {riak_repl2_fssink_sup, {riak_repl2_fssink_sup, start_link, []},
                   permanent, infinity, supervisor, [riak_repl2_fssink_sup]},
 


### PR DESCRIPTION
Although keylisting has a pool for issuing gets, both the
AAE and the Keylist strategies serialize writing objects
from the sink process.  This adds a pool with a default size
of 100 shared across all fullsync sinks that make the writes async.

No difference in safety properties, neither version checks
the response from the put FSM.
