### PR TITLE
Update AAE fullsync to support bucket types

### DIFF
--- a/src/riak_repl2_fssink_pool.erl
+++ b/src/riak_repl2_fssink_pool.erl
@@ -2,7 +2,7 @@
 %% fullsyncs are running.
 
 -module(riak_repl2_fssink_pool).
--export([start_link/0, status/0, bin_put/1]).
+-export([start_link/0, status/0, put/1, bin_put/1]).
 
 start_link() ->
     MinPool = app_helper:get_env(riak_repl, fssink_min_workers, 5),
@@ -20,6 +20,12 @@ status() ->
      {worker_queue_len, WorkerQueueLen},
      {overflow, Overflow},
      {num_monitors, NumMonitors}].
+
+%% @doc Send an object or BT hash / object pair to the worker pool to
+%% run a put against. No guarantees of completion.
+put(Obj) ->
+    Pid = poolboy:checkout(?MODULE, true, infinity),
+    riak_repl_fullsync_worker:do_put(Pid, Obj, ?MODULE).
 
 %% @doc Send a replication wire-encoded binary to the worker pool
 %% for running a put against.  No guarantees of completion.

--- a/src/riak_repl_aae_sink.erl
+++ b/src/riak_repl_aae_sink.erl
@@ -83,7 +83,7 @@ handle_info({Proto, _Socket, Data}, State=#state{transport=Transport,
         [MsgType|<<>>] ->
             process_msg(MsgType, State);
         [MsgType|MsgData] ->
-            process_msg(MsgType, binary_to_term(MsgData), State)
+            process_msg(MsgType, riak_repl_util:decode_obj_msg(MsgData), State)
     end;
 
 handle_info({'DOWN', _, _, _, _}, State) ->
@@ -143,10 +143,10 @@ process_msg(?MSG_GET_AAE_SEGMENT, {SegmentNum,IndexN}, State=#state{tree_pid=Tre
     send_reply(ResponseMsg, State);
 
 %% no reply
-process_msg(?MSG_PUT_OBJ, {fs_diff_obj, BObj}, State) ->
+process_msg(?MSG_PUT_OBJ, {fs_diff_obj, Obj}, State) ->
     %% may block on worker pool, ok return means work was submitted
     %% to pool, not that put FSM completed successfully.
-    ok = riak_repl2_fssink_pool:bin_put(BObj),
+    ok = riak_repl2_fssink_pool:put(Obj),
     {noreply, State};
 
 %% replies: ok | not_responsible

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -55,6 +55,7 @@
          sockname/2,
          deduce_wire_version_from_proto/1,
          encode_obj_msg/2,
+         decode_obj_msg/1,
          make_pg_proxy_name/1,
          make_pg_name/1,
          mode_12_enabled/1,
@@ -882,6 +883,18 @@ encode_obj(w0, RObj) ->
     RObj;
 encode_obj(W, RObj) ->
     to_wire(W, RObj).
+
+decode_obj_msg(Data) ->
+    Msg = binary_to_term(Data),
+    case Msg of
+        {fs_diff_obj, BObj} when is_binary(BObj) ->
+            RObj = riak_repl_util:from_wire(BObj),
+            {fs_diff_obj, RObj};
+        {fs_diff_obj, _RObj} ->
+            Msg;
+        Other ->
+            Other
+    end.
 
 %% @doc Create binary wire formatted replication blob for riak 2.0+, complete with
 %%      possible type, bucket and key for reconstruction on the other end. BinObj should be

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -888,9 +888,12 @@ decode_obj_msg(Data) ->
     Msg = binary_to_term(Data),
     case Msg of
         {fs_diff_obj, BObj} when is_binary(BObj) ->
-            RObj = riak_repl_util:from_wire(BObj),
+            RObj = from_wire(BObj),
             {fs_diff_obj, RObj};
-        {fs_diff_obj, _RObj} ->
+        {fs_diff_obj, {BTHash, BObj}} when is_binary(BObj) ->
+            RObj = from_wire(BObj),
+            {fs_diff_obj, {BTHash, RObj}};
+        {fs_diff_obj, _} ->
             Msg;
         Other ->
             Other

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -880,8 +880,8 @@ encode_obj_msg(V, {Cmd, RObj}, T) ->
 %% A wrapper around to_wire which leaves the object unencoded when using the w0 wire protocol.
 encode_obj(w0, RObj) ->
     RObj;
-encode_obj(_W, RObj) ->
-    to_wire(w1, RObj).
+encode_obj(W, RObj) ->
+    to_wire(W, RObj).
 
 %% @doc Create binary wire formatted replication blob for riak 2.0+, complete with
 %%      possible type, bucket and key for reconstruction on the other end. BinObj should be


### PR DESCRIPTION
Fixes issue #663 (RIAK-1292) (RIAK-1294) (RIAK-1295) by updating `encode_obj_msg` to support the `w2` wire protocol, and by changing the AAE sink to use an updated `decode_obj_msg` function which can now properly handle bucket type property hashes.

`encode_obj_msg` and `decode_obj_msg` are not currently proper inverses of each other, but I kept the current behavior as not all messages passed to `decode_obj_msg` are guaranteed to be encoded using `encode_obj_msg`.

I have manually verified that this allows keys with a bucket type to be synced using AAE fullsync, but a test combining bucket types and AAE fullsync should probably be added to `riak_test`.
