### PR TITLE
Improve AAE fullsync by estimating number of keys

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,6 +10,6 @@
         {lager, "2.0.3", {git, "git://github.com/basho/lager.git", {tag, "2.0.3"}}},
         {ranch, "0.4.0-p1", {git, "git://github.com/basho/ranch.git", {tag, "0.4.0-p1"}}},
         {ebloom, ".*", {git, "git://github.com/basho/ebloom.git", {tag, "2.0.0"}}},
-        {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {branch, "2.0"}}},
+        {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {branch, "feature/aae-estimate-keys"}}},
         {riak_repl_pb_api, ".*", {git, "git@github.com:basho/riak_repl_pb_api.git", {branch, "2.0"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -10,6 +10,6 @@
         {lager, "2.0.3", {git, "git://github.com/basho/lager.git", {tag, "2.0.3"}}},
         {ranch, "0.4.0-p1", {git, "git://github.com/basho/ranch.git", {tag, "0.4.0-p1"}}},
         {ebloom, ".*", {git, "git://github.com/basho/ebloom.git", {tag, "2.0.0"}}},
-        {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {branch, "feature/aae-estimate-keys"}}},
+        {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {branch, "2.0"}}},
         {riak_repl_pb_api, ".*", {git, "git@github.com:basho/riak_repl_pb_api.git", {branch, "2.0"}}}
        ]}.

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -863,7 +863,7 @@ schedule_stat_refresh(StatCache) ->
 
 %% @private Exported just to be able to spawn with arguments more nicely.
 refresh_stats_worker(ReportTo, Sources) ->
-    lager:info("Gathering source data for ~p", [Sources]),
+    lager:debug("Gathering source data for ~p", [Sources]),
     SourceStats = gather_source_stats(Sources),
     Time = riak_core_util:moment(),
     Self = self(),

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -768,8 +768,6 @@ remote_node_available({_Partition, _, RemoteNode}, Busies) ->
 start_fssource(Partition2={Partition,_,_} = PartitionVal, Ip, Port, State) ->
     #state{owners = Owners} = State,
     LocalNode = proplists:get_value(Partition, Owners),
-    lager:info("Starting fssource for ~p on ~p to ~p", [Partition, LocalNode,
-            Ip]),
     case riak_repl2_fssource_sup:enable(LocalNode, Partition, {Ip, Port}) of
         {ok, Pid} ->
             link(Pid),

--- a/src/riak_repl2_fssink_pool.erl
+++ b/src/riak_repl2_fssink_pool.erl
@@ -1,0 +1,28 @@
+%% Fullsync pool to be shared by all sinks.  Globally bounded in size in case multiple
+%% fullsyncs are running.
+
+-module(riak_repl2_fssink_pool).
+-export([start_link/0, status/0, bin_put/1]).
+
+start_link() ->
+    MinPool = app_helper:get_env(riak_repl, fssink_min_workers, 5),
+    MaxPool = app_helper:get_env(riak_repl, fssink_max_workers, 100),
+    PoolArgs = [{name, {local, ?MODULE}},
+                {worker_module, riak_repl_fullsync_worker},
+                {worker_args, []},
+                {size, MinPool}, {max_overflow, MaxPool}],
+    poolboy:start_link(PoolArgs).
+
+%% @doc Return the poolboy status
+status() ->
+    {StateName, WorkerQueueLen, Overflow, NumMonitors} = poolboy:status(?MODULE),
+    [{statename, StateName},
+     {worker_queue_len, WorkerQueueLen},
+     {overflow, Overflow},
+     {num_monitors, NumMonitors}].
+
+%% @doc Send a replication wire-encoded binary to the worker pool
+%% for running a put against.  No guarantees of completion.
+bin_put(BinObj) ->
+    Pid = poolboy:checkout(?MODULE, true, infinity),
+    riak_repl_fullsync_worker:do_binput(Pid, BinObj, ?MODULE).

--- a/src/riak_repl2_fssource.erl
+++ b/src/riak_repl2_fssource.erl
@@ -81,8 +81,9 @@ init([Partition, IP]) ->
     end.
 
 handle_call({connected, Socket, Transport, _Endpoint, Proto, Props},
-            _From, State=#state{partition=Partition, strategy=RequestedStrategy}) ->
+            _From, State=#state{ip=IP, partition=Partition, strategy=RequestedStrategy}) ->
     Cluster = proplists:get_value(clustername, Props),
+    lager:info("Fullsync connection to ~p for ~p",[IP, Partition]),
 
     SocketTag = riak_repl_util:generate_socket_tag("fs_source", Transport, Socket),
     lager:debug("Keeping stats for " ++ SocketTag),

--- a/src/riak_repl2_fssource.erl
+++ b/src/riak_repl2_fssource.erl
@@ -81,9 +81,8 @@ init([Partition, IP]) ->
     end.
 
 handle_call({connected, Socket, Transport, _Endpoint, Proto, Props},
-            _From, State=#state{ip=IP, partition=Partition, strategy=RequestedStrategy}) ->
+            _From, State=#state{partition=Partition, strategy=RequestedStrategy}) ->
     Cluster = proplists:get_value(clustername, Props),
-    lager:info("Fullsync connection to ~p for ~p",[IP, Partition]),
 
     SocketTag = riak_repl_util:generate_socket_tag("fs_source", Transport, Socket),
     lager:debug("Keeping stats for " ++ SocketTag),
@@ -287,7 +286,7 @@ maybe_exchange_caps(_, Caps, Socket, Transport) ->
 %% Start a connection to the remote sink node at IP, using the given fullsync strategy,
 %% for the given partition. The protocol version will be determined from the strategy.
 connect(IP, Strategy, Partition) ->
-    lager:info("Connecting to remote ~p for partition ~p", [IP, Partition]),
+    lager:debug("Connecting to remote ~p for partition ~p", [IP, Partition]),
     TcpOptions = [{keepalive, true},
                   {nodelay, true},
                   {packet, 4},

--- a/src/riak_repl_aae_sink.erl
+++ b/src/riak_repl_aae_sink.erl
@@ -141,9 +141,9 @@ process_msg(?MSG_GET_AAE_SEGMENT, {SegmentNum,IndexN}, State=#state{tree_pid=Tre
 
 %% no reply
 process_msg(?MSG_PUT_OBJ, {fs_diff_obj, BObj}, State) ->
-    RObj = riak_repl_util:from_wire(BObj),
-    %% do the put
-    riak_repl_util:do_repl_put(RObj),
+    %% may block on worker pool, ok return means work was submitted
+    %% to pool, not that put FSM completed successfully.
+    ok = riak_repl2_fssink_pool:bin_put(BObj),
     {noreply, State};
 
 %% replies: ok | not_responsible

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -25,8 +25,6 @@
 -export([init/1, handle_event/3, handle_sync_event/4, handle_info/3,
          terminate/3, code_change/4]).
 
--export([replicate_diff/3]).
-
 -type index() :: non_neg_integer().
 -type index_n() :: {index(), pos_integer()}.
 
@@ -516,34 +514,6 @@ bloom_fold({B, K}, V, {MPid, Bloom}) ->
             ok
     end,
     {MPid, Bloom}.
-
-%% @private
-%% Returns accumulator as a list of one element that is the count of
-%% keys that differed. Initial value of Acc is always [].
-replicate_diff(KeyDiff, {DiffCount, Bloom} = Acc, State=#state{index=Partition}) ->
-    case KeyDiff of
-        {remote_missing, Bin} ->
-            %% send object and related objects to remote
-            {Bucket,Key} = binary_to_term(Bin),
-            lager:debug("Keydiff: remote partition ~p remote missing: ~p:~p",
-                        [Partition, Bucket, Key]),
-            {DiffCount + send_missing(Bucket, Key, State), Bloom};
-        {different, Bin} ->
-            %% send object and related objects to remote
-            {Bucket,Key} = binary_to_term(Bin),
-            lager:debug("Keydiff: remote partition ~p different: ~p:~p",
-                        [Partition, Bucket, Key]),
-            {DiffCount + send_missing(Bucket, Key, State), Bloom};
-        {missing, Bin} ->
-            %% remote has a key we don't have. Ignore it.
-            {Bucket,Key} = binary_to_term(Bin),
-            lager:debug("Keydiff: remote partition ~p local missing: ~p:~p (ignored)",
-                        [Partition, Bucket, Key]),
-            Acc;
-        Other ->
-            lager:warning("Unexpected error keydiff: ~p (ignored)", [Other]),
-            Acc
-    end.
 
 accumulate_diff(KeyDiff, Exchange, State=#state{index=Partition}) ->
     case KeyDiff of

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -236,7 +236,7 @@ update_trees(start_exchange, State=#state{tree_pid=TreePid,
                               ok ->
                                   gen_fsm:send_event(self(), {tree_built, Partition, IndexN});
                               not_responsible ->
-                                  gen_fsm:send_event(self(), {not_responsible, Partition, IndexN}, State)
+                                  gen_fsm:send_event(self(), {not_responsible, Partition, IndexN})
                           end
                   end, IndexNs),
     {next_state, update_trees, State};

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -392,7 +392,7 @@ key_exchange(start_key_exchange, State=#state{cluster=Cluster,
                        Exchange2 = riak_kv_index_hashtree:compare(IndexN, Remote, AccFun, Exchange, TreePid),
                        lager:info("Full-sync with site ~p; fullsync difference generator for ~p complete (completed in ~p secs)",
                                   [State#state.cluster, Partition, riak_repl_util:elapsed_secs(StageStart)]),
-                       gen_fsm:send_event(SourcePid, {'$aae_src', Exchange2, done})
+                       gen_fsm:send_event(SourcePid, {'$aae_src', done, Exchange2})
                end),
 
     %% wait for differences from bloom_folder or to be done
@@ -422,7 +422,7 @@ compute_differences({'$aae_src', worker_pid, WorkerPid},
     WorkerPid ! {'$aae_src', ready, self()},
     {next_state, compute_differences, State};
 
-compute_differences({'$aae_src', Exchange, done}, State) ->
+compute_differences({'$aae_src', done, Exchange}, State) ->
     %% Just move on to the next tree exchange since we accumulate
     %% differences across all trees.
     State2 = State#state{exchange=Exchange},

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -220,7 +220,7 @@ prepare_exchange(start_exchange, State=#state{index=Partition}) ->
 update_trees(init, State) ->
     NumKeys = 10000000,
     {ok, Bloom} = ebloom:new(NumKeys, 0.01, random:uniform(1000)),
-    Limit = app_helper:get_env(riak_repl, fullsync_direct, ?GET_OBJECT_LIMIT),
+    Limit = app_helper:get_env(riak_repl, fullsync_direct_limit, ?GET_OBJECT_LIMIT),
     Mode = app_helper:get_env(riak_repl, fullsync_direct_mode, inline),
     Buffer = case Mode of
                  inline ->

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -87,7 +87,8 @@ cancel_fullsync(Pid) ->
 %%%===================================================================
 
 init([Cluster, Client, Transport, Socket, Partition, OwnerPid, Proto]) ->
-
+    lager:debug("AAE fullsync source worker started for partition ~p",
+               [Partition]),
 
     Ver = riak_repl_util:deduce_wire_version_from_proto(Proto),
     {_, ClientVer, _} = Proto,
@@ -251,6 +252,7 @@ update_trees({tree_built, _, _}, State = #state{indexns=IndexNs}) ->
         NeededBuilts ->
             %% Trees built now we can estimate how many keys
             {ok, EstimatedNrKeys} = riak_kv_index_hashtree:estimate_keys(State#state.tree_pid),
+            lager:debug("EstimatedNrKeys ~p for partition ~p", [EstimatedNrKeys, State#state.index]),
 
             lager:debug("Moving to key exchange state"),
             key_exchange(init, State#state{built=Built, estimated_nr_keys = EstimatedNrKeys});
@@ -285,6 +287,8 @@ key_exchange(cancel_fullsync, State) ->
     {stop, normal, State};
 key_exchange(finish_fullsync, State=#state{owner=Owner}) ->
     send_complete(State),
+    lager:debug("AAE fullsync source completed partition ~p",
+                [State#state.index]),
     riak_repl2_fssource:fullsync_complete(Owner),
     %% TODO: Why stay in key_exchange? Should we stop instead?
     {next_state, key_exchange, State};
@@ -408,10 +412,12 @@ maybe_send_direct(#exchange{mode=inline, count=Count, limit=Limit},
     lager:info("Directly sent ~b differences inline for partition ~p",
                [Sent, Partition]),
     ok;
-maybe_send_direct(#exchange{buffer=Buffer}, State) ->
+maybe_send_direct(#exchange{buffer=Buffer}, State=#state{index=Partition}) ->
     Keys = [{Bucket, Key} || {_, {Bucket, Key}} <- ets:tab2list(Buffer)],
     true = ets:delete(Buffer),
     Sorted = lists:sort(Keys),
+    Count = length(Sorted),
+    lager:debug("Directly sending ~p differences for partition ~p", [Count, Partition]),
     _ = [send_missing(Bucket, Key, State) || {Bucket, Key} <- Sorted],
     ok.
 

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -242,7 +242,8 @@ update_trees(start_exchange, State=#state{tree_pid=TreePid,
     {next_state, update_trees, State};
 
 update_trees({not_responsible, Partition, IndexN}, State = #state{owner=Owner}) ->
-    lager:debug("VNode ~p does not cover preflist ~p", [Partition, IndexN]),
+    lager:debug("Skipping AAE fullsync tree update for vnode ~p because"
+                " it is not responsible for the preflist ~p", [Partition, IndexN]),
     gen_server:cast(Owner, not_responsible),
     {stop, normal, State};
 update_trees({tree_built, _, _}, State = #state{indexns=IndexNs}) ->
@@ -449,7 +450,7 @@ send_diffs(diff_done, State) ->
 %%%===================================================================
 finish_sending_differences(#exchange{bloom=undefined, count=DiffCnt},
                            #state{index=Partition, estimated_nr_keys=EstimatedNrKeys}) ->
-    lager:info("No Bloom folding over ~p/~p differences for partition ~p with EstimatedNrKeys ~p",
+    lager:info("Syncing without bloom ~p/~p differences for partition ~p with EstimatedNrKeys ~p",
                [0, DiffCnt, Partition, EstimatedNrKeys]),
     gen_fsm:send_event(self(), diff_done);
 
@@ -457,7 +458,7 @@ finish_sending_differences(#exchange{bloom=Bloom, count=DiffCnt},
                            #state{index=Partition, estimated_nr_keys=EstimatedNrKeys}) ->
     case ebloom:elements(Bloom) of
         Count = 0 ->
-            lager:info("No Bloom folding over ~p/~p differences for partition ~p with EstimatedNrKeys ~p",
+            lager:info("Syncing without bloom ~p/~p differences for partition ~p with EstimatedNrKeys ~p",
                        [Count, DiffCnt, Partition, EstimatedNrKeys]),
             gen_fsm:send_event(self(), diff_done);
         Count ->

--- a/src/riak_repl_sup.erl
+++ b/src/riak_repl_sup.erl
@@ -48,6 +48,9 @@ init([]) ->
                  {riak_repl2_fssource_sup, {riak_repl2_fssource_sup, start_link, []},
                   permanent, infinity, supervisor, [riak_repl2_fssource_sup]},
 
+                 {riak_repl2_fssink_pool, {riak_repl2_fssink_pool, start_link, []},
+                  permanent, 5000, worker, [riak_repl2_fssink_pool, poolboy]},
+
                  {riak_repl2_fssink_sup, {riak_repl2_fssink_sup, start_link, []},
                   permanent, infinity, supervisor, [riak_repl2_fssink_sup]},
 


### PR DESCRIPTION
This pull-request extends AAE fullsync to sample the AAE trees to estimate the number of keys in a given partition.

This estimate is used to properly size the bloom filter, as well as enable a new percentage-based direct send threshold (eg. direct send up to 10% of differing keys).

To support AAE-based key estimation, this pull-request changes the fullsync logic to update all AAE trees before proceeding to the exchange phase. This change is necessary because all trees must be updated and sampled to calculate a correct estimate.

This pull-request also delays the creation of the bloom filter until it is needed. Fullsyncs that manage to send all differences directly will therefore avoid creating a bloom filter.

This work was performed by @lixen, @rsltrifork, and @krestenkrab. I rebased/squashed commits as necessary to make things apply cleanly on top of the current 2.0 branch, as this work was completed in parallel on top of older changes that were accidentally made against the develop branch.

Note: several commits were squashed together/re-ordered to make porting to the 2.0 branch easier. The original branch had numerous bi-directional merges that made things difficult to port. For reference, the original commits can be found in the [jdb-miklix_estimate_keys](https://github.com/basho/riak_repl/commits/jdb-miklix_estimate_keys) branch.

Sibling pull-requests: basho/riak_core#633, basho/riak_kv#1030
