### PR TITLE
core_connection exit abnormally on socket closed.

### DIFF
--- a/src/riak_core_connection.erl
+++ b/src/riak_core_connection.erl
@@ -249,7 +249,7 @@ handle_info({_TransTag, Socket, Data}, wait_for_protocol, State = #state{socket 
 
 handle_info({_LikelyClose, Socket}, _StateName, State = #state{socket = Socket}) ->
     lager:debug("Socket closed"),
-    {stop, normal, State}.
+    {stop, socket_closed, State}.
 
 terminate(_Why, _StateName, _State) ->
     ok.


### PR DESCRIPTION
The connection manager uses a helper process to wrap the call to
riak_core_connection:sync_connect/2. that call will start the gen_fsm that is
the connection, and then block until that gen_fsm exits (using a monitor).
On a normal exit, ‘ok’ is returned. On anything else, an error is returned.

In the case of the socket being closed while the gen_fsm is negotiating the
protocol, the exit cause was ‘normal’. this meant the riak_core_connection
process never called the method to tell a process wanting to connect (such as
a proxy get provider) it has a socket since it’s exited, and the connection
manager never called the method to the process wanting the connection the
connection failed since all it saw was a success.

this fix resolves a failing riak_test replication2_pg:test_pg_proxy
