### PR TITLE
Introduce exometer metrics into 2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+EXOMETER_PACKAGES = "(basic)"
+export EXOMETER_PACKAGES
+
 .PHONY: rel deps test
 
 all: deps compile

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -19,3 +19,5 @@ Unknown functions
 gen_leader.erl:936: The call sys:handle_debug(Debug::any(),{'gen_leader', 'print_event'},any(),{'in',_}) breaks the contract (Debug,FormFunc,Extra,Event) -> [dbg_opt()] when is_subtype(Debug,[dbg_opt()]), is_subtype(FormFunc,dbg_fun()), is_subtype(Extra,term()), is_subtype(Event,system_event())
 gen_leader.erl:952: Function system_terminate/4 has no local return
 gen_leader.erl:1115: The call sys:handle_debug(Debug::any(),{'gen_leader', 'print_event'},any(),Event::{'$leader_cast',_} | {'noreply',_} | {'ok',_} | {'out',_,_,_}) breaks the contract (Debug,FormFunc,Extra,Event) -> [dbg_opt()] when is_subtype(Debug,[dbg_opt()]), is_subtype(FormFunc,dbg_fun()), is_subtype(Extra,term()), is_subtype(Event,system_event())
+riak_core_connection_mgr_stats.erl:65: The variable Error can never match since previous clauses completely covered the type {'ok',_,_}
+riak_repl_stats.erl:157: The variable Error can never match since previous clauses completely covered the type {'ok',_,_}

--- a/src/riak_repl.app.src
+++ b/src/riak_repl.app.src
@@ -43,6 +43,11 @@
                   %% How many fullsync diff objects to send before needing an
                   %% ACK from the client. Setting this too high will clog your
                   %% TCP buffers.
-                  {diff_batch_size, 100}
+                  {diff_batch_size, 100},
+		  %% Exometer bootstrap
+		  {exometer_folsom_monitor,
+		   [{riak_core_connection_mgr_stats, riak_core_exo_monitor},
+		    {riak_repl_stats, riak_core_exo_monitor}
+		   ]}
                  ]}
 ]}.


### PR DESCRIPTION
This is a PR to hook riak_repl (2.0) into exometer metrics. The hook makes exometer eavesdrop on folsom stat creation from riak_repl, and shadowing their definitions in exometer.
