### PR TITLE
Bugfix/mw/better rt dirty

### DIFF
--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -195,7 +195,7 @@ node_dirty(Node) ->
         Leader ->
             Fullsyncs = riak_repl2_fscoordinator_sup:started(Leader),
             [riak_repl2_fscoordinator:node_dirty(Pid, Node) ||
-                {_, Pid} <- Fullsyncs]
+                {_, Pid} <- Fullsyncs, Pid =/= self()]
     end.
 
 node_dirty(Pid, Node) ->

--- a/src/riak_repl2_fscoordinator.erl
+++ b/src/riak_repl2_fscoordinator.erl
@@ -1080,5 +1080,5 @@ check_nodes_for_rt_dirty(Ring) ->
     [ case rpc:call(Node, riak_repl_stats, is_rt_dirty,[]) of
             false -> ok;
             _ -> riak_repl2_fscoordinator:node_dirty(Node)
-        end || Node <- Owners ].
+        end || {_Part, Node} <- Owners ].
 

--- a/src/riak_repl_stats.erl
+++ b/src/riak_repl_stats.erl
@@ -140,8 +140,10 @@ rt_dirty() ->
                         riak_repl2_fscoordinator:node_dirty(node())
                       catch
                         _:_ ->
-                         lager:debug("Failed to notify coordinator of rt_dirty status")
-                      end
+                         %% This could be triggered on startup if the
+                         %% fscoordinator isn't running
+                         lager:warning("Failed to notify coordinator of rt_dirty status.")
+                       end
             end),
             ok;
         false -> ok

--- a/src/riak_repl_stats.erl
+++ b/src/riak_repl_stats.erl
@@ -139,10 +139,10 @@ rt_dirty() ->
                       try
                         riak_repl2_fscoordinator:node_dirty(node())
                       catch
-                        _:_ ->
+                        W:Y ->
                          %% This could be triggered on startup if the
                          %% fscoordinator isn't running
-                         lager:warning("Failed to notify coordinator of rt_dirty status.")
+                         lager:warning("Failed to notify coordinator of rt_dirty status due to ~p:~p.", [W,Y])
                        end
             end),
             ok;


### PR DESCRIPTION
A rebase with a couple of fixes of https://github.com/basho/riak_repl/pull/389. Requires updates to r_t replication2_dirty found in https://github.com/basho/riak_test/pull/709.
