### PR TITLE
heartbeat scheduling bug fix

### DIFF
--- a/src/riak_repl2_rtsource_conn.erl
+++ b/src/riak_repl2_rtsource_conn.erl
@@ -480,6 +480,11 @@ schedule_heartbeat(State = #state{hb_interval_tref = undefined,
     TRef = erlang:send_after(timer:seconds(HBInterval), self(), send_heartbeat),
     State#state{hb_interval_tref = TRef};
 
+schedule_heartbeat(State = #state{hb_interval_tref = _TRef,
+                                  hb_interval = HBInterval}) when is_integer(HBInterval) ->
+    lager:warning("hb_interval_tref is not undefined when attempting to schedule new heartbeat."),
+    State;
+
 schedule_heartbeat(State) ->
     lager:warning("Heartbeat is misconfigured and is not a valid integer."),
     State.


### PR DESCRIPTION
In the case the `hb_interval` is already set, the pattern match to get into the first case will not succeed and thus an error message will be thrown.  However, the default error message is incorrect in the case that the heartbeat interval is already set.  We are seeing this issue in [Customer Ticket #10506](https://basho.zendesk.com/agent/tickets/10506) and we believe the root cause is similar to the issue Shino has raised - Ticket #637 (RIAK-1381).  This code change will allow for better logging statements in the situation the heartbeat is already set and we should just leave it alone.  
