### PR TITLE
Implement soft_exit, primarily for aae_fullsyn.

### DIFF
--- a/include/riak_repl.hrl
+++ b/include/riak_repl.hrl
@@ -28,6 +28,9 @@
 -define(DEFAULT_SOURCE_RETRIES, infinity).
 %% How many times we should retry when failing a reservation
 -define(DEFAULT_RESERVE_RETRIES, 0).
+%% How many times during a fullsync we should retry a partion that has sent
+%% a 'soft_exit' message to the coordinator
+-define(DEFAULT_SOURCE_SOFT_RETRIES, infinity).
 %% 20 seconds. sources should claim within 5 seconds, but give them a little more time
 -define(RESERVATION_TIMEOUT, (20 * 1000)).
 -define(DEFAULT_MAX_FS_BUSIES_TOLERATED, 10).

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -647,7 +647,10 @@ handle_socket_msg({location_down, Partition}, #state{whereis_waiting=Waiting} = 
             Tref = PartitionInfo#partition_info.whereis_tref,
             erlang:cancel_timer(Tref),
             Dropped = [Partition | State#state.dropped],
-            State2 = State#state{whereis_waiting = Waiting2, dropped = Dropped},
+            #state{retry_exits = RetryExits, error_exits = ErrorExits} = State,
+            State2 = State#state{whereis_waiting = Waiting2, dropped = Dropped,
+                                retry_exits = RetryExits + 1,
+                                error_exits = ErrorExits + 1},
             start_up_reqs(State2)
     end;
 handle_socket_msg({location_down, Partition, _Node}, #state{whereis_waiting=Waiting} = State) ->
@@ -665,10 +668,16 @@ handle_socket_msg({location_down, Partition, _Node}, #state{whereis_waiting=Wait
                 N when N > RetryLimit, is_integer(N) ->
                     lager:warning("Fullsync dropping partition ~p, ~p location_down failed retries", [PartitionInfo#partition_info.index, RetryLimit]),
                     Dropped = [Partition | State#state.dropped],
-                    State3#state{dropped = Dropped};
+                    #state{retry_exits = RetryExits,
+                           error_exits = ErrorExits} = State,
+                    State3#state{dropped = Dropped,
+                                 error_exits = ErrorExits + 1,
+                                 retry_exits = RetryExits + 1};
                 _ ->
                     PQueue = queue:in(PartitionInfo, State3#state.partition_queue),
-                    State3#state{partition_queue = PQueue}
+                    #state{retry_exits = RetryExits} = State,
+                    State3#state{partition_queue = PQueue,
+                                retry_exits = RetryExits + 1}
             end,
             start_up_reqs(State4)
     end.

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -660,7 +660,7 @@ handle_socket_msg({location_down, Partition, _Node}, #state{whereis_waiting=Wait
             RetryLimit = app_helper:get_env(riak_repl, max_reserve_retries, ?DEFAULT_RESERVE_RETRIES),
             lager:info("Partition ~p is unavailable on cluster ~p", [Partition, State#state.other_cluster]),
             State2 = State#state{whereis_waiting = Waiting2},
-            {RetriedCount, State3} = increment_error_dict(PartitionInfo, State#state.reserve_retries, State2),
+            {RetriedCount, State3} = increment_error_dict(PartitionInfo, #state.reserve_retries, State2),
             State4 = case RetriedCount of
                 N when N > RetryLimit, is_integer(N) ->
                     lager:warning("Fullsync dropping partition ~p, ~p location_down failed retries", [PartitionInfo#partition_info.index, RetryLimit]),

--- a/src/riak_repl2_fssource.erl
+++ b/src/riak_repl2_fssource.erl
@@ -101,14 +101,12 @@ init([Partition, IP, Owner]) ->
             case connect(IP, SupportedStrategy, Partition) of
                 {error, Reason} ->
                     {stop, Reason};
-                Result ->
-                    Result
+                {ok, State}->
+                    {ok, State#state{owner = Owner}}
             end;
         {error, Reason} ->
             %% the vnode is probably busy. Try again later.
-            {stop, Reason};
-        {ok, State}->
-            {ok, State#state{owner = Owner}}
+            {stop, Reason}
     end.
 
 handle_call({connected, Socket, Transport, _Endpoint, Proto, Props},

--- a/src/riak_repl2_fssource.erl
+++ b/src/riak_repl2_fssource.erl
@@ -3,8 +3,9 @@
 
 -behaviour(gen_server).
 %% API
--export([start_link/2, connected/6, connect_failed/3, start_fullsync/1,
-         stop_fullsync/1, cluster_name/1, legacy_status/2, fullsync_complete/1]).
+-export([start_link/2, start_link/3, connected/6, connect_failed/3,
+    start_fullsync/1, stop_fullsync/1, fullsync_complete/1,
+    cluster_name/1, legacy_status/2, soft_link/1]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -19,11 +20,15 @@
         connection_ref,
         fullsync_worker,
         work_dir,
-        strategy
+        strategy,
+        owner
     }).
 
 start_link(Partition, IP) ->
-    gen_server:start_link(?MODULE, [Partition, IP], []).
+    start_link(Partition, IP, undefined).
+
+start_link(Partition, IP, Owner) ->
+    gen_server:start_link(?MODULE, [Partition, IP, Owner], []).
 
 %% connection manager callbacks
 connected(Socket, Transport, Endpoint, Proto, Pid, Props) ->
@@ -51,9 +56,33 @@ cluster_name(Pid) ->
 legacy_status(Pid, Timeout) ->
     gen_server:call(Pid, legacy_status, Timeout).
 
+%% @doc Create a 'soft link' between the calling process and the fssource.
+%% A soft-link allows for a soft_exit message to be sent before a normal
+%% exit to any process that has created a soft link. Only one link is
+%% held at a time, and alink is in only one direction (the fssource
+%% reports to calling process).
+soft_link(Pid) ->
+    % not using default long timeout because this is primarily used by the
+    % fscoordinator, and we don't want to potentially block that for up to
+    % 2 minutes. 15 seconds is bad enough in a worst case scenario.
+    try gen_server:call(Pid, {soft_link, self()}, timer:seconds(15)) of
+        ok -> % older versions returned 'ok' for the catchall
+            false;
+        true ->
+            true
+    catch
+        _What:Reason ->
+            lager:debug("Could not create soft link to ~p from ~p due to ~p", [Pid, self(), Reason]),
+            {error, Reason}
+    end.
+
 %% gen server
 
 init([Partition, IP]) ->
+    init([Partition, IP, undefined]);
+
+init([Partition, IP, Owner]) ->
+
     RequestedStrategy = app_helper:get_env(riak_repl,
                                            fullsync_strategy,
                                            ?DEFAULT_FULLSYNC_STRATEGY),
@@ -77,7 +106,9 @@ init([Partition, IP]) ->
             end;
         {error, Reason} ->
             %% the vnode is probably busy. Try again later.
-            {stop, Reason}
+            {stop, Reason};
+        {ok, State}->
+            {ok, State#state{owner = Owner}}
     end.
 
 handle_call({connected, Socket, Transport, _Endpoint, Proto, Props},
@@ -149,9 +180,22 @@ handle_call(stop_fullsync, _From, State=#state{fullsync_worker=FSW,
 handle_call(legacy_status, _From, State=#state{fullsync_worker=FSW,
                                                socket=Socket,
                                                strategy=Strategy}) ->
-    Res = case is_pid(FSW) andalso is_process_alive(FSW) of
-        true -> gen_fsm:sync_send_all_state_event(FSW, status, infinity);
-        false -> []
+    lager:debug("Sending status to ~p", [FSW]),
+    Res = case is_pid(FSW) of
+        true ->
+            % try/catch because there may be a message in the pid's
+            % mailbox that will cause it to exit before it gets to our
+            % status request message.
+            try gen_fsm:sync_send_all_state_event(FSW, status, infinity) of
+                SyncSendRes ->
+                    SyncSendRes
+            catch
+                What:Why ->
+                    lager:notice("Error getting fullsync worker ~p status: ~p:~p", [FSW, What, Why]),
+                    []
+            end;
+        false ->
+            []
     end,
     SocketStats = riak_core_tcp_mon:format_socket_stats(
         riak_core_tcp_mon:socket_status(Socket), []),
@@ -172,6 +216,10 @@ handle_call(cluster_name, _From, State) ->
             ClusterName
     end,
     {reply, Name, State};
+handle_call({soft_link, NewOwner}, _From, State) ->
+    lager:debug("Changing soft_link from ~p to ~p", [State#state.owner, NewOwner]),
+    State2 = State#state{owner = NewOwner},
+    {reply, true, State2};
 handle_call(_Msg, _From, State) ->
     {reply, ok, State}.
 
@@ -221,16 +269,20 @@ handle_info({Proto, Socket, Data},
             gen_fsm:send_event(State#state.fullsync_worker, Msg),
             {noreply, State}
     end;
+handle_info({soft_exit, Pid, Reason}, State = #state{fullsync_worker = Pid}) ->
+    lager:debug("Fullsync worker exited normally, but really wanted it to be ~p", [Reason]),
+    maybe_soft_exit(Reason, State);
 handle_info(_Msg, State) ->
     {noreply, State}.
 
 terminate(_Reason, #state{fullsync_worker=FSW, work_dir=WorkDir}) ->
-    %% check if process alive only if it's defined
-    case is_pid(FSW) andalso is_process_alive(FSW) of
+    %% try to exit the fullsync worker; if we're dying because it did,
+    %% don't worry about the error (cause it's already dead).
+    case is_pid(FSW) of
         false ->
             ok;
         true ->
-            gen_fsm:sync_send_all_state_event(FSW, stop)
+            catch gen_fsm:sync_send_all_state_event(FSW, stop) 
     end,
     case WorkDir of
         undefined -> ok;
@@ -306,3 +358,13 @@ connect(IP, Strategy, Partition) ->
             lager:warning("Error connecting to remote ~p for partition ~p", [IP, Partition]),
             {error, Reason}
     end.
+
+maybe_soft_exit(Reason, State) ->
+    case State#state.owner of
+        undefined ->
+            {stop, Reason, State};
+        Owner ->
+            Owner ! {soft_exit, self(), Reason},
+            {stop, normal, State}
+    end.
+

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -106,7 +106,8 @@ handle_info({'DOWN', TreeMref, process, Pid, Why}, _StateName, State=#state{tree
     %% Local hashtree process went down. Stop exchange.
     lager:info("Monitored pid ~p, AAE Hashtree process went down because: ~p", [Pid, Why]),
     send_complete(State),
-    {stop, {aae_hashtree_went_down, Why}, State};
+    State#state.owner ! {soft_exit, self(), {aae_hastree_went_down, Why}},
+    {stop, normal, State};
 handle_info(Error={'DOWN', _, _, _, _}, _StateName, State) ->
     %% Something else exited. Stop exchange.
     lager:info("Something went down ~p", [Error]),
@@ -181,7 +182,8 @@ prepare_exchange(start_exchange, State0=#state{transport=Transport,
                 Error ->
                     lager:info("AAE source failed get_lock for partition ~p, got ~p",
                                [Partition, Error]),
-                    {stop, Error, State}
+                    State#state.owner ! {soft_exit, self(), Error},
+                    {stop, normal, State}
             end;
         {error, wrong_node} ->
             {stop, wrong_node, State0}
@@ -195,7 +197,8 @@ prepare_exchange(start_exchange, State=#state{index=Partition}) ->
             lager:info("Remote lock tree for partition ~p failed, got ~p",
                           [Partition, Error]),
             send_complete(State),
-            {stop, {remote, Error}, State}
+            State#state.owner ! {soft_exit, self(), {remote, Error}},
+            {stop, normal, State}
     end.
 
 %% @doc Now that locks have been acquired, ask both the local and remote

--- a/src/riak_repl_wm_stats.erl
+++ b/src/riak_repl_wm_stats.erl
@@ -125,7 +125,6 @@ format_pid_stat(Pair) ->
 
 
 jsonify_stats([], Acc) ->
-    %?debugFmt("Got []: Acc: ~w", [Acc]),
     lists:flatten(lists:reverse(Acc));
 
 jsonify_stats([{fullsync, Num, _Left}|T], Acc) ->


### PR DESCRIPTION
Problem: transient failures of aae, such as trees not yet built or locks not
being aquired, would cause an aae fullsync process to exit abnormally. This
could happen several times in a row, creating log spam.

Resolution: the concept of soft_exit. A soft_exit is a message sent from a soon
to be exiting process to a soft_linked process. The exiting process would then
exit normally, while any soft_linked processes could handle the soft_exit
message in a similar fashion as an exit message. This would indicate an exit
reason that should be handled, but not bad enough to have the system logger
know about it.

The soft_exit message sent from the aae worker to the fscoordinator is
as simple as `{soft_exit, pid(), term()}'.

The current implementation is not generic. There can only one soft_link to
the aae, and there's no general mechanism to use soft_link's or soft_exits
elsewhere in the code base. Sorry.

Another change rolled into this is consistent use of a #partition_info record
in the fscoordinator, and error tracking the fscoordinator's state. By swapping
to useing a single data structure in the partition queue, whereis waiting list,
and purgatory queues it makes it easier to understand the fscordinator (as
there is less code modify structures).

This is a forward port of the fix done for 1.4 (#626). A riak_test exists at https://github.com/basho/riak_test/pull/703. Conflicts favor existing code
where it does not directly effect the fix.

Conflicts:
    Makefile
    rebar.config
    src/riak_repl2_fssource.erl
    src/riak_repl2_rtq_proxy.erl
    src/riak_repl_aae_source.erl
    test/riak_core_cluster_mgr_tests.erl
