### PR TITLE
Issue Riak-1338

### DIFF
--- a/test/riak_repl2_rtq_tests.erl
+++ b/test/riak_repl2_rtq_tests.erl
@@ -74,7 +74,7 @@ overload_protection_start_test_() ->
             {ok, Rtq1} = riak_repl2_rtq:start_link(),
             unlink(Rtq1),
             exit(Rtq1, kill),
-            riak_repl_test_util:wait_for_pid(Rtq1),
+            riak_repl_test_util:wait_until_down(Rtq1),
             Got = riak_repl2_rtq:start_link(),
             ?assertMatch({ok, _Pid}, Got),
             riak_repl2_rtq:stop(),
@@ -96,7 +96,7 @@ overload_protection_start_test_() ->
             {ok, Pid1} = Got1,
             unlink(Pid1),
             exit(Pid1, kill),
-            riak_repl_test_util:wait_for_pid(Pid1),
+            riak_repl_test_util:wait_until_down(Pid1),
             Got2 = riak_repl2_rtq_overload_counter:start_link([{report_interval, 20}]),
             ?assertMatch({ok, _Pid}, Got2),
             riak_repl2_rtq_overload_counter:stop()

--- a/test/riak_repl_test_util.erl
+++ b/test/riak_repl_test_util.erl
@@ -1,13 +1,16 @@
 -module(riak_repl_test_util).
 
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+
 -export([reset_meck/1, reset_meck/2]).
 -export([abstract_gen_tcp/0, abstract_stats/0, abstract_stateful/0]).
 -export([kill_and_wait/1, kill_and_wait/2]).
--export([wait_for_pid/1, wait_for_pid/2]).
+-export([wait_until_down/1, wait_until_down/2]).
 -export([maybe_unload_mecks/1]).
 -export([start_test_ring/0, stop_test_ring/0]).
 -export([maybe_start_lager/0, start_lager/0, stop_apps/1]).
-
 
 start_test_ring() ->
     stop_test_ring(),
@@ -66,11 +69,17 @@ reset_meck(Mod, Opts) ->
     end,
     meck:new(Mod, Opts).
 
-kill_and_wait(Victem) ->
-    kill_and_wait(Victem, stupify).
+kill_and_wait(Victims) ->
+    kill_and_wait(Victims, stupify).
 
 kill_and_wait(undefined, _Cause) ->
     ok;
+
+kill_and_wait([], _Cause) ->
+    ok;
+kill_and_wait([Atom | Rest], Cause) ->
+    kill_and_wait(Atom, Cause),
+    kill_and_wait(Rest, Cause);
 
 kill_and_wait(Atom, Cause) when is_atom(Atom) ->
     kill_and_wait(whereis(Atom), Cause);
@@ -78,12 +87,12 @@ kill_and_wait(Atom, Cause) when is_atom(Atom) ->
 kill_and_wait(Pid, Cause) when is_pid(Pid) ->
     unlink(Pid),
     exit(Pid, Cause),
-    wait_for_pid(Pid).
+    wait_until_down(Pid).
 
-wait_for_pid(Pid) ->
-    wait_for_pid(Pid, infinity).
+wait_until_down(Pid) ->
+    wait_until_down(Pid, infinity).
 
-wait_for_pid(Pid, Timeout) ->
+wait_until_down(Pid, Timeout) ->
     Mon = erlang:monitor(process, Pid),
     receive
         {'DOWN', Mon, process, Pid, _Why} ->
@@ -119,3 +128,4 @@ stop_apps(Started) ->
         application:stop(App)
     end, lists:reverse(Started)).
 
+-endif. % TEST

--- a/test/rt_sink_eqc.erl
+++ b/test/rt_sink_eqc.erl
@@ -378,7 +378,7 @@ connect_from_v2(Remote) ->
 disconnect({_Remote, State}) ->
     {Source, Sink} = State#src_state.pids,
     riak_repl_test_util:kill_and_wait(Source),
-    riak_repl_test_util:wait_for_pid(Sink),
+    riak_repl_test_util:wait_until_down(Sink),
     {Source, Sink}.
 
 push_object({_Remote, #src_state{version = 2} = SrcState}, RiakObj, AlreadyRouted) ->


### PR DESCRIPTION
Cleaned up the care and feeding of the fake_sink test server to use a dynamically allocated port.  Also attempt to make sure it gets shut down cleanly so that the reported address-in-use error would be less likely, though the port could be in use otherwise so a dynamic one is superior all around.

Revised the riak_repl2_rtsource_conn eunit test to throw an error on failure, which is what eunit is looking for to determine pass/fail.

Removed a block of "receive" code at the end of the riak_repl2_rtsource_conn test that always returned a timeout error, as nothing was sending it a message at that point.

Refactored a teensy bit of test code so the names make sense.
