### PR TITLE
Address some minor bugs around establishing SSL connections

### DIFF
--- a/src/riak_core_cluster_conn.erl
+++ b/src/riak_core_cluster_conn.erl
@@ -362,7 +362,7 @@ code_change(_OldVsn, StateName, State, _Extra) ->
 request_cluster_name(#state{mode=test}) ->
     ok;
 request_cluster_name(#state{socket=Socket, transport=Transport}) ->
-    _ = inet:setopts(Socket, [{active, once}]),
+    _ = Transport:setopts(Socket, [{active, once}]),
     Transport:send(Socket, ?CTRL_ASK_NAME).
 
 -spec request_member_ips(state()) -> ok | {error, term()}.

--- a/src/riak_core_connection.erl
+++ b/src/riak_core_connection.erl
@@ -205,8 +205,8 @@ handle_info({_Transport, Socket, Data}, wait_for_capabilities, State = #state{so
                     {stop, Error, State};
                 {NewTransport, NewSocket} ->
                     FullProto = {State#state.protocol, State#state.protovers},
-                    NewTransport:send(Socket, erlang:term_to_binary(FullProto)),
-                    NewTransport:setopts(Socket, [{active, once}]),
+                    NewTransport:send(NewSocket, erlang:term_to_binary(FullProto)),
+                    NewTransport:setopts(NewSocket, [{active, once}]),
                     State2 = State#state{transport = NewTransport, socket = NewSocket, remote_capabilities = TheirCaps},
                     {next_state, wait_for_protocol, State2}
             end;
@@ -260,7 +260,6 @@ try_ssl(Socket, Transport, MyCaps, TheirCaps) ->
             {Transport, Socket};
         {true, true} ->
             lager:info("~p and ~p agreed to use SSL", [MyName, TheirName]),
-            ok = ssl:start(),
             case riak_core_ssl_util:upgrade_client_to_ssl(Socket, riak_core) of
                 {ok, SSLSocket} ->
                     {ranch_ssl, SSLSocket};
@@ -270,4 +269,3 @@ try_ssl(Socket, Transport, MyCaps, TheirCaps) ->
                     {error, Reason}
             end
       end.
-


### PR DESCRIPTION
A few minor bugs were discovered while investigating riak_test failures.
- The ssl application is explicitly started in
  riak_core_connection:try_ssl/0. The statement in the function
  expects the call to ssl:start/0 to always return ok, but in some
  cases the ssl application is already started and the call returns
  {error, {already_started, ssl}} instead. This should not represent
  an error condition, but as written an exception is generated in this
  case. This resulted in riak_test runs of replication tests that
  exercise SSL to stall. Really there is no reason to attempt to start
  the ssl application at this point in the code. The ssl application
  is an application dependency of the riak_repl application and should
  be started by the call to riak_core_util:start_app_deps in
  riak_repl_app:start/2. Removing the attempt to start ssl in
  riak_core_connection to avoid confusion.
- The first handle_info function clause in riak_core_connection that
  handles a message received while in the wait_for_capabilities state
  attempts to use SSL by calling the try_ssl/4 function. If it
  succeeds a pair is returned whose elements are the name of the new
  transport and a new socket for the SSL connection. However the new
  socket was not being used for subsequent calls to send and setopts
  and this caused failure of several riak_tests.
- The non-test function clause of
  riak_core_cluster_conn:request_cluster_name/1 contained assumptions
  about the transport in use and explicitly called
  inet:setopts/2. This does not work when SSL is used and also caused
  several test failures. The function has been changed so that the
  specified transport is used for the call to setopts instead.
