### PR TITLE
Improve CS replication on blocks

### DIFF
--- a/src/riak_repl_cs.erl
+++ b/src/riak_repl_cs.erl
@@ -128,7 +128,7 @@ dont_repl_storage_objects_test() ->
 
 dont_repl_tombstoned_object_test() ->
     reset_app_env(),
-    ok = application:set_env(riak_repl, replicate_block_tombstone, false),
+    ok = application:set_env(riak_repl, replicate_cs_block_tombstone, false),
     %% the riak client isn't even used
     Client = fake_client,
     Bucket = <<"anything">>,

--- a/src/riak_repl_cs.erl
+++ b/src/riak_repl_cs.erl
@@ -48,6 +48,13 @@ send_realtime(Object, _RiakClient) ->
 %%% Internal functions
 %%%===================================================================
 
+replicate_object(<<?BLOCK_BUCKET_PREFIX, _Rest/binary>>, IsTombstone, FSorRT) ->
+    case {IsTombstone, FSorRT} of
+        {false, fullsync} -> true;
+        {false, realtime} -> false;
+        {true, _} ->
+            app_helper:get_env(riak_repl, replicate_block_tombstone, true)
+    end;
 replicate_object(_, true, _) -> false;
 replicate_object(?STORAGE_BUCKET, _, _) -> false;
 replicate_object(?ACCESS_BUCKET, _, _) -> false;
@@ -55,8 +62,6 @@ replicate_object(?USER_BUCKET, _, _) ->
     app_helper:get_env(riak_repl, replicate_cs_user_objects, true);
 replicate_object(?BUCKETS_BUCKET, _, _) ->
     app_helper:get_env(riak_repl, replicate_cs_buckets_objects, true);
-replicate_object(<<?BLOCK_BUCKET_PREFIX, _Rest/binary>>, _, fullsync) -> true;
-replicate_object(<<?BLOCK_BUCKET_PREFIX, _Rest/binary>>, _, realtime) -> false;
 replicate_object(_, _, _) -> true.
 
 

--- a/src/riak_repl_cs.erl
+++ b/src/riak_repl_cs.erl
@@ -261,6 +261,32 @@ dont_repl_bucket_object_realtime_test() ->
     Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
     ?assertNot(ok_or_cancel_to_bool(send_realtime(Object, Client))).
 
+
+do_repl_gc_object_realtime_test() ->
+    Client = fake_client,
+    Bucket = <<"riak-cs-gc">>,
+    Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
+    ?assert(ok_or_cancel_to_bool(send_realtime(Object, Client))).
+
+do_repl_gc_object_fullsync_test() ->
+    Client = fake_client,
+    Bucket = <<"riak-cs-gc">>,
+    Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
+    ?assert(ok_or_cancel_to_bool(send(Object, Client))).
+
+do_repl_mb_weight_realtime_test() ->
+    Client = fake_client,
+    Bucket = <<"riak-cs-multibag">>,
+    Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
+    ?assert(ok_or_cancel_to_bool(send_realtime(Object, Client))).
+
+do_repl_mb_weight_fullsync_test() ->
+    Client = fake_client,
+    Bucket = <<"riak-cs-multibag">>,
+    Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
+    ?assert(ok_or_cancel_to_bool(send(Object, Client))).
+
+
 %% ===================================================================
 %% EUnit helpers
 %% ===================================================================

--- a/src/riak_repl_cs.erl
+++ b/src/riak_repl_cs.erl
@@ -50,8 +50,10 @@ send_realtime(Object, _RiakClient) ->
 
 replicate_object(<<?BLOCK_BUCKET_PREFIX, _Rest/binary>>, IsTombstone, FSorRT) ->
     case {IsTombstone, FSorRT} of
-        {false, fullsync} -> true;
-        {false, realtime} -> false;
+        {false, fullsync} ->
+            true;
+        {false, realtime} ->
+            app_helper:get_env(riak_repl, replicate_blocks, false);
         {true, _} ->
             app_helper:get_env(riak_repl, replicate_block_tombstone, true)
     end;

--- a/src/riak_repl_cs.erl
+++ b/src/riak_repl_cs.erl
@@ -99,55 +99,34 @@ reset_app_env() ->
     ok = application:unset_env(riak_repl, replicate_cs_bucket_objects),
     ok = application:unset_env(riak_repl, replicate_cs_user_objects).
 
-do_repl_blocks_fullsync_test() ->
+repl_blocks_test() ->
     reset_app_env(),
     %% the riak client isn't even used
     Client = fake_client,
     Bucket = <<"0b:foo">>,
     Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
-    ?assert(ok_or_cancel_to_bool(send(Object, Client))).
-
-dont_repl_blocks_realtime_test() ->
-    reset_app_env(),
-    %% the riak client isn't even used
-    Client = fake_client,
-    Bucket = <<"0b:foo">>,
-    Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
+    ?assert(ok_or_cancel_to_bool(send(Object, Client))),
     ?assertNot(ok_or_cancel_to_bool(send_realtime(Object, Client))).
 
-dont_repl_access_objects_fullsync_test() ->
+dont_repl_access_objects_test() ->
     reset_app_env(),
     %% the riak client isn't even used
     Client = fake_client,
     Bucket = <<"moss.access">>,
     Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
-    ?assertNot(ok_or_cancel_to_bool(send(Object, Client))).
-
-dont_repl_access_objects_realtime_test() ->
-    reset_app_env(),
-    %% the riak client isn't even used
-    Client = fake_client,
-    Bucket = <<"moss.access">>,
-    Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
+    ?assertNot(ok_or_cancel_to_bool(send(Object, Client))),
     ?assertNot(ok_or_cancel_to_bool(send_realtime(Object, Client))).
 
-dont_repl_storage_objects_fullsync_test() ->
+dont_repl_storage_objects_test() ->
     reset_app_env(),
     %% the riak client isn't even used
     Client = fake_client,
     Bucket = <<"moss.storage">>,
     Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
-    ?assertNot(ok_or_cancel_to_bool(send(Object, Client))).
-
-dont_repl_storage_objects_realtime_test() ->
-    reset_app_env(),
-    %% the riak client isn't even used
-    Client = fake_client,
-    Bucket = <<"moss.storage">>,
-    Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
+    ?assertNot(ok_or_cancel_to_bool(send(Object, Client))),
     ?assertNot(ok_or_cancel_to_bool(send_realtime(Object, Client))).
 
-dont_repl_tombstoned_object_fullsync_test() ->
+dont_repl_tombstoned_object_test() ->
     reset_app_env(),
     ok = application:set_env(riak_repl, replicate_block_tombstone, false),
     %% the riak client isn't even used
@@ -157,119 +136,50 @@ dont_repl_tombstoned_object_fullsync_test() ->
     M = dict:from_list([{<<"X-Riak-Deleted">>, true}]),
     Object2 = riak_object:update_metadata(Object, M),
     Object3 = riak_object:apply_updates(Object2),
-    ?assertNot(ok_or_cancel_to_bool(send(Object3, Client))).
+    ?assertNot(ok_or_cancel_to_bool(send(Object3, Client))),
+    ?assertNot(ok_or_cancel_to_bool(send_realtime(Object3, Client))).
 
-dont_repl_tombstoned_object_realtime_test() ->
+repl_user_object_test() ->
     reset_app_env(),
-    ok = application:set_env(riak_repl, replicate_block_tombstone, false),
     %% the riak client isn't even used
     Client = fake_client,
-    Bucket = <<"anything">>,
+    Bucket = <<"moss.users">>,
     Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
-    M = dict:from_list([{<<"X-Riak-Deleted">>, true}]),
-    Object2 = riak_object:update_metadata(Object, M),
-    Object3 = riak_object:apply_updates(Object2),
-    ?assertNot(ok_or_cancel_to_bool(send(Object3, Client))).
-
-do_repl_user_object_fullsync_test() ->
-    reset_app_env(),
     application:set_env(riak_repl, replicate_cs_user_objects, true),
-    %% the riak client isn't even used
-    Client = fake_client,
-    Bucket = <<"moss.users">>,
-    Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
-    ?assert(ok_or_cancel_to_bool(send(Object, Client))).
-
-dont_repl_user_object_fullsync_test() ->
-    reset_app_env(),
+    ?assert(ok_or_cancel_to_bool(send(Object, Client))),
+    ?assert(ok_or_cancel_to_bool(send_realtime(Object, Client))),
     application:set_env(riak_repl, replicate_cs_user_objects, false),
-    %% the riak client isn't even used
-    Client = fake_client,
-    Bucket = <<"moss.users">>,
-    Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
-    ?assertNot(ok_or_cancel_to_bool(send(Object, Client))).
-
-do_repl_user_object_realtime_test() ->
-    reset_app_env(),
-    application:set_env(riak_repl, replicate_cs_user_objects, true),
-    %% the riak client isn't even used
-    Client = fake_client,
-    Bucket = <<"moss.users">>,
-    Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
-    ?assert(ok_or_cancel_to_bool(send_realtime(Object, Client))).
-
-dont_repl_user_object_realtime_test() ->
-    reset_app_env(),
-    application:set_env(riak_repl, replicate_cs_user_objects, false),
-    %% the riak client isn't even used
-    Client = fake_client,
-    Bucket = <<"moss.users">>,
-    Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
+    ?assertNot(ok_or_cancel_to_bool(send(Object, Client))),
     ?assertNot(ok_or_cancel_to_bool(send_realtime(Object, Client))).
 
-do_repl_bucket_object_fullsync_test() ->
+repl_bucket_object_test() ->
     reset_app_env(),
+    %% the riak client isn't even used
+    Client = fake_client,
+    Bucket = <<"moss.buckets">>,
+    Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
     application:set_env(riak_repl, replicate_cs_bucket_objects, true),
-    %% the riak client isn't even used
-    Client = fake_client,
-    Bucket = <<"moss.buckets">>,
-    Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
-    ?assert(ok_or_cancel_to_bool(send(Object, Client))).
-
-dont_repl_bucket_object_fullsync_test() ->
-    reset_app_env(),
+    ?assert(ok_or_cancel_to_bool(send(Object, Client))),
+    ?assert(ok_or_cancel_to_bool(send_realtime(Object, Client))),
     application:set_env(riak_repl, replicate_cs_bucket_objects, false),
-    %% the riak client isn't even used
-    Client = fake_client,
-    Bucket = <<"moss.buckets">>,
-    Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
-    ?assertNot(ok_or_cancel_to_bool(send(Object, Client))).
-
-do_repl_bucket_object_realtime_test() ->
-    reset_app_env(),
-    application:set_env(riak_repl, replicate_cs_bucket_objects, true),
-    %% the riak client isn't even used
-    Client = fake_client,
-    Bucket = <<"moss.buckets">>,
-    Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
-    ?assert(ok_or_cancel_to_bool(send_realtime(Object, Client))).
-
-dont_repl_bucket_object_realtime_test() ->
-    reset_app_env(),
-    application:set_env(riak_repl, replicate_cs_bucket_objects, false),
-    %% the riak client isn't even used
-    Client = fake_client,
-    Bucket = <<"moss.buckets">>,
-    Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
+    ?assertNot(ok_or_cancel_to_bool(send(Object, Client))),
     ?assertNot(ok_or_cancel_to_bool(send_realtime(Object, Client))).
 
 
-do_repl_gc_object_realtime_test() ->
+do_repl_gc_object_test() ->
     reset_app_env(),
     Client = fake_client,
     Bucket = <<"riak-cs-gc">>,
     Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
-    ?assert(ok_or_cancel_to_bool(send_realtime(Object, Client))).
-
-do_repl_gc_object_fullsync_test() ->
-    reset_app_env(),
-    Client = fake_client,
-    Bucket = <<"riak-cs-gc">>,
-    Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
+    ?assert(ok_or_cancel_to_bool(send_realtime(Object, Client))),
     ?assert(ok_or_cancel_to_bool(send(Object, Client))).
 
-do_repl_mb_weight_realtime_test() ->
+do_repl_mb_weight_test() ->
     reset_app_env(),
     Client = fake_client,
     Bucket = <<"riak-cs-multibag">>,
     Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
-    ?assert(ok_or_cancel_to_bool(send_realtime(Object, Client))).
-
-do_repl_mb_weight_fullsync_test() ->
-    reset_app_env(),
-    Client = fake_client,
-    Bucket = <<"riak-cs-multibag">>,
-    Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
+    ?assert(ok_or_cancel_to_bool(send_realtime(Object, Client))),
     ?assert(ok_or_cancel_to_bool(send(Object, Client))).
 
 

--- a/test/riak_repl_cs_eqc.erl
+++ b/test/riak_repl_cs_eqc.erl
@@ -118,21 +118,26 @@ eqc_test_() ->
 fs_or_rt() -> oneof([fs, rt]).
 
 prop_main(DecisionTableVersion) ->
-    ok = application:unset_env(riak_repl, replicate_block_tombstone),
-    ok = application:unset_env(riak_repl, replicate_blocks),
-    DecisionTable = case DecisionTableVersion of
-                        v1 ->
-                            %% Default behaviour in Riak EE 1.4~2.1.1
-                            ok = application:set_env(riak_repl, replicate_block_tombstone, false),
-                            decision_table();
-                        v2 ->
-                            %% New behaviour since Riak EE 2.1.2?
-                            decision_table_v2();
-                        v2_blockrt ->
-                            %% Replicate blocks in realtime, off by default
-                            ok = application:set_env(riak_repl, replicate_blocks, true),
-                            decision_table_v2_blockrt()
-                    end,
+    ok = application:unset_env(riak_repl, replicate_cs_block_tombstone),
+    ok = application:unset_env(riak_repl, replicate_cs_blocks_realtime),
+    DecisionTable
+        = case DecisionTableVersion of
+              v1 ->
+                  %% Default behaviour in Riak EE 1.4~2.1.1
+                  ok = application:set_env(riak_repl,
+                                           replicate_cs_block_tombstone,
+                                           false),
+                  decision_table();
+              v2 ->
+                  %% New behaviour since Riak EE 2.1.2?
+                  decision_table_v2();
+              v2_blockrt ->
+                  %% Replicate blocks in realtime, off by default
+                  ok = application:set_env(riak_repl,
+                                           replicate_cs_blocks_realtime,
+                                           true),
+                  decision_table_v2_blockrt()
+          end,
     ?FORALL({Object, FSorRT}, {riak_object(), fs_or_rt()},
             begin
                 Impl =

--- a/test/riak_repl_cs_eqc.erl
+++ b/test/riak_repl_cs_eqc.erl
@@ -80,7 +80,8 @@ do_send(RTorFS, Object, DecisionTable) ->
         fs -> FS
     end.
 
-cs_bucket() ->
+%% Bucket names in Riak, used by CS
+raw_cs_bucket() ->
     oneof([<<"moss.buckets">>,
            <<"moss.users">>,
            <<"0b:deadbeef">>,
@@ -89,11 +90,14 @@ cs_bucket() ->
            <<"moss.access">>,
            <<"moss.storage">>,
            <<"riak-cs-multibag">>,
+           %% And this binary() is default fallback, although this is
+           %% not supposed to happen in CS use cases. But just in
+           %% case.
            binary()]).
 
 riak_object() ->
     ?LET({Bucket, Key, HasTombstone},
-         {cs_bucket(), non_empty(binary()), bool()},
+         {raw_cs_bucket(), non_empty(binary()), bool()},
          begin
              Object = riak_object:new(Bucket, Key, <<"val">>),
              case HasTombstone of

--- a/test/riak_repl_cs_eqc.erl
+++ b/test/riak_repl_cs_eqc.erl
@@ -117,7 +117,7 @@ prop_main(DecisionTableVersion) ->
                         rt -> riak_repl_cs:send_realtime(Object, fake_client)
                     end,
                 Verify = do_send(FSorRT, Object, DecisionTable),
-                ?debugVal({Verify, Impl, DecisionTableVersion}),
+                %% ?debugVal({Verify, Impl, DecisionTableVersion}),
                 Verify =:= Impl
             end).
 

--- a/test/riak_repl_cs_eqc.erl
+++ b/test/riak_repl_cs_eqc.erl
@@ -58,9 +58,9 @@ decision_table_v2_blockrt() ->
      {tss,       cancel, cancel}, %% Tombstones in short
      {other,     ok,     ok}].
 
-bucket_name_to_type(<<"0b:", _/binary>>, true) -> block_ts;
+bucket_name_to_type(<<"0b:", _/binary>>, true) -> block_ts; %% Block tombstones
 bucket_name_to_type(<<"0b:", _/binary>>, false) -> blocks;
-bucket_name_to_type(_, true) -> tss;
+bucket_name_to_type(_, true) -> tss; %% Tombstones
 bucket_name_to_type(<<"moss.buckets">>, _) -> buckets;
 bucket_name_to_type(<<"moss.users">>, _) -> users;
 bucket_name_to_type(<<"0o:", _/binary>>, _) -> manifests;

--- a/test/riak_repl_cs_eqc.erl
+++ b/test/riak_repl_cs_eqc.erl
@@ -93,17 +93,20 @@ riak_object() ->
          end).
 
 eqc_test_() ->
-    [ % run qc tests
-      {timeout, 60, ?_assertEqual(true, eqc:quickcheck(eqc:numtests(250, ?QC_OUT(prop_main(v1)))))}
-    ].
+    {inorder,
+     [ % run qc tests
+       ?_assertEqual(true, eqc:quickcheck(eqc:numtests(250, ?QC_OUT(prop_main(v1))))),
+       ?_assertEqual(true, eqc:quickcheck(eqc:numtests(250, ?QC_OUT(prop_main(v2)))))
+     ]}.
 
 fs_or_rt() -> oneof([fs, rt]).
 
 prop_main(DecisionTableVersion) ->
+    ok = application:unset_env(riak_repl, replicate_block_tombstone),
     DecisionTable = case DecisionTableVersion of
                         v1 ->
                             %% Default behaviour in Riak EE 1.4~2.1.1
-                            ok = application:set_env(riak_repl, replicate_block_tomstone, false),
+                            ok = application:set_env(riak_repl, replicate_block_tombstone, false),
                             decision_table();
                         v2 ->
                             %% New behaviour since Riak EE 2.1.2?

--- a/test/riak_repl_cs_eqc.erl
+++ b/test/riak_repl_cs_eqc.erl
@@ -1,0 +1,124 @@
+%%
+%% EQC test for CS replication, with just another impl
+%%
+
+-module(riak_repl_cs_eqc).
+-compile(export_all).
+
+-ifdef(EQC).
+-include_lib("eqc/include/eqc.hrl").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-define(QC_OUT(P),
+        eqc:on_output(fun(Str, Args) -> io:format(user, Str, Args) end, P)).
+
+
+decision_table() ->
+    %% type, rt, fs
+    [{buckets,   ok,     ok}, %% Configurable, but default
+     {users,     ok,     ok}, %% Configurable, but default
+     {blocks,    cancel, ok},
+     {block_ts,  cancel, cancel},
+     {manifests, ok,     ok},
+     {gc,        ok,     ok}, %% riak-cs-gc
+     {access,    cancel, cancel},
+     {storage,   cancel, cancel},
+     {mb,        ok,     ok}, %% Multibag
+     {tss,       cancel, cancel}, %% Tombstones in short
+     {other,     ok,     ok}].
+
+decision_table_v2() ->
+    %% type, rt, fs
+    [{buckets,   ok,     ok}, %% Configurable, but default
+     {users,     ok,     ok}, %% Configurable, but default
+     {blocks,    cancel, ok},
+     {block_ts,  ok,     ok},
+     {manifests, ok,     ok},
+     {gc,        ok,     ok}, %% riak-cs-gc
+     {access,    cancel, cancel},
+     {storage,   cancel, cancel},
+     {mb,        ok,     ok}, %% Multibag
+     {tss,       cancel, cancel}, %% Tombstones in short
+     {other,     ok,     ok}].
+
+bucket_name_to_type(<<"0b:", _/binary>>, true) -> block_ts;
+bucket_name_to_type(<<"0b:", _/binary>>, false) -> blocks;
+bucket_name_to_type(_, true) -> tss;
+bucket_name_to_type(<<"moss.buckets">>, _) -> buckets;
+bucket_name_to_type(<<"moss.users">>, _) -> users;
+bucket_name_to_type(<<"0o:", _/binary>>, _) -> manifests;
+bucket_name_to_type(<<"riak-cs-gc">>, _) -> gc;
+bucket_name_to_type(<<"moss.access">>, _) -> access;
+bucket_name_to_type(<<"moss.storage">>, _) -> storage;
+bucket_name_to_type(<<"riak-cs-multibag">>, _) -> mb;
+bucket_name_to_type(Bin, _) when is_binary(Bin) -> other.
+
+
+do_send(RTorFS, Object, DecisionTable) ->
+    Type = bucket_name_to_type(riak_object:bucket(Object),
+                               riak_kv_util:is_x_deleted(Object)),
+    {Type, RT, FS} = lists:keyfind(Type, 1, DecisionTable),
+    case RTorFS of
+        rt -> RT;
+        fs -> FS
+    end.
+
+cs_bucket() ->
+    oneof([<<"moss.buckets">>,
+           <<"moss.users">>,
+           <<"0b:deadbeef">>,
+           <<"0o:deadbeef">>,
+           <<"riak-cs-gc">>,
+           <<"moss.access">>,
+           <<"moss.storage">>,
+           <<"riak-cs-multibag">>,
+           binary()]).
+
+riak_object() ->
+    ?LET({Bucket, Key, HasTombstone},
+         {cs_bucket(), non_empty(binary()), bool()},
+         begin
+             Object = riak_object:new(Bucket, Key, <<"val">>),
+             case HasTombstone of
+                 true ->
+                     M = dict:from_list([{<<"X-Riak-Deleted">>, true}]),
+                     Object2 = riak_object:update_metadata(Object, M),
+                     riak_object:apply_updates(Object2);
+                 false ->
+                     Object
+             end
+         end).
+
+eqc_test_() ->
+    [ % run qc tests
+      {timeout, 60, ?_assertEqual(true, eqc:quickcheck(eqc:numtests(250, ?QC_OUT(prop_main(v1)))))}
+    ].
+
+fs_or_rt() -> oneof([fs, rt]).
+
+prop_main(DecisionTableVersion) ->
+    DecisionTable = case DecisionTableVersion of
+                        v1 ->
+                            %% Default behaviour in Riak EE 1.4~2.1.1
+                            ok = application:set_env(riak_repl, replicate_block_tomstone, false),
+                            decision_table();
+                        v2 ->
+                            %% New behaviour since Riak EE 2.1.2?
+                            decision_table_v2()
+                    end,
+    ?FORALL({Object, FSorRT}, {riak_object(), fs_or_rt()},
+            begin
+                Impl =
+                    case FSorRT of
+                        fs -> riak_repl_cs:send(Object, fake_client);
+                        rt -> riak_repl_cs:send_realtime(Object, fake_client)
+                    end,
+                Verify = do_send(FSorRT, Object, DecisionTable),
+                ?debugVal({Verify, Impl, DecisionTableVersion}),
+                Verify =:= Impl
+            end).
+
+-endif.

--- a/test/riak_repl_cs_eqc.erl
+++ b/test/riak_repl_cs_eqc.erl
@@ -119,6 +119,7 @@ fs_or_rt() -> oneof([fs, rt]).
 
 prop_main(DecisionTableVersion) ->
     ok = application:unset_env(riak_repl, replicate_block_tombstone),
+    ok = application:unset_env(riak_repl, replicate_blocks),
     DecisionTable = case DecisionTableVersion of
                         v1 ->
                             %% Default behaviour in Riak EE 1.4~2.1.1


### PR DESCRIPTION
This pull request includes:
- Add eqc tests on skip/send logic combination, which used to be confusing, and to avoid regression
- Refactor existing `send/2` and `send_realtime/2` logic
- Add config knob to switch block tombstone replication (both fs and rt, on by default)
- Add config knob to switch block replication (only rt, off by default)

This does not change replication semantics for CS, but add tombstone of blocks are replicated by default to improve disk space reclaim performance, and deletion performance.

This addressed #654.
