### PR TITLE
add exometer hook as environment variable

### DIFF
--- a/src/riak_repl.app.src
+++ b/src/riak_repl.app.src
@@ -43,6 +43,11 @@
                   %% How many fullsync diff objects to send before needing an
                   %% ACK from the client. Setting this too high will clog your
                   %% TCP buffers.
-                  {diff_batch_size, 100}
+                  {diff_batch_size, 100},
+		  %% Exometer bootstrap
+		  {exometer_folsom_monitor,
+		   [{riak_core_connection_mgr_stats, riak_core_exo_monitor},
+		    {riak_repl_stats, riak_core_exo_monitor}
+		   ]}
                  ]}
 ]}.


### PR DESCRIPTION
Related to https://github.com/basho/riak_ee/pull/286 - making riak_ee work with exometer. This PR adds an environment variable that's detected by exometer, and causes folsom metrics created from `riak_core_connection_mgr_stats` and `riak_repl_stats` to be created as corresponding metrics in exometer.
