### PR TITLE
Refactor cluster manager and connection manager to use otp behaviors.

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,8 +1,8 @@
-riak_repl_keylist_client.erl:107: The call application:unset_env('riak_repl',{'progress',_}) breaks the contract (Application,Par) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom())
-riak_repl_keylist_client.erl:215: The call application:unset_env('riak_repl',{'progress',_}) breaks the contract (Application,Par) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom())
-riak_repl_keylist_client.erl:264: The call application:unset_env('riak_repl',{'progress',_}) breaks the contract (Application,Par) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom())
-riak_repl_keylist_client.erl:116: The call application:unset_env('riak_repl',{'progress',_}) breaks the contract (Application,Par) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom())
-riak_repl_keylist_client.erl:128: The call application:set_env('riak_repl',{'progress',_},nonempty_maybe_improper_list()) breaks the contract (Application,Par,Val) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom()), is_subtype(Val,term())
+riak_repl_keylist_client.erl:108: The call application:unset_env('riak_repl',{'progress',_}) breaks the contract (Application,Par) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom())
+riak_repl_keylist_client.erl:218: The call application:unset_env('riak_repl',{'progress',_}) breaks the contract (Application,Par) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom())
+riak_repl_keylist_client.erl:267: The call application:unset_env('riak_repl',{'progress',_}) breaks the contract (Application,Par) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom())
+riak_repl_keylist_client.erl:120: The call application:unset_env('riak_repl',{'progress',_}) breaks the contract (Application,Par) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom())
+riak_repl_keylist_client.erl:132: The call application:set_env('riak_repl',{'progress',_},nonempty_maybe_improper_list()) breaks the contract (Application,Par,Val) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom()), is_subtype(Val,term())
 riak_core_connection.erl:108: Function exchange_handshakes_with/4 has no local return
 riak_core_connection.erl:110: The call ranch_tcp:send(Socket::port(),Hello::binary()) breaks the contract (inet:socket(),iolist()) -> 'ok' | {'error',atom()}
 riak_core_connection.erl:189: Function try_ssl/4 will never be called
@@ -16,6 +16,6 @@ riak_core_connection_mgr.erl:546: The pattern 'ok' can never match the type {'er
 cluster_info:format/3
 cluster_info:register_app/1
 Unknown functions
-gen_leader.erl:937: The call sys:handle_debug(Debug::any(),{'gen_leader', 'print_event'},any(),{'in',_}) breaks the contract (Debug,FormFunc,Extra,Event) -> [dbg_opt()] when is_subtype(Debug,[dbg_opt()]), is_subtype(FormFunc,dbg_fun()), is_subtype(Extra,term()), is_subtype(Event,system_event())
-gen_leader.erl:953: Function system_terminate/4 has no local return
-gen_leader.erl:1116: The call sys:handle_debug(Debug::any(),{'gen_leader', 'print_event'},any(),Event::{'$leader_cast',_} | {'noreply',_} | {'ok',_} | {'out',_,_,_}) breaks the contract (Debug,FormFunc,Extra,Event) -> [dbg_opt()] when is_subtype(Debug,[dbg_opt()]), is_subtype(FormFunc,dbg_fun()), is_subtype(Extra,term()), is_subtype(Event,system_event())
+gen_leader.erl:936: The call sys:handle_debug(Debug::any(),{'gen_leader', 'print_event'},any(),{'in',_}) breaks the contract (Debug,FormFunc,Extra,Event) -> [dbg_opt()] when is_subtype(Debug,[dbg_opt()]), is_subtype(FormFunc,dbg_fun()), is_subtype(Extra,term()), is_subtype(Event,system_event())
+gen_leader.erl:952: Function system_terminate/4 has no local return
+gen_leader.erl:1115: The call sys:handle_debug(Debug::any(),{'gen_leader', 'print_event'},any(),Event::{'$leader_cast',_} | {'noreply',_} | {'ok',_} | {'out',_,_,_}) breaks the contract (Debug,FormFunc,Extra,Event) -> [dbg_opt()] when is_subtype(Debug,[dbg_opt()]), is_subtype(FormFunc,dbg_fun()), is_subtype(Extra,term()), is_subtype(Event,system_event())

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -4,7 +4,7 @@ riak_repl_keylist_client.erl:267: The call application:unset_env('riak_repl',{'p
 riak_repl_keylist_client.erl:120: The call application:unset_env('riak_repl',{'progress',_}) breaks the contract (Application,Par) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom())
 riak_repl_keylist_client.erl:132: The call application:set_env('riak_repl',{'progress',_},nonempty_maybe_improper_list()) breaks the contract (Application,Par,Val) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom()), is_subtype(Val,term())
 riak_core_connection.erl:108: Function exchange_handshakes_with/4 has no local return
-riak_core_connection.erl:110: The call ranch_tcp:send(Socket::port(),Hello::binary()) breaks the contract (inet:socket(),iolist()) -> 'ok' | {'error',atom()}
+riak_core_connection.erl:171: The call ranch_tcp:send(Socket::port(),Hello::binary()) breaks the contract (inet:socket(),iolist()) -> 'ok' | {'error',atom()}
 riak_core_connection.erl:189: Function try_ssl/4 will never be called
 riak_core_connection.erl:225: Function negotiate_proto_with_server/3 will never be called
 riak_repl_keylist_client.erl:106: The call application:unset_env('riak_repl',{'progress',_}) breaks the contract (Application,Par) -> 'ok' when is_subtype(Application,atom()), is_subtype(Par,atom())

--- a/include/riak_core_connection.hrl
+++ b/include/riak_core_connection.hrl
@@ -31,6 +31,7 @@
 
 
 -define(CONNECTION_SETUP_TIMEOUT, 10000).
+-define(INITIAL_CONNECTION_RESPONSE_TIMEOUT, 15000).
 
 
 
@@ -97,4 +98,3 @@
 
 
 -type(cluster_finder_fun() :: fun(() -> {ok,node()} | {error, term()})).
-

--- a/rebar.config
+++ b/rebar.config
@@ -13,3 +13,5 @@
         {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {branch, "2.0"}}},
         {riak_repl_pb_api, ".*", {git, "git@github.com:basho/riak_repl_pb_api.git", {branch, "2.0"}}}
        ]}.
+
+{edoc_opts, [{preprocess, true}]}.

--- a/src/gen_leader.erl
+++ b/src/gen_leader.erl
@@ -63,11 +63,10 @@
 %%%                   {bcast_type,Type::bcast_type()}   |
 %%%                   {heartbeat, Seconds::integer()}
 %%% @type bcast_type() = all | sender.
-%%%         Notification control of candidate membership changes. `all' 
-%%%         means that returns from the handle_DOWN/3 and elected/3 leader's events 
-%%%         will be broadcast to all candidates. 
+%%%         Notification control of candidate membership changes. `all'
+%%%         means that returns from the handle_DOWN/3 and elected/3 leader's events
+%%%         will be broadcast to all candidates.
 %%% @type election() = tuple(). Opaque state of the gen_leader behaviour.
-%%% @type node() = atom(). A node name.
 %%% @type name() = atom(). A locally registered name.
 %%% @type serverRef() = Name | {name(),node()} | {global,Name} | pid().
 %%%   See gen_server.

--- a/src/riak_core_cluster_conn.erl
+++ b/src/riak_core_cluster_conn.erl
@@ -163,10 +163,10 @@ initiating_connection(_, State) ->
     {next_state, initiating_connection, State}.
 
 %% Sync message handling for the `initiating_connection' state
-initiating_connection(status, _From, _State) ->
-    {reply, initiating_connection, initiating_connection, _State};
-initiating_connection(_, _From, _State) ->
-    {reply, ok, initiating_connection, _State}.
+initiating_connection(status, _From, State) ->
+    {reply, {initiating_connection, State#state.remote}, initiating_connection, State};
+initiating_connection(_, _From, State) ->
+    {reply, ok, initiating_connection, State}.
 
 %% Async message handling for the `connecting' state
 connecting(timeout, State=#state{remote=Remote}) ->
@@ -217,7 +217,7 @@ connecting(Other, State=#state{remote=Remote}) ->
 
 %% Sync message handling for the `connecting' state
 connecting(status, _From, State) ->
-    {reply, connecting, connecting, State};
+    {reply, {connecting, State#state.remote}, connecting, State};
 connecting(_, _From, _State) ->
     {reply, ok, connecting, _State}.
 
@@ -235,7 +235,7 @@ waiting_for_cluster_name(_, _State) ->
 
 %% Sync message handling for the `waiting_for_cluster_name' state
 waiting_for_cluster_name(status, _From, State) ->
-    {reply, waiting_for_cluster_name, waiting_for_cluster_name, State};
+    {reply, {waiting_for_cluster_name, State#state.remote}, waiting_for_cluster_name, State};
 waiting_for_cluster_name(_, _From, _State) ->
     {reply, ok, waiting_for_cluster_name, _State}.
 
@@ -260,7 +260,7 @@ waiting_for_cluster_members(_, _State) ->
 
 %% Sync message handling for the `waiting_for_cluster_members' state
 waiting_for_cluster_members(status, _From, State) ->
-    {reply, waiting_for_cluster_members, waiting_for_cluster_members, State};
+    {reply, {waiting_for_cluster_members, State#state.name}, waiting_for_cluster_members, State};
 waiting_for_cluster_members(_, _From, _State) ->
     {reply, ok, waiting_for_cluster_members, _State}.
 

--- a/src/riak_core_cluster_conn.erl
+++ b/src/riak_core_cluster_conn.erl
@@ -334,7 +334,8 @@ handle_info({_TransTagClosed, Socket} = Msg,
     % thus, we exit abnormally and let the supervisor restart a new us.
     ok = lager:debug("Stopping because it looks like the connect closed: ~p", [Msg]),
     {stop, connection_closed, State};
-handle_info(_, StateName, State) ->
+handle_info(Msg, StateName, State) ->
+    lager:warning("Unmatch message ~p", [Msg]),
     {next_state, StateName, State}.
 
 terminate(Reason, StateName, _State) ->

--- a/src/riak_core_cluster_conn.erl
+++ b/src/riak_core_cluster_conn.erl
@@ -339,6 +339,9 @@ handle_info({TransClosed, Socket} = Msg,
     % thus, we exit abnormally and let the supervisor restart a new us.
     ok = lager:debug("Stopping because it looks like the connect closed: ~p", [Msg]),
     {stop, connection_closed, State};
+handle_info({_ClusterManager, poll_cluster}, StateName, State) ->
+    gen_fsm:send_event(self(), poll_cluster),
+    {next_state, StateName, State};
 handle_info(Msg, StateName, State) ->
     lager:warning("Unmatch message ~p", [Msg]),
     {next_state, StateName, State}.

--- a/src/riak_core_cluster_conn.erl
+++ b/src/riak_core_cluster_conn.erl
@@ -86,7 +86,7 @@
                 connection_timeout :: timeout(),
                 transport :: atom(),
                 address :: peer_address(),
-                connection_props :: proplist:proplist(),
+                connection_props :: proplists:proplist(),
                 transport_msgs :: ranch_transport_messages()}).
 -type state() :: #state{}.
 

--- a/src/riak_core_cluster_conn.erl
+++ b/src/riak_core_cluster_conn.erl
@@ -222,8 +222,8 @@ connecting(_, _From, _State) ->
     {reply, ok, connecting, _State}.
 
 %% Async message handling for the `waiting_for_cluster_name' state
-waiting_for_cluster_name({cluster_name, NewName}, State=#state{previous_name="undefined"}) ->
-    UpdState = State#state{name=NewName},
+waiting_for_cluster_name({cluster_name, NewName}, State=#state{name=undefined}) ->
+    UpdState = State#state{name=NewName, previous_name="undefined"},
     _ = request_member_ips(UpdState),
     {next_state, waiting_for_cluster_members, UpdState, ?CONNECTION_SETUP_TIMEOUT};
 waiting_for_cluster_name({cluster_name, NewName}, State=#state{name=Name}) ->

--- a/src/riak_core_cluster_conn_sup.erl
+++ b/src/riak_core_cluster_conn_sup.erl
@@ -64,4 +64,4 @@ init([]) ->
 
 make_remote(Remote) ->
     {Remote, {riak_core_cluster_conn, start_link, [Remote]},
-        permanent, ?SHUTDOWN, worker, [riak_core_cluster_conn]}.
+        transient, ?SHUTDOWN, worker, [riak_core_cluster_conn]}.

--- a/src/riak_core_cluster_mgr.erl
+++ b/src/riak_core_cluster_mgr.erl
@@ -145,7 +145,7 @@ register_restore_cluster_targets_fun(ReadClusterFun) ->
 register_save_cluster_members_fun(WriteClusterFun) ->
     gen_server:cast(?SERVER, {register_save_cluster_members_fun, WriteClusterFun}).
 
-%% @doc Specify how to reach a remote cluster, it's name is
+%% @doc Specify how to reach a remote cluster, its name is
 %% retrieved by asking it via the control channel.
 -spec(add_remote_cluster(ip_addr()) -> ok).
 add_remote_cluster({IP,Port}) ->

--- a/src/riak_core_cluster_mgr.erl
+++ b/src/riak_core_cluster_mgr.erl
@@ -98,7 +98,7 @@
          terminate/2, code_change/3]).
 
 %% internal functions
--export([ctrlService/5, ctrlServiceProcess/5,
+-export([%ctrlService/5, ctrlServiceProcess/5,
          round_robin_balancer/1, cluster_mgr_sites_fun/0,
          get_my_members/1]).
 
@@ -191,7 +191,8 @@ init(Defaults) ->
     case riak_core_service_mgr:is_registered(?CLUSTER_PROTO_ID) of
         false ->
             ServiceProto = {?CLUSTER_PROTO_ID, [{1,0}]},
-            ServiceSpec = {ServiceProto, {?CTRL_OPTIONS, ?MODULE, ctrlService, []}},
+            %ServiceSpec = {ServiceProto, {?CTRL_OPTIONS, ?MODULE, ctrlService, []}},
+            ServiceSpec = {ServiceProto, {?CTRL_OPTIONS, riak_core_cluster_serv, start_link, []}},
             riak_core_service_mgr:sync_register_service(ServiceSpec, {round_robin,?MAX_CONS});
         true ->
             ok
@@ -712,75 +713,6 @@ cluster_mgr_sites_fun() ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     Clusters = riak_repl_ring:get_clusters(Ring),
     [{?CLUSTER_NAME_LOCATOR_TYPE, Name} || {Name, _Addrs} <- Clusters].    
-
-%%-------------------------
-%% control channel services
-%%-------------------------
-
-ctrlService(_Socket, _Transport, {error, Reason}, _Args, _Props) ->
-    riak_repl_stats:server_connect_errors(),
-    lager:error("Failed to accept control channel connection: ~p", [Reason]);
-ctrlService(Socket, Transport, {ok, {cluster_mgr, MyVer, RemoteVer}}, _Args, Props) ->
-    {ok, ClientAddr} = Transport:peername(Socket),
-    RemoteClusterName = proplists:get_value(clustername, Props),
-    lager:debug("Cluster Manager: accepted connection from cluster at ~p named ~p",
-               [ClientAddr, RemoteClusterName]),
-    Pid = proc_lib:spawn_link(?MODULE,
-                              ctrlServiceProcess,
-                              [Socket, Transport, MyVer, RemoteVer, ClientAddr]),
-    Transport:controlling_process(Socket, Pid),
-    {ok, Pid}.
-
-read_ip_address(Socket, Transport, Remote) ->
-    case Transport:recv(Socket, 0, ?CONNECTION_SETUP_TIMEOUT) of
-        {ok, BinAddr} ->
-            MyAddr = binary_to_term(BinAddr),
-            {ok, MyAddr};
-        {error, closed} ->
-            {error, closed};
-        Error ->
-            lager:error("Cluster Manager: failed to receive ip addr from remote ~p: ~p",
-                        [Remote, Error]),
-            Error
-    end.
-
-%% process instance for handling control channel requests from remote clusters.
-ctrlServiceProcess(Socket, Transport, MyVer, RemoteVer, ClientAddr) ->
-    case Transport:recv(Socket, 0, ?CONNECTION_SETUP_TIMEOUT) of
-        {ok, ?CTRL_ASK_NAME} ->
-            %% remote wants my name
-            MyName = riak_core_connection:symbolic_clustername(),
-            ok = Transport:send(Socket, term_to_binary(MyName)),
-            ctrlServiceProcess(Socket, Transport, MyVer, RemoteVer, ClientAddr);
-        {ok, ?CTRL_ASK_MEMBERS} ->
-            %% remote wants list of member machines in my cluster
-            case read_ip_address(Socket, Transport, ClientAddr) of
-                {error, closed} ->
-                    {error, connection_closed};
-                {ok, MyAddr} ->
-                    BalancedMembers = gen_server:call(?SERVER, {get_my_members, MyAddr}, infinity),
-                    ok = Transport:send(Socket, term_to_binary(BalancedMembers)),
-                    ctrlServiceProcess(Socket, Transport, MyVer, RemoteVer, ClientAddr);
-                Error ->
-                    Error
-            end;
-        {error, timeout} ->
-            %% timeouts are OK, I think.
-            ctrlServiceProcess(Socket, Transport, MyVer, RemoteVer, ClientAddr);
-        {error, closed} ->
-            % nothing to do now but die quietly
-            {error, connection_closed};
-        {error, Reason} ->
-            lager:error("Cluster Manager: service ~p failed recv on control channel. Error = ~p",
-                        [self(), Reason]),
-            % nothing to do now but die
-            {error, Reason};
-        Other ->
-            lager:error("Cluster Manger: service ~p recv'd unknown message on cluster control channel: ~p",
-                        [self(), Other]),
-            % ignore and keep trying to be a nice service
-            ctrlServiceProcess(Socket, Transport, MyVer, RemoteVer, ClientAddr)
-    end.
 
 %% @doc If the current leader, connect to all clusters that have been
 %%      currently persisted in the ring.

--- a/src/riak_core_cluster_serv.erl
+++ b/src/riak_core_cluster_serv.erl
@@ -5,7 +5,7 @@
 -include("riak_core_connection.hrl").
 
 -record(state, {
-    transport, socket, local_ver, remote_ver, remote_addr, remote_name
+    transport, transport_msgs, socket, local_ver, remote_ver, remote_addr, remote_name
 }).
 
 % external api
@@ -60,7 +60,8 @@ handle_call(_Req, _From, State) ->
 handle_cast(control_given, State) ->
     #state{transport = Transport, socket = Socket} = State,
     ok = Transport:setopts(Socket, [{active, once}]),
-    {noreply, State};
+    TransportMsgs = Transport:messages(),
+    {noreply, State#state{transport_msgs = TransportMsgs}};
 
 handle_cast(_Req, State) ->
     {noreply, State}.
@@ -69,14 +70,14 @@ handle_cast(_Req, State) ->
 %% handle_info
 %% ==========
 
-handle_info({_TransTag, Socket, Data}, State = #state{socket = Socket}) when is_binary(Data) ->
+handle_info({TransOk, Socket, Data}, State = #state{transport_msgs = {TransOk, _, _}, socket = Socket}) when is_binary(Data) ->
     %Termed = binary_to_term(Data),
     handle_socket_info(Data, State#state.transport, State#state.socket, State);
 
-handle_info({TransClosed, Socket}, State = #state{socket = Socket}) when is_atom(TransClosed) ->
+handle_info({TransClosed, Socket}, State = #state{socket = Socket, transport_msgs = {_, TransClosed, _}}) ->
     {stop, normal, State};
 
-handle_info({_TransTag, Socket, Error}, State = #state{socket = Socket}) ->
+handle_info({TransError, Socket, Error}, State = #state{socket = Socket, transport_msgs = {_, _, TransError}}) ->
     {stop, {error, {connection_error, Error}}, State}.
 
 %% ==========

--- a/src/riak_core_cluster_serv.erl
+++ b/src/riak_core_cluster_serv.erl
@@ -1,0 +1,128 @@
+-module(riak_core_cluster_serv).
+-behavior(gen_server).
+
+-include("riak_core_cluster.hrl").
+-include("riak_core_connection.hrl").
+
+-record(state, {
+    transport, socket, local_ver, remote_ver, remote_addr, remote_name
+}).
+
+% external api
+-export([ start_link/5 ]).
+% gen_server
+-export([
+    init/1,
+    handle_call/3, handle_cast/2, handle_info/2,
+    terminate/2, code_change/3
+]).
+
+%% ==========
+%% public api
+%% ==========
+
+start_link(_Socket, _Transport, {error, _} = Error, _Args, _Props) ->
+    Error;
+
+start_link(Socket, Transport, NegotiatedVers, _Args, Props) ->
+    {ok, ClientAddr} = Transport:peername(Socket),
+    RemoteClusterName = proplists:get_value(clustername, Props),
+    lager:debug("Cluster Manager: accepted connection from cluster at ~p named ~p"),
+    case gen_server:start_link(?MODULE, {Socket, Transport, NegotiatedVers, ClientAddr, RemoteClusterName, Props}, []) of
+        {ok, Pid} ->
+            Transport:controlling_process(Socket, Pid),
+            ok = gen_server:cast(Pid, control_given),
+            {ok, Pid};
+        Else ->
+            Else
+    end.
+
+%% ==========
+%% init
+%% ==========
+
+init({Socket, Transport, NegotiatedVers, ClientAddr, RemoteClusterName, _Props}) ->
+    {ok, {cluster_mgr, LocalVer, RemoteVer}} = NegotiatedVers,
+    State = #state{socket = Socket, transport = Transport, remote_addr = ClientAddr, remote_name = RemoteClusterName, local_ver = LocalVer, remote_ver = RemoteVer},
+    {ok, State}.
+
+%% ==========
+%% handle_call
+%% ==========
+
+handle_call(_Req, _From, State) ->
+    {reply, {error, invalid}, State}.
+
+%% ==========
+%% handle_cast
+%% ==========
+
+handle_cast(control_given, State) ->
+    #state{transport = Transport, socket = Socket} = State,
+    ok = Transport:setops(Socket, [{active, once}]),
+    {noreply, State};
+
+handle_cast(_Req, State) ->
+    {noreply, State}.
+
+%% ==========
+%% handle_info
+%% ==========
+
+handle_info({_TransTag, Socket, Data}, State = #state{socket = Socket}) when is_binary(Data) ->
+    Termed = binary_to_term(Data),
+    handle_socket_info(Termed, State#state.transport, State#state.socket, State);
+
+handle_info({TransClosed, Socket}, State = #state{socket = Socket}) when is_atom(TransClosed) ->
+    {stop, {error, closed}, State};
+
+handle_info({_TransTag, Socket, Error}, State = #state{socket = Socket}) ->
+    {stop, {error, {connection_error, Error}}, State}.
+
+%% ==========
+%% terminate
+%% ==========
+
+terminate(_Why, _State) ->
+    ok.
+
+%% ==========
+%% code_change
+%% ==========
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% ==========
+%% Internal
+%% ==========
+
+handle_socket_info({ok, ?CTRL_ASK_NAME}, Transport, Socket, State) ->
+    LocalName = riak_core_connection:symbolic_clustername(),
+    ok = Transport:send(Socket, term_to_binary(LocalName)),
+    ok = Transport:setopts([{active, once}]),
+    {noreply, State};
+
+handle_socket_info({ok, ?CTRL_ASK_MEMBERS}, Transport, Socket, State) ->
+    case read_ip_address(Socket, Transport, State#state.remote_addr) of
+        {ok, RemoteConnectedToIp} ->
+            Members = gen_server:call(?CLUSTER_MANAGER_SERVER, {get_my_members, RemoteConnectedToIp}, infinity),
+            ok = Transport:send(Socket, term_to_binary(Members)),
+            {noreply, State};
+        Else ->
+            {stop, Else, State}
+    end.
+
+read_ip_address(Socket, Transport, Remote) ->
+    case Transport:recv(Socket, 0, ?CONNECTION_SETUP_TIMEOUT) of
+        {ok, BinAddr} ->
+            MyAddr = binary_to_term(BinAddr),
+            {ok, MyAddr};
+        {error, closed} ->
+            {error, closed};
+        Error ->
+            lager:error("Cluster Manager: failed to receive ip addr from remote ~p: ~p",
+                        [Remote, Error]),
+            Error
+    end.
+

--- a/src/riak_core_connection.erl
+++ b/src/riak_core_connection.erl
@@ -134,22 +134,16 @@ start_link({Ip, Port}, ClientSpec) ->
     start_link(Ip, Port, Protocol, ProtoVers, TcpOptions, CallbackMod, CallbackArgs).
 
 start_link(Ip, Port, Protocol, ProtoVers, SocketOptions, Mod, ModArgs) ->
-    start(Ip, Port, Protocol, ProtoVers, SocketOptions, Mod, ModArgs, true).
+    start_maybe_link(Ip, Port, Protocol, ProtoVers, SocketOptions, Mod, ModArgs, start_link).
 
 start({IP, Port}, ClientSpec) ->
     {{Protocol, ProtoVers}, {TcpOptions, CallbackMod, CallbackArgs}} = ClientSpec,
-    start(IP, Port, Protocol, ProtoVers, TcpOptions, CallbackMod, CallbackArgs, false).
+    start(IP, Port, Protocol, ProtoVers, TcpOptions, CallbackMod, CallbackArgs).
 
 start(Ip, Port, Protocol, ProtoVers, TcpOptions, CallbackMod, CallbackArgs) ->
-    start(Ip, Port, Protocol, ProtoVers, TcpOptions, CallbackMod, CallbackArgs, false).
+    start_maybe_link(Ip, Port, Protocol, ProtoVers, TcpOptions, CallbackMod, CallbackArgs, start).
 
-start(Ip, Port, Protocol, ProtoVers, SocketOptions, Mod, ModArgs, Link) ->
-    StartFunc = if
-        Link ->
-            start_link;
-        true ->
-            start
-    end,
+start_maybe_link(Ip, Port, Protocol, ProtoVers, SocketOptions, Mod, ModArgs, StartFunc) ->
     gen_fsm:StartFunc(?MODULE, {Ip, Port, Protocol, ProtoVers, SocketOptions, Mod, ModArgs}, []).
 
 %% gen_fsm callbacks

--- a/src/riak_core_connection.erl
+++ b/src/riak_core_connection.erl
@@ -117,6 +117,8 @@ sync_connect(IPPort, ClientSpec) ->
                 {'DOWN', Mon, process, Pid, Why} ->
                     {error, Why}
             end;
+        ignore ->
+            {error, could_not_connect};
         Else ->
             Else
     end.
@@ -126,7 +128,7 @@ start_link({Ip, Port}, ClientSpec) ->
     start_link(Ip, Port, Protocol, ProtoVers, TcpOptions, CallbackMod, CallbackArgs).
 
 start_link(Ip, Port, Protocol, ProtoVers, SocketOptions, Mod, ModArgs) ->
-    gen_fsm:start_link(?MODULE, {Ip, Port, Protocol, ProtoVers, SocketOptions, Mod, ModArgs}).
+    gen_fsm:start_link(?MODULE, {Ip, Port, Protocol, ProtoVers, SocketOptions, Mod, ModArgs}, []).
 
 %% gen_fsm callbacks
 
@@ -142,7 +144,7 @@ init({IP, Port, Protocol, ProtoVers, SocketOptions, Mod, ModArgs}) ->
             State = #state{transport = ranch_tcp, socket = Socket, protocol = Protocol, protovers = ProtoVers, socket_opts = SocketOptions, mod = Mod, mod_args = ModArgs, cluster_name = MyName, local_capabilities = MyCaps, ip = IP, port = Port},
             {ok, wait_for_capabilities, State};
         Else ->
-            lager:notice("Could not connect ~p:~p due to ~p", [IP, Port, Else]),
+            lager:warning("Could not connect ~p:~p due to ~p", [IP, Port, Else]),
             ignore
     end.
 

--- a/src/riak_core_connection.erl
+++ b/src/riak_core_connection.erl
@@ -260,7 +260,7 @@ try_ssl(Socket, Transport, MyCaps, TheirCaps) ->
             {Transport, Socket};
         {true, true} ->
             lager:info("~p and ~p agreed to use SSL", [MyName, TheirName]),
-            ssl:start(),
+            ok = ssl:start(),
             case riak_core_ssl_util:upgrade_client_to_ssl(Socket, riak_core) of
                 {ok, SSLSocket} ->
                     {ranch_ssl, SSLSocket};

--- a/src/riak_core_connection.erl
+++ b/src/riak_core_connection.erl
@@ -197,7 +197,9 @@ handle_event(_Req, StateName, State) ->
 
 handle_info({_Transport, Socket, Data}, wait_for_capabilities, State = #state{socket = Socket}) ->
     case binary_to_term(Data) of
-        {?CTRL_ACK, _TheirRev, TheirCaps} ->
+        % 'Tis better to check this a fail than hope the future is always
+        % compatible.
+        {?CTRL_ACK, ?CTRL_REV, TheirCaps} ->
             case try_ssl(Socket, ranch_tcp, State#state.local_capabilities, TheirCaps) of
                 {error, _} = Error ->
                     {stop, Error, State};

--- a/src/riak_core_connection.erl
+++ b/src/riak_core_connection.erl
@@ -125,6 +125,7 @@ sync_connect(IPPort, ClientSpec) ->
         ignore ->
             {error, could_not_connect};
         Else ->
+            lager:debug("start returned ~p", [Else]),
             Else
     end.
 
@@ -218,7 +219,11 @@ handle_info({_TransTag, Socket, Data}, wait_for_protocol, State = #state{socket 
         Else ->
             lager:warning("Invalid version returned: ~p", [Else]),
             {stop, Else, State}
-    end.
+    end;
+
+handle_info({_LikelyClose, Socket}, _StateName, State = #state{socket = Socket}) ->
+    lager:debug("Socket closed"),
+    {stop, normal, State}.
 
 terminate(_Why, _StateName, _State) ->
     ok.

--- a/src/riak_core_connection.erl
+++ b/src/riak_core_connection.erl
@@ -19,6 +19,18 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
+
+%% @doc This module handles the protocol negotiation for new connections.
+%% Basic operation is this:
+%%
+%% Connections are initally a raw tcp socket {packet, 4}.
+%% <ol>
+%% <li>Initally the client sends `term_to_binary({?CTRL_HELLO, ?CTRL_REV, MyCaps}).'</li>
+%% <li>The server sends `term_to_binary({?CTRL_ACK, ?CTRL_REV, TheirCaps}).'</li>
+%% <li>If the server and client agree on SSL, the session is upgraded.</li>
+%% <li>The client sends `term_to_binary({Protocol, Version}).'</li>
+%% <li>The server sends `term_to_binary({ok, {ProtoName, {CommonMajor, RemoteMinor, LocalMinor}}})', after which we call ?MODULE:connect/6 and exit.</li>
+
 -module(riak_core_connection).
 -behavior(gen_fsm).
 

--- a/src/riak_core_connection_mgr.erl
+++ b/src/riak_core_connection_mgr.erl
@@ -136,7 +136,7 @@ start_link() ->
 
 %% @doc Begins or resumes accepting and establishing new connections, in
 %% order to maintain the protocols that have been (or continue to be) registered
-%% and unregistered. pause() will not kill any existing connections, but will
+%% and unregistered. `pause()' will not kill any existing connections, but will
 %% cease accepting new requests or retrying lost connections.
 -spec(resume() -> ok).
 resume() ->
@@ -169,19 +169,19 @@ register_locator(Type, Fun) ->
 apply_locator(Name, Strategy) ->
     gen_server:call(?SERVER, {apply_locator, Name, Strategy}, infinity).
 
-%% @doc Establish a connection to the remote destination. be persistent about it,
+%% @doc Establish a connection to the remote destination. Be persistent about it,
 %% but not too annoying to the remote end. Connect by name of cluster or
 %% IP address. Use default strategy to find "best" peer for connection.
 %%
 %% Targets are found by applying a registered locator for it.
 %% The identity locator is pre-installed, so if you want to connect to a list
-%% of IP and Port addresses, supply a Target like this: {identity, [{IP, Port},...]},
-%% where IP::string() and Port::integer(). You can also pass {identity, {IP, Port}}
+%% of IP and Port addresses, supply a Target like this: `{identity, [{IP, Port},...]}',
+%% where `IP::string()' and `Port::integer()'. You can also pass `{identity, {IP, Port}}'
 %% and the locator will use just that one IP. With a list, it will rotate
 %% trying them all until a connection is established.
 %%
 %% Other locator types must be registered with this connection manager
-%% before calling connect().
+%% before calling `connect()'.
 %%
 %% Supervision must be done by the calling process if desired. No supervision
 %% is done here.
@@ -196,11 +196,11 @@ connect(Target, ClientSpec) ->
 disconnect(Target) ->
     gen_server:cast(?SERVER, {disconnect, Target}).
 
-%% @doc Get the #req.target and #req.state for all connections
+%% @doc Get the `#req.target' and `#req.state' for all connections
 get_request_states() ->
     gen_server:call(?SERVER, get_request_states).
 
-%% @doc Return the #ep.addr and #ep.failures for all connections
+%% @doc Return the `#ep.addr' and `#ep.failures' for all connections
 get_connection_errors(Addr) ->
     gen_server:call(?SERVER, {get_connection_errors, Addr}).
 

--- a/src/riak_core_connection_mgr_stats.erl
+++ b/src/riak_core_connection_mgr_stats.erl
@@ -57,7 +57,7 @@ register_stats() ->
 %% @doc Return all stats from the cached value. This will refresh
 %% the cache if it's been over 5 seconds since the last query.
 %% When the cache needs to get the latest values, it will call our
-%% produce_stats() function.
+%% `produce_stats()' function.
 get_stats() ->
     case riak_core_stat_cache:get_stats(?APP) of
         {ok, Stats, _TS} ->

--- a/src/riak_core_service_conn.erl
+++ b/src/riak_core_service_conn.erl
@@ -1,0 +1,236 @@
+-module(riak_core_service_conn).
+-behavior(gen_fsm).
+
+-include("riak_core_connection.hrl").
+
+% external api; generally used by ranch
+-export([start_link/4]).
+% gen_fsm
+-export([init/1]).
+-export([
+    wait_for_hello/3, wait_for_hello/2,
+    wait_for_protocol_versions/3, wait_for_protocol_versions/2
+]).
+-export([ handle_event/3, handle_sync_event/4, handle_info/3 ]).
+-export([code_change/4, terminate/3]).
+
+-record(state, {
+    transport, socket, remote_rev, remote_caps, init_args
+}).
+
+%% ===============
+%% Public API
+%% ===============
+
+start_link(Listener, Socket, Transport, InArgs) ->
+    lager:debug("Start_link dispatch_service"),
+    % to avoid a race condition with ranch, we need to do a little
+    % song and dance with the init and start up.
+    % in short, the start_link doesn't return until the init is complete,
+    % and the ranch_ack does a blocking call into the process that starts
+    % the gen_*.
+    % http://ninenines.eu/docs/en/ranch/HEAD/guide/protocols/#using_gen_server
+    proc_lib:start_link(?MODULE, init, [{Listener, Socket, Transport, InArgs}]).
+
+%% ===============
+%% Init
+%% ===============
+
+init({Listener, Socket, Transport, InArgs}) ->
+    ok = proc_lib:init_ack({ok, self()}),
+    ok = ranch:accept_ack(Listener),
+    ok = Transport:setopts(Socket, ?CONNECT_OPTIONS),
+    ok = Transport:setopts(Socket, [{active, once}]),
+    State = #state{transport = Transport, socket = Socket, init_args = InArgs},
+    gen_fsm:enter_loop(?MODULE, [], wait_for_hello, State).
+
+%% ===============
+%% wait_for_hello
+%% ===============
+
+wait_for_hello(_Req, _From, State) ->
+    {reply, {error, invalid}, wait_for_hello, State}.
+
+wait_for_hello(_Req, State) ->
+    {next_state, wait_for_hello, State}.
+
+%% ===============
+%% wait_for_protocol_versions
+%% ===============
+
+wait_for_protocol_versions(_Req, _From, State) ->
+    {reply, {error, invalid}, wait_for_protocol_versions, State}.
+
+wait_for_protocol_versions(_Req, State) ->
+    {next_state, wait_for_protocol_versions, State}.
+
+%% ===============
+%% handle_event/handle_sync_event
+%% ===============
+
+handle_sync_event(_Req, _From, StateName, State) ->
+    {reply, {error, invalid}, StateName, State}.
+
+handle_event(_Req, StateName, State) ->
+    {next_state, StateName, State}.
+
+%% ===============
+%% handle_info
+%% ===============
+
+handle_info({_TransTag, Socket, Data}, wait_for_hello, State = #state{socket = Socket}) when is_binary(Data) ->
+    case binary_to_term(Data) of
+        {?CTRL_HELLO, TheirRev, ThierCaps} ->
+            SSLEnabled = app_helper:get_env(riak_core, ssl_enabled, false),
+            MyName = riak_core_connection:symbolic_clustername(),
+            MyCaps = [{clustername, MyName}, {ssl_enabled, SSLEnabled}],
+
+            Ack = term_to_binary({?CTRL_ACK, ?CTRL_REV, MyCaps}),
+            (State#state.transport):send(Socket, Ack),
+            case try_ssl(Socket, State#state.transport, MyCaps, ThierCaps) of
+                {error, _Reson} = Err ->
+                    {stop, Err, State};
+                {NewTransport, NewSocket} ->
+                    NewTransport:setopts(NewSocket, [{active, once}]),
+                    State2 = State#state{transport = NewTransport, socket = NewSocket, remote_caps = ThierCaps, remote_rev = TheirRev},
+                    {next_state, wait_for_protocol_versions, State2}
+            end;
+        _Else ->
+            lager:debug("Invalid hello: ~p", [Data]),
+            {stop, {error, invalid_hello}, State}
+    end;
+
+handle_info({_TransTag, Socket, Data}, wait_for_protocol_versions, State = #state{socket = Socket}) when is_binary(Data) ->
+    case binary_to_term(Data) of
+        {ClientProto, _Versions} = ClientVersions->
+            Transport = State#state.transport,
+            Services = gen_server:call(riak_core_service_manager, get_services),
+            MyVersions = [Protocol || {_Key, {Protocol, _Strat}} <- Services],
+            ChosenVer = choose_version(ClientVersions, MyVersions),
+            case ChosenVer of
+                {ok, {ClientProto, Major, ClientMinor, MyMinor}, Rest} ->
+                    ok = Transport:send(Socket, term_to_binary({ok, {ClientProto, {Major, MyMinor, ClientMinor}}})),
+                    Negotiated = {{ok, {ClientProto, {Major, MyMinor}, {Major, ClientMinor}}}, Rest},
+                    lager:debug("What I'm sending to the start_negotiated_service: ~p", [Negotiated]),
+                    start_negotiated_service(Socket, State#state.transport, Negotiated, State#state.remote_caps);
+                {error, _} = ChosenError ->
+                    Transport:send(Socket, term_to_binary(ChosenError)),
+                    {stop, ChosenError, State};
+                {error, ChosenError, _} ->
+                    Transport:send(Socket, term_to_binary({error, ChosenError})),
+                    {stop, {error, ChosenError}, State}
+            end;
+        _Else ->
+            {stop, {error, invalid_protocol_response}, State}
+    end;
+
+handle_info({_LikelyClosed, Socket}, StateName, State = #state{socket = Socket}) ->
+    lager:debug("Socket closed"),
+    {stop, normal, StateName, State}.
+
+%% ===============
+%% termiante
+%% ===============
+
+terminate(Why, StateName, _State) ->
+    lager:debug("Exiting while in state ~s due to ~p", [StateName, Why]),
+    ok.
+
+%% ===============
+%% Code change
+%% ===============
+
+code_change(_OldVsn, StateName, State, _Extra) ->
+    {ok, StateName, State}.
+
+%% ===============
+%% Interal
+%% ===============
+
+try_ssl(Socket, Transport, MyCaps, TheirCaps) ->
+    MySSL = proplists:get_value(ssl_enabled, TheirCaps, false),
+    TheirSSL = proplists:get_value(ssl_enabled, MyCaps, false),
+    MyName = proplists:get_value(clustername, MyCaps),
+    TheirName = proplists:get_value(clustername, TheirCaps),
+    _Res = case {MySSL, TheirSSL} of
+        {true, false} ->
+            lager:warning("~p requested SSL, but ~p doesn't support it",
+                [MyName, TheirName]),
+            {error, no_ssl};
+        {false, true} ->
+            lager:warning("~p requested SSL but ~p doesn't support it",
+                [TheirName, MyName]),
+            {error, no_ssl};
+        {true, true} ->
+            lager:info("~p and ~p agreed to use SSL", [MyName, TheirName]),
+            case riak_core_ssl_util:maybe_use_ssl(riak_core) of
+                false ->
+                    {ranch_tcp, Socket};
+                _Config ->
+                    case riak_core_ssl_util:upgrade_server_to_ssl(Socket, riak_core) of
+                        {ok, S} ->
+                            {ranch_ssl, S};
+                        Other ->
+                            Other
+                    end
+            end;
+        {false, false} ->
+            lager:info("~p and ~p agreed to not use SSL", [MyName, TheirName]),
+            {Transport, Socket}
+    end.
+
+%% Note that the callee is responsible for taking ownership of the socket via
+%% Transport:controlling_process(Socket, Pid),
+start_negotiated_service(Socket, Transport,
+                         {NegotiatedProtocols, {Options, Module, Function, Args}},
+                         Props) ->
+    %% Set requested Tcp socket options now that we've finished handshake phase
+    lager:debug("Setting user options on service side; ~p", [Options]),
+    lager:debug("negotiated protocols: ~p", [NegotiatedProtocols]),
+    Transport:setopts(Socket, Options),
+
+    %% call service body function for matching protocol. The callee should start
+    %% a process or gen_server or such, and return `{ok, pid()}'.
+    case Module:Function(Socket, Transport, NegotiatedProtocols, Args, Props) of
+        {ok, Pid} ->
+            {ok,{ClientProto,_Client,_Host}} = NegotiatedProtocols,
+            gen_server:cast(riak_core_service_manager, {service_up_event, Pid, ClientProto}),
+            {stop, normal, undefined};
+        Error ->
+            lager:debug("service dispatch of ~p:~p failed with ~p",
+                             [Module, Function, Error]),
+            lager:error("service dispatch of ~p:~p failed with ~p",
+                        [Module, Function, Error]),
+            {stop, Error, undefined}
+    end.
+
+choose_version({ClientProto,ClientVersions}=_CProtocol, HostProtocols) ->
+    lager:debug("choose_version: client proto = ~p, HostProtocols = ~p",
+                     [_CProtocol, HostProtocols]),
+    %% first, see if the host supports the subprotocol
+    case [H || {{HostProto,_Versions},_Rest}=H <- HostProtocols, ClientProto == HostProto] of
+        [] ->
+            %% oops! The host does not support this sub protocol type
+            lager:error("Failed to find host support for protocol: ~p", [ClientProto]),
+            lager:debug("choose_version: no common protocols"),
+            {error,protocol_not_supported};
+        [{{_HostProto,HostVersions},Rest}=_Matched | _DuplicatesIgnored] ->
+            lager:debug("choose_version: unsorted = ~p clientversions = ~p",
+                             [_Matched, ClientVersions]),
+            CommonVers = [{CM,CN,HN} || {CM,CN} <- ClientVersions, {HM,HN} <- HostVersions, CM == HM],
+            lager:debug("common versions = ~p", [CommonVers]),
+            %% sort by major version, highest to lowest, and grab the top one.
+            case lists:reverse(lists:keysort(1,CommonVers)) of
+                [] ->
+                    %% oops! No common major versions for Proto.
+                    lager:debug("Failed to find a common major version for protocol: ~p",
+                                     [ClientProto]),
+                    lager:error("Failed to find a common major version for protocol: ~p", [ClientProto]),
+                    {error,protocol_version_not_supported,Rest};
+                [{Major,CN,HN}] ->
+                    {ok, {ClientProto,Major,CN,HN},Rest};
+                [{Major,CN,HN} | _] ->
+                    {ok, {ClientProto,Major,CN,HN},Rest}
+            end
+    end.
+

--- a/src/riak_core_service_mgr.erl
+++ b/src/riak_core_service_mgr.erl
@@ -375,7 +375,7 @@ start_negotiated_service(Socket, Transport,
     Transport:setopts(Socket, Options),
 
     %% call service body function for matching protocol. The callee should start
-    %% a process or gen_server or such, and return `{ok, pid()}`.
+    %% a process or gen_server or such, and return `{ok, pid()}'.
     case Module:Function(Socket, Transport, NegotiatedProtocols, Args, Props) of
         {ok, Pid} ->
             {ok,{ClientProto,_Client,_Host}} = NegotiatedProtocols,
@@ -504,7 +504,7 @@ normalize_ip(IP) when is_tuple(IP) ->
 %% listener connections and supported sub-protocols. When a connection
 %% request arrives, it is mapped via the associated Protocol atom to an
 %% acceptor function called as `Module:Function(Listener, Socket, Transport, Args)',
-%% which must create its own process and return `{ok, pid()}`.
+%% which must create its own process and return `{ok, pid()}'.
 
 -spec(start_dispatcher(ip_addr(), non_neg_integer(), [hostspec()]) -> {ok, pid()}).
 start_dispatcher({IP,Port}, MaxListeners, SubProtocols) ->

--- a/src/riak_core_service_mgr.erl
+++ b/src/riak_core_service_mgr.erl
@@ -511,7 +511,7 @@ start_dispatcher({IP,Port}, MaxListeners, SubProtocols) ->
     {ok, RawAddress} = inet_parse:address(IP),
     {ok, Pid} = ranch:start_listener({IP,Port}, MaxListeners, ranch_tcp,
                                 [{ip, RawAddress}, {port, Port}],
-                                ?MODULE, SubProtocols),
+                                riak_core_service_conn, SubProtocols),
     lager:info("Service manager: listening on ~s:~p", [IP, Port]),
     {ok, Pid}.
 

--- a/src/riak_core_service_mgr.erl
+++ b/src/riak_core_service_mgr.erl
@@ -375,7 +375,7 @@ start_negotiated_service(Socket, Transport,
     Transport:setopts(Socket, Options),
 
     %% call service body function for matching protocol. The callee should start
-    %% a process or gen_server or such, and return {ok, pid()}.
+    %% a process or gen_server or such, and return `{ok, pid()}`.
     case Module:Function(Socket, Transport, NegotiatedProtocols, Args, Props) of
         {ok, Pid} ->
             {ok,{ClientProto,_Client,_Host}} = NegotiatedProtocols,
@@ -504,7 +504,7 @@ normalize_ip(IP) when is_tuple(IP) ->
 %% listener connections and supported sub-protocols. When a connection
 %% request arrives, it is mapped via the associated Protocol atom to an
 %% acceptor function called as `Module:Function(Listener, Socket, Transport, Args)',
-%% which must create its own process and return {ok, pid()}
+%% which must create its own process and return `{ok, pid()}`.
 
 -spec(start_dispatcher(ip_addr(), non_neg_integer(), [hostspec()]) -> {ok, pid()}).
 start_dispatcher({IP,Port}, MaxListeners, SubProtocols) ->

--- a/src/riak_core_service_mgr.erl
+++ b/src/riak_core_service_mgr.erl
@@ -144,7 +144,7 @@ is_registered(ProtocolId) ->
 
 %% @doc Register a callback function that will get called periodically or
 %% when the connection status of services changes. The function will
-%% receive a list of tuples: {<protocol-id>, <stats>} where stats
+%% receive a list of tuples: {&lt;protocol-id>, &lt;stats>} where stats
 %% holds the number of open connections that have been accepted  for that
 %% protocol type. This can be used to report load, in the form of
 %% connected-ness, for each protocol type, to remote clusters, e.g.,

--- a/src/riak_core_service_mgr.erl
+++ b/src/riak_core_service_mgr.erl
@@ -30,7 +30,7 @@
 %% common, the connection fails. Minor versions do not need to match. On a
 %% success, the server sends the Major version, Client minor version, and
 %% Host minor version to the client. After that, the registered
-%% module:function/5 is called and control of the socket passed to it.
+%% `module:function/5' is called and control of the socket passed to it.
 
 
 -module(riak_core_service_mgr).
@@ -115,26 +115,26 @@ start_link({IP,Port}) when is_integer(Port), Port >= 0 ->
 %% @doc Once a protocol specification is registered, it will be kept
 %% available by the Service Manager. Note that the callee is responsible
 %% for taking ownership of the socket via
-%% Transport:controlling_process(Socket, Pid).  Only the strategy of
-%% `round_robin' is supported; it's arg is ignored.
+%% `Transport:controlling_process(Socket, Pid)'.  Only the strategy of
+%% `round_robin' is supported; its arg is ignored.
 register_service(HostProtocol, Strategy) ->
     %% only one strategy is supported as yet
     {round_robin, _NB} = Strategy,
     gen_server:cast(?SERVER, {register_service, HostProtocol, Strategy}).
 
-%% @doc Blocking version of register_service.
+%% @doc Blocking version of `register_service'.
 sync_register_service(HostProtocol, Strategy) ->
     %% only one strategy is supported as yet
     {round_robin, _NB} = Strategy,
     gen_server:call(?SERVER, {register_service, HostProtocol, Strategy}).
 
-%% @doc Unregister the given protocol-id. Existing connections for this
+%% @doc Unregister the given protocol id. Existing connections for this
 %% protocol are not killed. New connections for this protocol will not be
 %% accepted until re-registered.
 unregister_service(ProtocolId) ->
     gen_server:cast(?SERVER, {unregister_service, ProtocolId}).
 
-%% @doc Blocking version of unregister_service.
+%% @doc Blocking version of `unregister_service'.
 sync_unregister_service(ProtocolId) ->
     gen_server:call(?SERVER, {unregister_service, ProtocolId}).
 
@@ -144,7 +144,7 @@ is_registered(ProtocolId) ->
 
 %% @doc Register a callback function that will get called periodically or
 %% when the connection status of services changes. The function will
-%% receive a list of tuples: {&lt;protocol-id>, &lt;stats>} where stats
+%% receive a list of tuples: `{<protocol-id>, <stats>}' where stats
 %% holds the number of open connections that have been accepted  for that
 %% protocol type. This can be used to report load, in the form of
 %% connected-ness, for each protocol type, to remote clusters, e.g.,
@@ -503,8 +503,8 @@ normalize_ip(IP) when is_tuple(IP) ->
 %% @doc Start the connection dispatcher with a limit of MaxListeners
 %% listener connections and supported sub-protocols. When a connection
 %% request arrives, it is mapped via the associated Protocol atom to an
-%% acceptor function called as Module:Function(Listener, Socket, Transport, Args),
-%% which must create it's own process and return {ok, pid()}
+%% acceptor function called as `Module:Function(Listener, Socket, Transport, Args)',
+%% which must create its own process and return {ok, pid()}
 
 -spec(start_dispatcher(ip_addr(), non_neg_integer(), [hostspec()]) -> {ok, pid()}).
 start_dispatcher({IP,Port}, MaxListeners, SubProtocols) ->

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -1,22 +1,27 @@
-%% @doc Coordinates full sync replication parallelism.  Uses 3 riak_repl
-%% application env's:  fullsync_on_connect, max_fssource_cluster, and
-%% max_fssource_node.
+%% @doc Coordinates full sync replication parallelism.  Uses 3
+%% `riak_repl' application environment values: `fullsync_on_connect',
+%% `max_fssource_cluster', and `max_fssource_node'.
 %%
-%% ## `{fullsync_on_connect, boolean()}'
-%%
-%% If true, as soon as a connection to the remote cluster is established,
-%% fullsync starts.  If false, then an explicit start must be sent.
+%% <dl>
+%%  <dt>`{fullsync_on_connect, boolean()}'</dt>
+%%  <dd>
+%% If `true', as soon as a connection to the remote cluster is established,
+%% fullsync starts.  If `false', then an explicit start must be sent.
 %% Defaults to true.
+%%  </dd>
 %%
-%% ## `{max_fssource_cluster, pos_integer()}'
-%%
+%%  <dt>`{max_fssource_cluster, pos_integer()}'</dt>
+%%  <dd>
 %% How many sources can be started across all nodes in the local cluster.
 %% Defaults to 5.
+%%  </dd>
 %%
-%% ## `{max_fssource_node, pos_integer()}'
-%%
+%%  <dt>`{max_fssource_node, pos_integer()}'</dt>
+%%  <dd>
 %% How many sources can be started on a single node, provided starting one
-%% wouldn't exceede the max_fssource_cluster setting. Defaults to 1.
+%% wouldn't exceed the `max_fssource_cluster' setting. Defaults to 1.
+%%  </dd>
+%% </dl>
 
 -module(riak_repl2_fscoordinator).
 -include("riak_repl.hrl").
@@ -107,7 +112,7 @@
 %% API Function Definitions
 %% ------------------------------------------------------------------
 
-%% @doc Start a fullsync coordinator for managing a sycn to the remote `Cluster'.
+%% @doc Start a fullsync coordinator for managing a sync to the remote Cluster.
 -spec start_link(Cluster :: string()) -> {'ok', pid()}.
 start_link(Cluster) ->
     gen_server:start_link(?MODULE, Cluster, []).
@@ -142,7 +147,7 @@ status() ->
     end.
 
 %% @doc Get the status proplist for the given fullsync process. Same as
-%% `status(Pid, infinity'.
+%% `status(Pid, infinity)'.
 %% @see status/2
 -spec status(Pid :: pid()) -> [tuple()].
 status(Pid) ->
@@ -159,7 +164,7 @@ status(Pid, Timeout) ->
         []
     end.
 
-%% @doc Return true if the given fullsync coordiniator is in the middle of
+%% @doc Return true if the given fullsync coordinator is in the middle of
 %% syncing, otherwise false.
 -spec is_running(Pid :: pid()) -> boolean().
 is_running(Pid) when is_pid(Pid) ->

--- a/src/riak_repl2_fssink.erl
+++ b/src/riak_repl2_fssink.erl
@@ -7,7 +7,7 @@
 %% of a single partition. The partition to synchronize is transmitted from the
 %% connected fssource on the source cluster. The strategy for fullsync is determined
 %% dynamically as well:
-%%   keylist - used if the protocol version is < 2.0
+%%   keylist - used if the protocol version is &lt; 2.0
 %%   aae     - used if the protocol version is >= 2.0 and AAE is enabled and repl_strategy=aae
 %%
 %% Protocol Support Summary:

--- a/src/riak_repl2_ip.erl
+++ b/src/riak_repl2_ip.erl
@@ -8,7 +8,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
-%% @doc Given the result of inet:getifaddrs() and an IP a client has
+%% @doc Given the result of `inet:getifaddrs()' and an IP a client has
 %%      connected to, attempt to determine the appropriate subnet mask.  If
 %%      the IP the client connected to cannot be found, undefined is returned.
 determine_netmask(Ifaddrs, SeekIP) when is_list(SeekIP) ->

--- a/src/riak_repl2_leader.erl
+++ b/src/riak_repl2_leader.erl
@@ -264,6 +264,3 @@ maybe_start_helper(State) ->
                                                            State#state.workers)
     end,
     State#state{helper_pid = Pid}.
-
-%% @private
-%%

--- a/src/riak_repl2_rtq.erl
+++ b/src/riak_repl2_rtq.erl
@@ -1,6 +1,5 @@
 %% Riak EnterpriseDS
 %% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
--module(riak_repl2_rtq).
 
 %% @doc Queue module for realtime replication.
 %%
@@ -16,6 +15,7 @@
 %%
 %% The queue is currently stored in a private ETS table.  Once
 %% all consumers are done with an item it is removed from the table.
+-module(riak_repl2_rtq).
 
 -behaviour(gen_server).
 %% API
@@ -87,7 +87,7 @@
 -type name() :: term().
 
 %% API
-%% @doc Start linked, registeres to module name.
+%% @doc Start linked, registered to module name.
 -spec start_link() -> {ok, pid()}.
 start_link() ->
     Overload = app_helper:get_env(riak_repl, rtq_overload_threshold, ?DEFAULT_OVERLOAD),
@@ -95,12 +95,12 @@ start_link() ->
     Opts = [{overload_threshold, Overload}, {overload_recover, Recover}],
     start_link(Opts).
 
-%% @doc Start linked, registers to module name, with given options. This makes
-%% testing some options a bit easier as it removes a dependance on app_helper.
 -type overload_threshold_option() :: {'overload_threshold', pos_integer()}.
 -type overload_recover_option() :: {'overload_recover', pos_integer()}.
 -type start_option() :: overload_threshold_option() | overload_recover_option().
 -type start_options() :: [start_option()].
+%% @doc Start linked, registers to module name, with given options. This makes
+%% testing some options a bit easier as it removes a dependance on app_helper.
 -spec start_link(Options :: start_options()) -> {'ok', pid()}.
 start_link(Options) ->
     case ets:info(?overload_ets) of

--- a/src/riak_repl2_rtq.erl
+++ b/src/riak_repl2_rtq.erl
@@ -100,7 +100,7 @@ start_link() ->
 -type start_option() :: overload_threshold_option() | overload_recover_option().
 -type start_options() :: [start_option()].
 %% @doc Start linked, registers to module name, with given options. This makes
-%% testing some options a bit easier as it removes a dependance on app_helper.
+%% testing some options a bit easier as it removes a dependence on `app_helper'.
 -spec start_link(Options :: start_options()) -> {'ok', pid()}.
 start_link(Options) ->
     case ets:info(?overload_ets) of
@@ -152,7 +152,7 @@ set_max_bytes(MaxBytes) ->
 
 %% @doc Push an item onto the queue. Bin should be the list of objects to push
 %% run through term_to_binary, while NumItems is the length of that list
-%% before being turned to a binary. Meta is an orddict() of data about the
+%% before being turned to a binary. Meta is an orddict of data about the
 %% queued item. The key `routed_clusters' is a list of the clusters the item
 %% has received and ack for. The key `local_forwards' is added automatically.
 %% It is a list of the remotes this cluster forwards to. It is intended to be
@@ -172,7 +172,7 @@ should_drop() ->
     [{overloaded, Val}] = ets:lookup(?overload_ets, overloaded),
     Val.
 
-%% @doc Like push/3, only Meta is orddict:new/0.
+%% @doc Like `push/3', only Meta is `orddict:new/0'.
 -spec push(NumItems :: pos_integer(), Bin :: binary()) -> 'ok'.
 push(NumItems, Bin) ->
     push(NumItems, Bin, []).
@@ -197,26 +197,26 @@ pull_sync(Name, DeliverFun) ->
 ack(Name, Seq) ->
     gen_server:cast(?SERVER, {ack, Name, Seq}).
 
-%% @doc Same as ack/2, but blocks the caller.
+%% @doc Same as `ack/2', but blocks the caller.
 -spec ack_sync(Name :: name(), Seq :: pos_integer()) ->'ok'.
 ack_sync(Name, Seq) ->
     gen_server:call(?SERVER, {ack_sync, Name, Seq}, infinity).
 
 %% @doc The status of the queue.
 %% <dl>
-%% <dt>percent_bytes_used</dt><dd>How full the queue is in percentage to 3 significant digits</dd>
-%% <dt>bytes</dt><dd>Size of the data store backend</dd>
-%% <dt>max_bytes</dt><dd>Maximum size of the data store backend</dd>
-%% <dt>consumers</dt><dd>Key - Value pair of the consumer stats, key is the
+%% <dt>`percent_bytes_used'</dt><dd>How full the queue is in percentage to 3 significant digits</dd>
+%% <dt>`bytes'</dt><dd>Size of the data store backend</dd>
+%% <dt>`max_bytes'</dt><dd>Maximum size of the data store backend</dd>
+%% <dt>`consumers'</dt><dd>Key - Value pair of the consumer stats, key is the
 %% consumer name.</dd>
 %% </dl>
 %%
 %% The consumers have the following data:
 %% <dl>
-%% <dt>pending</dt><dd>Number of queue items left to send.</dd>
-%% <dt>unacked</dt><dd>Number of queue items that are sent, but not yet acked</dd>
-%% <dt>drops</dt><dd>Dropped entries due to max_bytes</dd>
-%% <dt>errs</dt><dd>Number of non-ok returns from deliver fun</dd>
+%% <dt>`pending'</dt><dd>Number of queue items left to send.</dd>
+%% <dt>`unacked'</dt><dd>Number of queue items that are sent, but not yet acked</dd>
+%% <dt>`drops'</dt><dd>Dropped entries due to `max_bytes'</dd>
+%% <dt>`errs'</dt><dd>Number of non-ok returns from deliver fun</dd>
 %% </dl>
 -spec status() -> [any()].
 status() ->

--- a/src/riak_repl2_rtsink_helper.erl
+++ b/src/riak_repl2_rtsink_helper.erl
@@ -1,6 +1,5 @@
 %% Riak EnterpriseDS
 %% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
--module(riak_repl2_rtsink_helper).
 
 %% @doc Realtime replication sink module
 %%
@@ -8,6 +7,7 @@
 %%  consider moving out socket responsibilities to another process
 %%  to keep this one responsive (but it would pretty much just do status)
 %%
+-module(riak_repl2_rtsink_helper).
 
 %% API
 -export([start_link/1,

--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -1,6 +1,5 @@
 %% Riak EnterpriseDS
 %% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
--module(riak_repl2_rtsource_conn).
 
 %% @doc Realtime replication source connection module
 %%
@@ -9,15 +8,15 @@
 %% process accepts the remote Acks and clears the RTQ.
 %%
 %% If both sides support heartbeat message, it is sent from the RT source
-%% every {riak_repl, rt_heartbeat_interval} which default to 15s.  If
+%% every `{riak_repl, rt_heartbeat_interval}' which default to 15s.  If
 %% a response is not received in {riak_repl, rt_heartbeat_timeout}, also
 %% default to 15s then the source connection exits and will be re-established
 %% by the supervisor.
 %%
-%% 1. On startup/interval timer - rtsource_conn casts to rtsource_helper
-%%    to send over the socket.  If TCP buffer is full or rtsource_helper
-%%    is otherwise hung the rtsource_conn process will still continue.
-%%    rtsource_conn sets up a heartbeat timeout.
+%% 1. On startup/interval timer - `rtsource_conn' casts to `rtsource_helper'
+%%    to send over the socket.  If TCP buffer is full or `rtsource_helper'
+%%    is otherwise hung the `rtsource_conn' process will still continue.
+%%    `rtsource_conn' sets up a heartbeat timeout.
 %%
 %% 2. At rtsink, on receipt of a heartbeat message it sends back
 %%    a heartbeat message and stores the timestamp it last received one.
@@ -25,13 +24,14 @@
 %%    as new ones can be established harmlessly.  Keep it simple.
 %%
 %% 3. If rtsource receives the heartbeat back, it cancels the timer
-%%    and updates the hearbeat round trip time (hb_rtt) then sets
+%%    and updates the hearbeat round trip time (`hb_rtt') then sets
 %%    a new heartbeat_interval timer.
 %%
 %%    If the heartbeat_timeout fires, the rtsource connection terminates.
-%%    The rtsource_helper:stop call is now wrapped in a timeout in
-%%    case it is hung so we don't get nasty messages about rtsource_conn
+%%    The `rtsource_helper:stop' call is now wrapped in a timeout in
+%%    case it is hung so we don't get nasty messages about `rtsource_conn'
 %%    crashing when it's the helper that is causing the problems.
+-module(riak_repl2_rtsource_conn).
 
 -behaviour(gen_server).
 -include("riak_repl.hrl").

--- a/src/riak_repl_console.erl
+++ b/src/riak_repl_console.erl
@@ -312,14 +312,14 @@ showClusterConn({Remote,Pid}) ->
     %% if we haven't connected successfully yet, it will time out, which we will fail
     %% fast for since it's a local process, not a remote one.
     try riak_core_cluster_conn:status(Pid, 2) of
-        {Pid, connecting, SRemote} ->
-            io:format("~-20s ~-20s ~-15s (connecting to ~p)~n",
-                      [ConnName, "", PidStr, string_of_remote(SRemote)]);
         {Pid, status, {ClientAddr, _Transport, Name, Members}} ->
             IPs = [string_of_ipaddr(Addr) || Addr <- Members],
             CAddr = choose_best_addr(Remote, ClientAddr),
             io:format("~-20s ~-20s ~-15s ~p (via ~s)~n",
-                      [ConnName, Name, PidStr,IPs, CAddr])
+                      [ConnName, Name, PidStr,IPs, CAddr]);
+        {_StateName, SRemote} ->
+            io:format("~-20s ~-20s ~-15s (connecting to ~p)~n",
+                      [ConnName, "", PidStr, string_of_remote(SRemote)])
     catch
         'EXIT':{timeout, _} ->
             io:format("~-20s ~-20s ~-15s (status timed out)~n",

--- a/src/riak_repl_console.erl
+++ b/src/riak_repl_console.erl
@@ -311,8 +311,7 @@ showClusterConn({Remote,Pid}) ->
     %% try to get status from Pid of cluster control channel.
     %% if we haven't connected successfully yet, it will time out, which we will fail
     %% fast for since it's a local process, not a remote one.
-    Pid ! {self(), status},
-    receive
+    try riak_core_cluster_conn:status(Pid, 2) of
         {Pid, connecting, SRemote} ->
             io:format("~-20s ~-20s ~-15s (connecting to ~p)~n",
                       [ConnName, "", PidStr, string_of_remote(SRemote)]);
@@ -321,7 +320,8 @@ showClusterConn({Remote,Pid}) ->
             CAddr = choose_best_addr(Remote, ClientAddr),
             io:format("~-20s ~-20s ~-15s ~p (via ~s)~n",
                       [ConnName, Name, PidStr,IPs, CAddr])
-    after 2 ->
+    catch
+        'EXIT':{timeout, _} ->
             io:format("~-20s ~-20s ~-15s (status timed out)~n",
                       [ConnName, "", PidStr])
     end.

--- a/src/riak_repl_fullsync_helper.erl
+++ b/src/riak_repl_fullsync_helper.erl
@@ -393,7 +393,7 @@ missing_key(PBKey, DiffState) ->
 %% the same, then a badfun error will occur since the MD5s of the
 %% modules are not the same.
 %%
-%% @see http://www.javalimit.com/2010/05/passing-funs-to-other-erlang-nodes.html
+%% See http://www.javalimit.com/2010/05/passing-funs-to-other-erlang-nodes.html
 keylist_fold({B,Key}=K, V, {MPid, Count, Total}) ->
     try
         H = hash_object(B,Key,V),

--- a/src/riak_repl_fullsync_helper.erl
+++ b/src/riak_repl_fullsync_helper.erl
@@ -389,11 +389,11 @@ missing_key(PBKey, DiffState) ->
 %% purposefully created because if you use a lambda then things will
 %% go wrong when the MD5 of this module changes. I.e. if the lambda is
 %% shipped to another node with a different version of
-%% riak_repl_fullsync_helper, even if the code inside the lambda is
+%% `riak_repl_fullsync_helper', even if the code inside the lambda is
 %% the same, then a badfun error will occur since the MD5s of the
 %% modules are not the same.
 %%
-%% See http://www.javalimit.com/2010/05/passing-funs-to-other-erlang-nodes.html
+%% See [http://www.javalimit.com/2010/05/passing-funs-to-other-erlang-nodes.html]
 keylist_fold({B,Key}=K, V, {MPid, Count, Total}) ->
     try
         H = hash_object(B,Key,V),

--- a/src/riak_repl_keylist_client.erl
+++ b/src/riak_repl_keylist_client.erl
@@ -1,10 +1,12 @@
 %% Riak EnterpriseDS
 %% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
--module(riak_repl_keylist_client).
 
 %% @doc This is the client-side component of the new fullsync strategy
-%% introduced in riak 1.1. See the repl_keylist_server module for more
+%% introduced in riak 1.1. See the `repl_keylist_server' module for more
 %% information on the protocol and the improvements.
+%%
+%% @see repl_keylist_server
+-module(riak_repl_keylist_client).
 
 -behaviour(gen_fsm).
 

--- a/src/riak_repl_keylist_server.erl
+++ b/src/riak_repl_keylist_server.erl
@@ -1,17 +1,18 @@
 %% Riak EnterpriseDS
 %% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
--module(riak_repl_keylist_server).
 
 %% @doc This is the server-side component of the new fullsync strategy
 %% introduced in riak 1.1. It is an improvement over the previous strategy in
 %% several ways:
 %%
-%% * Client and server build keylist in parallel
-%% * No useless merkle tree is built
-%% * Differences are calculated and transmitted in batches, not all in one
-%%   message
-%% * Backpressure is introduced in the exchange of differences
-%% * Pausing/cancelling the diff is immediate
+%% <ul>
+%%   <li>Client and server build keylist in parallel</li>
+%%   <li>No useless merkle tree is built</li>
+%%   <li>Differences are calculated and transmitted in batches, not all in one
+%%   message</li>
+%%   <li>Backpressure is introduced in the exchange of differences</li>
+%%   <li>Pausing/cancelling the diff is immediate</li>
+%% </ul>
 %%
 %% In addition, the client does the requesting of partition data, which makes
 %% this more of a pull model as compared to the legacy strategy, which was more
@@ -34,6 +35,7 @@
 %%
 %% Note that the new key list algorithm uses a bloom fold filter to keep the
 %% keys in disk-order to speed up the key-list creation process.
+-module(riak_repl_keylist_server).
 
 -behaviour(gen_fsm).
 

--- a/src/riak_repl_leader.erl
+++ b/src/riak_repl_leader.erl
@@ -770,7 +770,7 @@ prop_balance() ->
 %% eunit wrapper
 eqc_test_() ->
     {spawn,
-     [{timeout, 10, ?_assert(eqc:quickcheck(eqc:testing_time(4, prop_balance())))}]}.
+     [{timeout, 60, ?_assert(eqc:quickcheck(eqc:testing_time(4, prop_balance())))}]}.
 
 -endif.
 

--- a/src/riak_repl_tcp_client.erl
+++ b/src/riak_repl_tcp_client.erl
@@ -1,6 +1,5 @@
 %% Riak EnterpriseDS
 %% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
--module(riak_repl_tcp_client).
 
 %% @doc This module is responsible for the client-side TCP communication
 %% during replication. A seperate instance of this module is started for every
@@ -10,6 +9,7 @@
 %% the main difference being that this module also manages a pool of put
 %% workers to avoid running the VM out of processes during very heavy
 %% replication load.
+-module(riak_repl_tcp_client).
 
 -include("riak_repl.hrl").
 

--- a/src/riak_repl_tcp_server.erl
+++ b/src/riak_repl_tcp_server.erl
@@ -1,8 +1,6 @@
 %% Riak EnterpriseDS
 %% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
 
--module(riak_repl_tcp_server).
-
 %% @doc This module is responsible for the server-side TCP communication
 %% during replication. A seperate instance of this module is started for every
 %% replication connection that is established. A handshake with the client is
@@ -18,6 +16,7 @@
 %% the cluster are sent to the replication leader, which will then forward
 %% the update out to any connected replication sites. An optional protocol
 %% extension is to use a bounded queue to throttle the stream of updates.
+-module(riak_repl_tcp_server).
 
 -include("riak_repl.hrl").
 

--- a/src/riak_repl_wm_stats.erl
+++ b/src/riak_repl_wm_stats.erl
@@ -83,7 +83,7 @@ produce_body(ReqData, Ctx) ->
 
 %% @spec pretty_print(webmachine:wrq(), context()) ->
 %%          {string(), webmachine:wrq(), context()}
-%% @doc Format the respons JSON object is a "pretty-printed" style.
+%% @doc Format the response JSON object in a "pretty-printed" style.
 pretty_print(RD1, C1=#ctx{}) ->
     {Json, RD2, C2} = produce_body(RD1, C1),
     {json_pp:print(binary_to_list(list_to_binary(Json))), RD2, C2}.

--- a/test/riak_core_cluster_conn_eqc.erl
+++ b/test/riak_core_cluster_conn_eqc.erl
@@ -77,9 +77,11 @@ eqc_test_() ->
 
 setup() ->
     error_logger:tty(false),
+    lager:start(),
     ok.
 
 cleanup(_) ->
+    application:stop(lager),
     ok.
 
 %% ====================================================================
@@ -174,7 +176,7 @@ postcondition(initiating_connection, connecting, _S, {call, ?MODULE, send_timeou
     ?P(?MODULE:current_fsm_state(Pid) =:= connecting);
 postcondition(connected, connected, _S ,{call, ?MODULE, status, _}, R) ->
     ExpectedStatus = {fake_socket,
-                      gen_netbeui,
+                      ranch_tcp,
                       "overtherainbow",
                       [{clustername, "FARFARAWAY"}]},
     {_, status, Status} = R,
@@ -225,7 +227,7 @@ garbage_event(Pid) ->
 connected_to_remote(Pid) ->
     Event = {connected_to_remote,
              fake_socket,
-             gen_netbeui,
+             ranch_tcp,
              "overtherainbow",
              [{clustername, "FARFARAWAY"}]},
     gen_fsm:send_event(Pid, Event).

--- a/test/riak_core_cluster_conn_eqc.erl
+++ b/test/riak_core_cluster_conn_eqc.erl
@@ -76,13 +76,10 @@ eqc_test_() ->
      }}.
 
 setup() ->
-    error_logger:tty(false),
-    lager:start(),
-    ok.
+    riak_repl_test_util:start_lager().
 
-cleanup(_) ->
-    application:stop(lager),
-    ok.
+cleanup(Apps) ->
+    riak_repl_test_util:stop_apps(Apps).
 
 %% ====================================================================
 %% EQC Properties

--- a/test/riak_core_cluster_conn_eqc.erl
+++ b/test/riak_core_cluster_conn_eqc.erl
@@ -1,0 +1,244 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+%% @doc Quickcheck test module for `riak_core_cluster_conn'.
+
+-module(riak_core_cluster_conn_eqc).
+
+-ifdef(EQC).
+-include_lib("eqc/include/eqc.hrl").
+-include_lib("eqc/include/eqc_fsm.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%% eqc properties
+-export([prop_cluster_conn_state_transition/0]).
+
+%% States
+-export([connecting/1,
+         waiting_for_cluster_name/1,
+         waiting_for_cluster_members/1,
+         connected/1]).
+
+%% eqc_fsm callbacks
+-export([initial_state/0,
+         initial_state_data/0,
+         next_state_data/5,
+         precondition/4,
+         postcondition/5]).
+
+%% Helpers
+-export([test/0,
+         test/1]).
+
+-compile(export_all).
+
+-define(QC_OUT(P),
+        eqc:on_output(fun(Str, Args) ->
+                              io:format(user, Str, Args) end, P)).
+
+-define(TEST_ITERATIONS, 500).
+-define(TEST_MODULE, riak_core_cluster_conn).
+
+-define(P(EXPR), PPP = (EXPR), case PPP of true -> ok; _ -> io:format(user, "PPP ~p at line ~p\n", [PPP, ?LINE]) end, PPP).
+
+-record(ccst_state, {current_state :: atom(),
+                     previous_state :: atom()}).
+
+%%====================================================================
+%% Eunit tests
+%%====================================================================
+
+eqc_test_() ->
+    {setup,
+     fun setup/0,
+     fun cleanup/1,
+     {spawn,
+      [
+       {timeout, 60, ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(30, ?QC_OUT(prop_cluster_conn_state_transition()))))}
+      ]
+     }}.
+
+setup() ->
+    error_logger:tty(false),
+    ok.
+
+cleanup(_) ->
+    ok.
+
+%% ====================================================================
+%% EQC Properties
+%% ====================================================================
+
+%% This property is designed to exercise the state transitions of
+%% `riak_core_cluster_conn'. The goal is to ensure that the reception
+%% of expected and unexpected events results in the expected state
+%% transition behavior. It is not intended to verify any of the side
+%% effects that may occur in any particular state and those are
+%% avoided by starting the fsm in `test' mode.
+prop_cluster_conn_state_transition() ->
+    ?FORALL(Cmds,
+            commands(?MODULE),
+            begin
+                {ok, Pid} = ?TEST_MODULE:start_link("FARFARAWAY", test),
+                {H, {_F, _S}, Res} =
+                    run_commands(?MODULE, Cmds, [{fsm_pid, Pid}]),
+                aggregate(zip(state_names(H), command_names(Cmds)),
+                          ?WHENFAIL(
+                             begin
+                                 ?debugFmt("\nCmds: ~p~n",
+                                           [zip(state_names(H),
+                                                command_names(Cmds))]),
+                                 ?debugFmt("\nResult: ~p~n", [Res]),
+                                 ?debugFmt("\nHistory: ~p~n", [H])
+                             end,
+                             equals(ok, Res)))
+            end).
+
+%%====================================================================
+%% eqc_fsm callbacks
+%%====================================================================
+
+initiating_connection(_S) ->
+    [
+     {history, {call, ?MODULE, poll_cluster, [{var, fsm_pid}]}},
+     {history, {call, ?MODULE, garbage_event, [{var, fsm_pid}]}},
+     {history, {call, ?TEST_MODULE, status, [{var, fsm_pid}]}},
+     {connecting, {call, ?MODULE, send_timeout, [{var, fsm_pid}]}}
+    ].
+
+connecting(_S) ->
+    [
+     {history, {call, ?MODULE, poll_cluster, [{var, fsm_pid}]}},
+     {history, {call, ?MODULE, garbage_event, [{var, fsm_pid}]}},
+     {history, {call, ?TEST_MODULE, status, [{var, fsm_pid}]}},
+     {waiting_for_cluster_name, {call, ?MODULE, connected_to_remote, [{var, fsm_pid}]}}
+    ].
+
+waiting_for_cluster_name(_S) ->
+    [
+     {history, {call, ?MODULE, poll_cluster, [{var, fsm_pid}]}},
+     {history, {call, ?MODULE, garbage_event, [{var, fsm_pid}]}},
+     {history, {call, ?TEST_MODULE, status, [{var, fsm_pid}]}},
+     {waiting_for_cluster_members, {call, ?MODULE, cluster_name, [{var, fsm_pid}]}}
+    ].
+
+waiting_for_cluster_members(_S) ->
+    [
+     {history, {call, ?MODULE, poll_cluster, [{var, fsm_pid}]}},
+     {history, {call, ?MODULE, garbage_event, [{var, fsm_pid}]}},
+     {history, {call, ?TEST_MODULE, status, [{var, fsm_pid}]}},
+     {connected, {call, ?MODULE, cluster_members, [{var, fsm_pid}]}}
+    ].
+
+connected(_S) ->
+    [
+     {history, {call, ?MODULE, garbage_event, [{var, fsm_pid}]}},
+     {history, {call, ?TEST_MODULE, status, [{var, fsm_pid}]}},
+     {waiting_for_cluster_name, {call, ?MODULE, poll_cluster, [{var, fsm_pid}]}},
+     {stopped, {call, ?TEST_MODULE, stop, [{var, fsm_pid}]}}
+    ].
+
+stopped(_S) ->
+    [].
+
+initial_state() ->
+    initiating_connection.
+
+initial_state_data() ->
+    #ccst_state{}.
+
+next_state_data(_From, _To, S, _R, _C) ->
+    S.
+
+precondition(_From, _To, _S, _C) ->
+    true.
+
+postcondition(initiating_connection, connecting, _S, {call, ?MODULE, send_timeout, [Pid]}, _R) ->
+    ?P(?MODULE:current_fsm_state(Pid) =:= connecting);
+postcondition(connected, connected, _S ,{call, ?MODULE, status, _}, R) ->
+    ExpectedStatus = {fake_socket,
+                      gen_netbeui,
+                      "overtherainbow",
+                      [{clustername, "FARFARAWAY"}]},
+    {_, status, Status} = R,
+    ?P(Status =:= ExpectedStatus);
+postcondition(State, State, _S ,{call, ?MODULE, status, [Pid]}, R) ->
+    ?P(R =:= State andalso ?MODULE:current_fsm_state(Pid) =:= State);
+postcondition(State, State, _S ,{call, ?MODULE, garbage_event, [Pid]}, _R) ->
+    ?P(?MODULE:current_fsm_state(Pid) =:= State);
+postcondition(connected, waiting_for_cluster_name, _S, {call, ?MODULE, poll_cluster, [Pid]}, _R) ->
+    ?P(?MODULE:current_fsm_state(Pid) =:= waiting_for_cluster_name);
+postcondition(State, State, _S, {call, ?MODULE, poll_cluster, [Pid]}, _R) ->
+    ?P(?MODULE:current_fsm_state(Pid) =:= State);
+postcondition(connecting, waiting_for_cluster_name, _S, {call, ?MODULE, connected_to_remote, [Pid]}, _R) ->
+    ?P(?MODULE:current_fsm_state(Pid) =:= waiting_for_cluster_name);
+postcondition(waiting_for_cluster_name, waiting_for_cluster_members, _S, {call, ?MODULE, cluster_name, [Pid]}, _R) ->
+    ?P(?MODULE:current_fsm_state(Pid) =:= waiting_for_cluster_members);
+postcondition(waiting_for_cluster_members, connected, _S, {call, ?MODULE, cluster_members, [Pid]}, _R) ->
+    ?P(?MODULE:current_fsm_state(Pid) =:= connected);
+postcondition(connected, stopped, _S ,{call, ?TEST_MODULE, stop, [Pid]}, _R) ->
+    ?P(is_process_alive(Pid) =:= false);
+%% Catch all
+postcondition(_From, _To, _S , _C, _R) ->
+    true.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+test() ->
+    test(500).
+
+test(Iterations) ->
+    eqc:quickcheck(eqc:numtests(Iterations, prop_cluster_conn_state_transition())).
+
+current_fsm_state(Pid) ->
+    {CurrentState, _} = ?TEST_MODULE:current_state(Pid),
+    CurrentState.
+
+send_timeout(Pid) ->
+    gen_fsm:send_event(Pid, timeout).
+
+poll_cluster(Pid) ->
+    gen_fsm:send_event(Pid, poll_cluster).
+
+garbage_event(Pid) ->
+    gen_fsm:send_event(Pid, slartibartfast).
+
+connected_to_remote(Pid) ->
+    Event = {connected_to_remote,
+             fake_socket,
+             gen_netbeui,
+             "overtherainbow",
+             [{clustername, "FARFARAWAY"}]},
+    gen_fsm:send_event(Pid, Event).
+
+cluster_name(Pid) ->
+    Event = {cluster_name, "FARFARAWAY"},
+    gen_fsm:send_event(Pid, Event).
+
+cluster_members(Pid) ->
+    Event = {cluster_members,
+             [{"fake-address-1", 1},
+              {"fake-address-2", 2}
+             ]},
+    gen_fsm:send_event(Pid, Event).
+
+-endif.

--- a/test/riak_core_cluster_mgr_tests.erl
+++ b/test/riak_core_cluster_mgr_tests.erl
@@ -283,7 +283,10 @@ start_link_setup() ->
     start_link_setup(?MY_CLUSTER_ADDR).
 
 start_link_setup(ClusterAddr) ->
-    error_logger:tty(false),
+    case os:getenv("ENABLE_LAGER") of
+        false -> error_logger:tty(false);
+        _ -> lager:start(), lager:set_loglevel(lager_console_backend, debug)
+    end,
     % core features that are needed
     {ok, Eventer} = riak_core_ring_events:start_link(),
     {ok, RingMgr} = riak_core_ring_manager:start_link(test),

--- a/test/riak_core_cluster_mgr_tests.erl
+++ b/test/riak_core_cluster_mgr_tests.erl
@@ -283,10 +283,7 @@ start_link_setup() ->
     start_link_setup(?MY_CLUSTER_ADDR).
 
 start_link_setup(ClusterAddr) ->
-    case os:getenv("ENABLE_LAGER") of
-        false -> error_logger:tty(false);
-        _ -> lager:start(), lager:set_loglevel(lager_console_backend, debug)
-    end,
+    Started = riak_repl_test_util:maybe_start_lager(),
     % core features that are needed
     {ok, Eventer} = riak_core_ring_events:start_link(),
     {ok, RingMgr} = riak_core_ring_manager:start_link(test),
@@ -311,7 +308,7 @@ start_link_setup(ClusterAddr) ->
     %% now start cluster manager
     {ok, Pid4 } = riak_core_cluster_mgr:start_link(),
     start_fake_remote_cluster_service(),
-    [Leader, Eventer, RingMgr, Pid1, Pid2, Pid3, Pid4].
+    {Started, [Leader, Eventer, RingMgr, Pid1, Pid2, Pid3, Pid4]}.
 
 watchit(Pid) ->
     proc_lib:spawn(?MODULE, watchit_loop, [Pid]).
@@ -332,7 +329,7 @@ watchit_loop(Pid, Mon) ->
             watchit_loop(Pid, Mon)
     end.
 
-cleanup(Pids) ->
+cleanup({Apps, Pids}) ->
     process_flag(trap_exit, true),
     stop_fake_remote_cluster_service(),
     riak_core_service_mgr:stop(),
@@ -346,6 +343,7 @@ cleanup(Pids) ->
     catch exit(riak_core_ring_events, kill),
     [catch exit(Pid, kill) || Pid <- Pids],
     meck:unload(),
+    ok = riak_repl_test_util:stop_apps(Apps),
     process_flag(trap_exit, false),
     ok.
 

--- a/test/riak_core_connection_mgr_tests.erl
+++ b/test/riak_core_connection_mgr_tests.erl
@@ -80,7 +80,12 @@ connections_test_() ->
      [
       {setup,
        fun() ->
-               error_logger:tty(false),
+               case os:getenv("ENABLE_LAGER") of
+                    false -> error_logger:tty(false);
+                    _ ->
+                        lager:start(),
+                        lager:set_loglevel(lager_console_backend, debug)
+               end,
                ok = application:start(ranch),
                riak_core_ring_events:start_link(),
                riak_core_ring_manager:start_link(test),

--- a/test/riak_core_connection_mgr_tests.erl
+++ b/test/riak_core_connection_mgr_tests.erl
@@ -80,19 +80,15 @@ connections_test_() ->
      [
       {setup,
        fun() ->
-               case os:getenv("ENABLE_LAGER") of
-                    false -> error_logger:tty(false);
-                    _ ->
-                        lager:start(),
-                        lager:set_loglevel(lager_console_backend, debug)
-               end,
+               Apps = riak_repl_test_util:maybe_start_lager(),
                ok = application:start(ranch),
                riak_core_ring_events:start_link(),
                riak_core_ring_manager:start_link(test),
                {ok, _} = riak_core_service_mgr:start_link(?REMOTE_CLUSTER_ADDR),
-               {ok, _} = riak_core_connection_mgr:start_link()
+               {ok, _} = riak_core_connection_mgr:start_link(),
+               Apps
        end,
-       fun(_) ->
+       fun(StartedApps) ->
                process_flag(trap_exit, true),
                riak_core_connection_mgr:stop(),
                riak_core_service_mgr:stop(),
@@ -100,6 +96,7 @@ connections_test_() ->
                catch exit(riak_core_ring_events, kill),
                application:stop(ranch),
                process_flag(trap_exit, false),
+               riak_repl_test_util:stop_apps(StartedApps),
                ok
        end,
        fun(_) -> [

--- a/test/riak_core_connection_tests.erl
+++ b/test/riak_core_connection_tests.erl
@@ -74,24 +74,20 @@ conection_test_() ->
      [
       {setup,
        fun() ->
-               case os:getenv("ENABLE_LAGER") of
-                    false -> ok;
-                    _ ->
-                        lager:start(),
-                        lager:set_loglevel(lager_console_backend, debug)
-               end,
+               Apps = riak_repl_test_util:maybe_start_lager(),
                riak_core_ring_events:start_link(),
                riak_core_ring_manager:start_link(test),
                ok = application:start(ranch),
                {ok, _} = riak_core_service_mgr:start_link(?TEST_ADDR),
-               ok
+               Apps
        end,
-       fun(_) ->
+       fun(Apps) ->
                process_flag(trap_exit, true),
                riak_core_service_mgr:stop(),
                riak_core_ring_manager:stop(),
                catch exit(riak_core_ring_events, kill),
                application:stop(ranch),
+               ok = riak_repl_test_util:stop_apps(Apps),
                process_flag(trap_exit, false),
                ok
        end,

--- a/test/riak_core_connection_tests.erl
+++ b/test/riak_core_connection_tests.erl
@@ -140,7 +140,8 @@ conection_test_() ->
                            %% try to connect via a client that speaks 0.1 and 3.1. No Match with host!
                            ClientProtocol = {test1protoFailed, [{0,1},{3,1}]},
                            ClientSpec = {ClientProtocol, {?TCP_OPTIONS, ?MODULE, failed_client_args}},
-                           riak_core_connection:connect(?TEST_ADDR, ClientSpec),
+                           Got = riak_core_connection:sync_connect(?TEST_ADDR, ClientSpec),
+                           ?assertEqual({error, protocol_version_not_supported}, Got),
 
                            timer:sleep(2000)
                    end}

--- a/test/riak_core_connection_tests.erl
+++ b/test/riak_core_connection_tests.erl
@@ -74,6 +74,12 @@ conection_test_() ->
      [
       {setup,
        fun() ->
+               case os:getenv("ENABLE_LAGER") of
+                    false -> ok;
+                    _ ->
+                        lager:start(),
+                        lager:set_loglevel(lager_console_backend, debug)
+               end,
                riak_core_ring_events:start_link(),
                riak_core_ring_manager:start_link(test),
                ok = application:start(ranch),

--- a/test/riak_core_service_mgr_tests.erl
+++ b/test/riak_core_service_mgr_tests.erl
@@ -50,7 +50,10 @@ service_test_() ->
      [
       {setup,
        fun() ->
-               error_logger:tty(false),
+               case os:getenv("ENABLE_LAGER") of
+                    false -> error_logger:tty(false);
+                    _ -> lager:start(), lager:set_loglevel(lager_console_backend, debug)
+               end,
                riak_core_ring_events:start_link(),
                riak_core_ring_manager:start_link(test),
                ok = application:start(ranch),

--- a/test/riak_repl_test_util.erl
+++ b/test/riak_repl_test_util.erl
@@ -6,6 +6,7 @@
 -export([wait_for_pid/1, wait_for_pid/2]).
 -export([maybe_unload_mecks/1]).
 -export([start_test_ring/0, stop_test_ring/0]).
+-export([maybe_start_lager/0, start_lager/0, stop_apps/1]).
 
 
 start_test_ring() ->
@@ -90,3 +91,31 @@ wait_for_pid(Pid, Timeout) ->
     after Timeout ->
         {error, timeout}
     end.
+
+%% @doc Check the enviroment variable "ENABLE_LAGER" and return any
+%% applications that were started if it was set. If it wasn't set, it
+%% returns an empty list.
+maybe_start_lager() ->
+    maybe_start_lager(os:getenv("ENABLE_LAGER")).
+
+maybe_start_lager(false) ->
+    [];
+
+maybe_start_lager(_) ->
+    start_lager().
+
+start_lager() ->
+    %error_logger:tty(false),
+    {ok, Started} = application:ensure_all_started(lager),
+    lager:set_loglevel(lager_console_backend, debug),
+    Started.
+
+%% @doc Stop the applications listsed. The list is assumed to be in the
+%% order they were started, like what is returned from
+%% `application:ensure_all_started/1'. The apps are stopped in the reverse
+%% order.
+stop_apps(Started) ->
+    lists:foreach(fun(App) ->
+        application:stop(App)
+    end, lists:reverse(Started)).
+


### PR DESCRIPTION
Splits out responsibilities a bit and uses otp behaviors (mainly gen_fsm) to help code-readability and introspection of running systems.

Riak_test is basho/riak_test#684 .

This is a re-do of #621 as that was pointed to the wrong branch.
