### PR TITLE
Fix replication2_ssl test for Riak 2.0.5 [JIRA: RIAK-1523]

### DIFF
--- a/src/riak_core_connection.erl
+++ b/src/riak_core_connection.erl
@@ -216,8 +216,8 @@ handle_info({_Transport, Socket, Data}, wait_for_capabilities, State = #state{so
                     {stop, Error, State};
                 {NewTransport, NewSocket} ->
                     FullProto = {State#state.protocol, State#state.protovers},
-                    NewTransport:send(Socket, erlang:term_to_binary(FullProto)),
-                    NewTransport:setopts(Socket, [{active, once}]),
+                    NewTransport:send(NewSocket, erlang:term_to_binary(FullProto)),
+                    NewTransport:setopts(NewSocket, [{active, once}]),
                     State2 = State#state{transport = NewTransport,
                                          socket = NewSocket,
                                          remote_capabilities = TheirCaps},


### PR DESCRIPTION
Fixes replication2_ssl test for Riak 2.0.5
