### PR TITLE
AAE FS Automatic creation of hashtrees 

### DIFF
--- a/src/riak_repl2_fssink.erl
+++ b/src/riak_repl2_fssink.erl
@@ -236,13 +236,12 @@ decide_common_strategy(OurCaps, TheirCaps) ->
 %% Based on the agreed common protocol level and the supported
 %% mode of AAE, decide what strategy we are capable of offering.
 decide_our_caps(CommonMajor) ->
-    SupportedStrategy =
-        case {riak_kv_entropy_manager:enabled(), CommonMajor} of
-            {_,1} -> keylist;
-            {false,_} -> keylist;
-            {true,_} -> aae
-        end,
-    [{strategy, SupportedStrategy}].
+	SupportedStrategy =
+		case CommonMajor of
+			1 -> keylist;
+			_ -> aae
+		end,
+	[{strategy, SupportedStrategy}].
 
 %% Depending on the protocol version number, send our capabilities
 %% as a list of properties, in binary.

--- a/src/riak_repl_aae_sink.erl
+++ b/src/riak_repl_aae_sink.erl
@@ -123,7 +123,7 @@ code_change(_OldVsn, State, _Extra) ->
 
 %% replies: ok
 process_msg(?MSG_INIT, Partition, State) ->
-    case riak_kv_vnode:hashtree_pid(Partition) of
+    case riak_kv_vnode:hashtree_pid(Partition, riak_kv_entropy_manager:enabled()) of
         {ok, TreePid} ->
             %% monitor the tree and crash if the tree goes away
             monitor(process, TreePid),

--- a/src/riak_repl_aae_sink.erl
+++ b/src/riak_repl_aae_sink.erl
@@ -131,7 +131,7 @@ process_msg(?MSG_INIT, Partition, State) ->
             riak_repl2_fs_node_reserver:claim_reservation(Partition),
             case riak_kv_entropy_manager:enabled() of
                 false ->
-                    riak_kv_index_hashtree:poke(TreePid);
+                    riak_kv_index_hashtree:build(TreePid);
                _ ->
                     ok
             end,
@@ -164,7 +164,7 @@ process_msg(?MSG_UPDATE_TREE, IndexN, State=#state{tree_pid=TreePid}) ->
 process_msg(?MSG_LOCK_TREE, State=#state{tree_pid=TreePid}) ->
     %% NOTE: be sure to die if tcp connection dies, to give back lock
     case riak_kv_index_hashtree:wait_for_lock(TreePid, fullsync_source) of
-        not_built ->
+        building ->
             %% Wait for lock
             {noreply, State};
         Response ->

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -198,6 +198,12 @@ prepare_exchange(start_exchange, State0=#state{transport=Transport,
                 ok ->
                     prepare_exchange(start_exchange, State#state{local_lock=true});
                 Error ->
+                    case riak_kv_entropy_manager:enabled() of
+                        false ->
+                            riak_kv_index_hashtree:poke(TreePid);
+                        true ->
+                            ok
+                    end,
                     lager:info("AAE source failed get_lock for partition ~p, got ~p",
                                [Partition, Error]),
                     State#state.owner ! {soft_exit, self(), Error},

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -188,7 +188,7 @@ prepare_exchange(start_exchange, State0=#state{transport=Transport,
     %% List of IndexNs to iterate over.
     IndexNs = riak_kv_util:responsible_preflists(Partition),
 
-case riak_kv_vnode:hashtree_pid(Partition) of
+case riak_kv_vnode:hashtree_pid(Partition, riak_kv_entropy_manager:enabled()) of
     {ok, TreePid} ->
         TreeMref = monitor(process, TreePid),
         State = State0#state{timeout=Timeout,

--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -197,11 +197,11 @@ case riak_kv_vnode:hashtree_pid(Partition) of
                              tree_mref=TreeMref},
         case riak_kv_entropy_manager:enabled() of
             false ->
-                riak_kv_index_hashtree:poke(TreePid),
+                riak_kv_index_hashtree:build(TreePid),
                 case riak_kv_index_hashtree:wait_for_lock(TreePid, fullsync_source) of
                     ok ->
                         prepare_exchange(start_exchange, State#state{local_lock=true});
-                    not_built ->
+                    building ->
                         {next_state, prepare_exchange, State};
                     Error ->
                         lager:info("AAE source failed get_lock for partition ~p, got ~p",


### PR DESCRIPTION
Fullsync_strategy is configured to aae
AAE is set to off

1) AAE trees are completely built.
2) The AAE FS completes successully
3) AAE trees are removed as we shouldn't let the soon outdated AAE trees linger.
https://bashoeng.atlassian.net/browse/RIAK-1134

Some performance numbers:
https://docs.google.com/a/basho.com/spreadsheets/d/1YW3yqhX_tJd_PbgLiUFJnT585No50-mWtnfbhwSdKwg/edit#gid=0
