### PR TITLE
Fix deadlocks in fullsync (aae and keylist) when handoff occurs

### DIFF
--- a/src/riak_repl_aae_source.erl
+++ b/src/riak_repl_aae_source.erl
@@ -492,8 +492,11 @@ finish_sending_differences(#exchange{bloom=Bloom, count=DiffCnt},
                                 {FoldRef, _Reply} ->
                                     %% we don't care about the reply
                                     gen_fsm:send_event(Self, diff_done);
-                                {'DOWN', MonRef, process, VNodePid, Reason}
-                                        when Reason /= normal ->
+                                {'DOWN', MonRef, process, VNodePid, normal} ->
+                                    lager:warning("VNode ~p exited before fold for partition ~p",
+                                        [VNodePid, Partition]),
+                                    exit({bloom_fold, vnode_exited_before_fold});
+                                {'DOWN', MonRef, process, VNodePid, Reason}  ->
                                     lager:warning("Fold of ~p exited with ~p",
                                                   [Partition, Reason]),
                                     exit({bloom_fold, Reason})

--- a/src/riak_repl_keylist_server.erl
+++ b/src/riak_repl_keylist_server.erl
@@ -503,8 +503,11 @@ diff_bloom({Ref, diff_done}, #state{diff_ref=Ref, partition=Partition, bloom=Blo
                                     %% we don't care about the reply
                                     gen_fsm:send_event(Self,
                                                        {Ref, diff_exchanged});
-                                {'DOWN', MonRef, process, VNodePid, Reason}
-                                        when Reason /= normal ->
+                                {'DOWN', MonRef, process, VNodePid, normal} ->
+                                    lager:warning("VNode ~p exited before fold for partition ~p",
+                                        [VNodePid, Partition]),
+                                    exit({bloom_fold, vnode_exited_before_fold});
+                                {'DOWN', MonRef, process, VNodePid, Reason} ->
                                     lager:warning("Fold of ~p exited with ~p",
                                                   [Partition, Reason]),
                                     exit({bloom_fold, Reason})

--- a/src/riak_repl_keylist_server.erl
+++ b/src/riak_repl_keylist_server.erl
@@ -276,7 +276,11 @@ wait_keylist({kl_hunk, Hunk}, State) ->
     kl_hunk(Hunk, State);
 %% the client has finished sending the keylist
 wait_keylist(kl_eof, State) ->
-    kl_eof(State).
+    kl_eof(State);
+wait_keylist({skip_partition, Partition}, #state{partition=Partition} = State) ->
+    lager:warning("Full-sync with site ~p; skipping partition ~p as requested by client",
+        [State#state.sitename, Partition]),
+    {next_state, wait_for_partition, State}.
 
 wait_keylist(Command, _From, State) when Command == cancel_fullsync ->
     log_stop(Command, State),
@@ -294,11 +298,7 @@ wait_keylist({kl_hunk, Hunk}, _From, State) ->
     kl_hunk(Hunk, State);
 %% the client has finished sending the keylist
 wait_keylist(kl_eof, _From, State) ->
-    kl_eof(State);
-wait_keylist({skip_partition, Partition}, _From, #state{partition=Partition} = State) ->
-    lager:warning("Full-sync with site ~p; skipping partition ~p as requested by client",
-        [State#state.sitename, Partition]),
-    {next_state, wait_for_partition, State}.
+    kl_eof(State).
 
 %% ----------------------------------- non bloom-fold -----------------------
 %% diff_keylist states


### PR DESCRIPTION
Before this fix, neither source would handle a 'DOWN' message with a normal reason code, which would cause them to deadlock waiting for the vnode to respond if it was handed off to another node.
Tests in riak_repl (will update comments with PR).
