### PR TITLE
Remove partition from purgatory when giving up

### DIFF
--- a/test/riak_repl_test_util.erl
+++ b/test/riak_repl_test_util.erl
@@ -105,9 +105,9 @@ maybe_start_lager(_) ->
     start_lager().
 
 start_lager() ->
-    %error_logger:tty(false),
     {ok, Started} = application:ensure_all_started(lager),
-    lager:set_loglevel(lager_console_backend, debug),
+    % But keep it quiet, please
+    lager:set_loglevel(lager_console_backend, '=emergency'),
     Started.
 
 %% @doc Stop the applications listsed. The list is assumed to be in the


### PR DESCRIPTION
When a partition has hit the soft exit limit, we add it to the dropped
list, but forgot to remove it from the purgatory list. So it may
actually be retried later.

Also, using a big hammer to silence noisy lager output during EQC tests.

This should fix the cause of this riak_test failure: http://giddyup.basho.com/#/projects/riak_ee/scorecards/115/115-1668-repl_aae_fullsync-centos-6-64/65935/artifacts/1226179

Where you can see partitions being "discared" when they hit the soft limit, but then tried again later. btw, that typo is also fixed by this PR.

/cc @lordnull 
