### PR TITLE
Enhanced coverage of riak_core_cluster_conn.

### DIFF
--- a/test/riak_core_cluster_conn_eqc.erl
+++ b/test/riak_core_cluster_conn_eqc.erl
@@ -26,6 +26,7 @@
 -include_lib("eqc/include/eqc.hrl").
 -include_lib("eqc/include/eqc_fsm.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("kernel/include/inet.hrl").
 
 %% eqc properties
 -export([prop_cluster_conn_state_transition/0]).
@@ -34,7 +35,8 @@
 -export([connecting/1,
          waiting_for_cluster_name/1,
          waiting_for_cluster_members/1,
-         connected/1]).
+         connected/1,
+         stopped/1]).
 
 %% eqc_fsm callbacks
 -export([initial_state/0,
@@ -55,11 +57,25 @@
 
 -define(TEST_ITERATIONS, 500).
 -define(TEST_MODULE, riak_core_cluster_conn).
+-define(CLUSTER_NAME, "FARFARAWAY").
+-define(ERROR_MSG, "FBADBEEF").
 
--define(P(EXPR), PPP = (EXPR), case PPP of true -> ok; _ -> io:format(user, "PPP ~p at line ~p\n", [PPP, ?LINE]) end, PPP).
+-define(EQ(Lhs, Rhs), PPP = Lhs =:= Rhs, case PPP of true -> ok; _ -> io:format(user, "EQ ~p =/= ~p at line ~p\n", [Lhs, Rhs, ?LINE]) end, PPP).
+-define(NEQ(Lhs, Rhs), PPP = Lhs =/= Rhs, case PPP of true -> ok; _ -> io:format(user, "NEQ ~p =:= ~p at line ~p\n", [Lhs, Rhs, ?LINE]) end, PPP).
 
--record(ccst_state, {current_state :: atom(),
-                     previous_state :: atom()}).
+-type cluster_member_1_0_type() :: {inet:ip_address(), inet:port_number()}.
+-type cluster_member_1_1_type() :: {node(), {cluster_member_1_0_type()}}.
+-type cluster_member_type() :: cluster_member_1_0_type() | cluster_member_1_1_type().
+
+-record(ccst_state, {fsm_pid :: pid(),
+                     fsm_protocol_version :: { pos_integer(), pos_integer()},
+                     cluster_members = [] :: cluster_member_type()}).
+
+%% Generators
+-define(protocol_versions, [{1, 0}, {1, 1}, {0, 1}, {2, 0}]). % 1.0 and 1.1 are known at this time
+
+protocol_version() ->
+    elements(?protocol_versions).
 
 %%====================================================================
 %% Eunit tests
@@ -92,13 +108,12 @@ cleanup(Apps) ->
 %% effects that may occur in any particular state and those are
 %% avoided by starting the fsm in `test' mode.
 prop_cluster_conn_state_transition() ->
-    ?FORALL(Cmds,
-            commands(?MODULE),
+    ?FORALL(Cmds, commands(?MODULE),
+            ?FORALL(ProtocolVersion, protocol_version(),
             begin
-                {ok, Pid} = ?TEST_MODULE:start_link("FARFARAWAY", test),
                 {H, {_F, _S}, Res} =
-                    run_commands(?MODULE, Cmds, [{fsm_pid, Pid}]),
-                aggregate(zip(state_names(H), command_names(Cmds)),
+                    run_commands(?MODULE, Cmds, [{protocol_version, ProtocolVersion}]),
+                          aggregate(zip(state_names(H), command_names(Cmds)),
                           ?WHENFAIL(
                              begin
                                  ?debugFmt("\nCmds: ~p~n",
@@ -108,93 +123,115 @@ prop_cluster_conn_state_transition() ->
                                  ?debugFmt("\nHistory: ~p~n", [H])
                              end,
                              equals(ok, Res)))
-            end).
+            end)).
 
 %%====================================================================
 %% eqc_fsm callbacks
 %%====================================================================
 
-initiating_connection(_S) ->
+initiating_connection(#ccst_state{fsm_pid = FsmPid}) ->
     [
-     {history, {call, ?MODULE, poll_cluster, [{var, fsm_pid}]}},
-     {history, {call, ?MODULE, garbage_event, [{var, fsm_pid}]}},
-     {history, {call, ?TEST_MODULE, status, [{var, fsm_pid}]}},
-     {connecting, {call, ?MODULE, send_timeout, [{var, fsm_pid}]}}
+     {history, {call, ?MODULE, poll_cluster, [FsmPid]}},
+     {history, {call, ?MODULE, garbage_event, [FsmPid]}},
+     {history, {call, ?TEST_MODULE, status, [FsmPid]}},
+     {connecting, {call, ?MODULE, send_timeout, [FsmPid]}}
     ].
 
-connecting(_S) ->
+connecting(#ccst_state{fsm_pid = FsmPid, fsm_protocol_version = ProtocolVersion}) ->
     [
-     {history, {call, ?MODULE, poll_cluster, [{var, fsm_pid}]}},
-     {history, {call, ?MODULE, garbage_event, [{var, fsm_pid}]}},
-     {history, {call, ?TEST_MODULE, status, [{var, fsm_pid}]}},
-     {waiting_for_cluster_name, {call, ?MODULE, connected_to_remote, [{var, fsm_pid}]}}
+     {history, {call, ?MODULE, poll_cluster, [FsmPid]}},
+     {history, {call, ?MODULE, garbage_event, [FsmPid]}},
+     {history, {call, ?TEST_MODULE, status, [FsmPid]}},
+     {waiting_for_cluster_name, {call, ?MODULE, connected_to_remote, [FsmPid, ProtocolVersion]}},
+     {stopped, {call, ?MODULE, send_timeout, [FsmPid]}},
+     {stopped, {call, ?MODULE, send_connection_failed, [FsmPid, ?ERROR_MSG]}}
     ].
 
-waiting_for_cluster_name(_S) ->
+waiting_for_cluster_name(#ccst_state{fsm_pid = FsmPid}) ->
     [
-     {history, {call, ?MODULE, poll_cluster, [{var, fsm_pid}]}},
-     {history, {call, ?MODULE, garbage_event, [{var, fsm_pid}]}},
-     {history, {call, ?TEST_MODULE, status, [{var, fsm_pid}]}},
-     {waiting_for_cluster_members, {call, ?MODULE, cluster_name, [{var, fsm_pid}]}}
+     {history, {call, ?MODULE, poll_cluster, [FsmPid]}},
+     {history, {call, ?MODULE, garbage_event, [FsmPid]}},
+     {history, {call, ?TEST_MODULE, status, [FsmPid]}},
+     {waiting_for_cluster_members, {call, ?MODULE, cluster_name, [FsmPid]}}
     ].
 
-waiting_for_cluster_members(_S) ->
+waiting_for_cluster_members(#ccst_state{fsm_pid = FsmPid,
+                                        fsm_protocol_version = ProtocolVersion,
+                                        cluster_members = ExistingMembers}) ->
     [
-     {history, {call, ?MODULE, poll_cluster, [{var, fsm_pid}]}},
-     {history, {call, ?MODULE, garbage_event, [{var, fsm_pid}]}},
-     {history, {call, ?TEST_MODULE, status, [{var, fsm_pid}]}},
-     {connected, {call, ?MODULE, cluster_members, [{var, fsm_pid}]}}
+     {history, {call, ?MODULE, poll_cluster, [FsmPid]}},
+     {history, {call, ?MODULE, garbage_event, [FsmPid]}},
+     {history, {call, ?TEST_MODULE, status, [FsmPid]}},
+     {connected, {call, ?MODULE, send_update_cluster_members, [FsmPid, 5, ProtocolVersion, ExistingMembers]}},
+     {connected, {call, ?MODULE, send_cluster_members, [FsmPid, 3, ProtocolVersion, ExistingMembers]}}
     ].
 
-connected(_S) ->
+connected(#ccst_state{fsm_pid = FsmPid, fsm_protocol_version = _ProtocolVersion}) ->
     [
-     {history, {call, ?MODULE, garbage_event, [{var, fsm_pid}]}},
-     {history, {call, ?TEST_MODULE, status, [{var, fsm_pid}]}},
-     {waiting_for_cluster_name, {call, ?MODULE, poll_cluster, [{var, fsm_pid}]}},
-     {stopped, {call, ?TEST_MODULE, stop, [{var, fsm_pid}]}}
+     {history, {call, ?MODULE, garbage_event, [FsmPid]}},
+     {history, {call, ?TEST_MODULE, status, [FsmPid]}},
+     {waiting_for_cluster_name, {call, ?MODULE, poll_cluster, [FsmPid]}},
+     {stopped, {call, ?TEST_MODULE, stop, [FsmPid]}}
     ].
 
 stopped(_S) ->
-    [].
+    [
+      %% as though _sup is present, restart
+      {initiating_connection, { call, ?MODULE, start_link, [{var, protocol_version}] }}
+    ].
 
 initial_state() ->
-    initiating_connection.
+    stopped.
 
 initial_state_data() ->
     #ccst_state{}.
 
+next_state_data(stopped, initiating_connection, S, R, { call, ?MODULE, start_link, [ProtocolVersion] }) ->
+    S#ccst_state{fsm_pid=R, fsm_protocol_version = ProtocolVersion};
+next_state_data(waiting_for_cluster_members, connected, S, R, {call, ?MODULE, send_cluster_members, [_Pid, _Count, _ProtocolVersion]}) ->
+    S#ccst_state{cluster_members=R};
+next_state_data(_, stopped, S, _R, _C) ->
+    S#ccst_state{fsm_pid=undefined};
 next_state_data(_From, _To, S, _R, _C) ->
     S.
 
+precondition(connecting, stopped, #ccst_state{fsm_pid = FsmPid}, _C) ->
+    FsmPid /= undefined;
 precondition(_From, _To, _S, _C) ->
     true.
 
 postcondition(initiating_connection, connecting, _S, {call, ?MODULE, send_timeout, [Pid]}, _R) ->
-    ?P(?MODULE:current_fsm_state(Pid) =:= connecting);
+    ?EQ(?MODULE:current_fsm_state(Pid), connecting);
 postcondition(connected, connected, _S ,{call, ?MODULE, status, _}, R) ->
     ExpectedStatus = {fake_socket,
                       ranch_tcp,
                       "overtherainbow",
-                      [{clustername, "FARFARAWAY"}],
+                      [{clustername, ?CLUSTER_NAME}],
                       {1,0}},
     {_, status, Status} = R,
-    ?P(Status =:= ExpectedStatus);
+    ?EQ(Status, ExpectedStatus);
 postcondition(State, State, _S ,{call, ?MODULE, status, [Pid]}, R) ->
-    ?P(R =:= State andalso ?MODULE:current_fsm_state(Pid) =:= State);
+    A0 = ?EQ(R, State),
+    A1 = ?EQ(?MODULE:current_fsm_state(Pid), State),
+    A0 andalso A1;
 postcondition(State, State, _S ,{call, ?MODULE, garbage_event, [Pid]}, _R) ->
-    ?P(?MODULE:current_fsm_state(Pid) =:= State);
+    ?EQ(?MODULE:current_fsm_state(Pid), State);
 postcondition(connected, waiting_for_cluster_name, _S, {call, ?MODULE, poll_cluster, [Pid]}, _R) ->
-    ?P(?MODULE:current_fsm_state(Pid) =:= waiting_for_cluster_name);
+    ?EQ(?MODULE:current_fsm_state(Pid), waiting_for_cluster_name);
 postcondition(State, State, _S, {call, ?MODULE, poll_cluster, [Pid]}, _R) ->
-    ?P(?MODULE:current_fsm_state(Pid) =:= State);
-postcondition(connecting, waiting_for_cluster_name, _S, {call, ?MODULE, connected_to_remote, [Pid]}, _R) ->
-    ?P(?MODULE:current_fsm_state(Pid) =:= waiting_for_cluster_name);
+    ?EQ(?MODULE:current_fsm_state(Pid), State);
+postcondition(connecting, waiting_for_cluster_name, _S, {call, ?MODULE, connected_to_remote, [Pid, _ProtoVersion]}, _R) ->
+    ?EQ(?MODULE:current_fsm_state(Pid), waiting_for_cluster_name);
 postcondition(waiting_for_cluster_name, waiting_for_cluster_members, _S, {call, ?MODULE, cluster_name, [Pid]}, _R) ->
-    ?P(?MODULE:current_fsm_state(Pid) =:= waiting_for_cluster_members);
-postcondition(waiting_for_cluster_members, connected, _S, {call, ?MODULE, cluster_members, [Pid]}, _R) ->
-    ?P(?MODULE:current_fsm_state(Pid) =:= connected);
+    ?EQ(?MODULE:current_fsm_state(Pid), waiting_for_cluster_members);
+postcondition(waiting_for_cluster_members, connected, _S, {call, ?MODULE, send_cluster_members, [Pid, _Count, _ProtocolVersion, ExistingMembers]}, R) ->
+    ?EQ(?MODULE:current_fsm_state(Pid), connected),
+    assert_existing_members_present(ExistingMembers, R),
+    assert_existing_members_present(R, ?MODULE:current_fsm_members(Pid));
 postcondition(connected, stopped, _S ,{call, ?TEST_MODULE, stop, [Pid]}, _R) ->
-    ?P(is_process_alive(Pid) =:= false);
+    ?EQ(is_process_alive(Pid), false);
+postcondition(connected, stopped, _S ,{call, ?MODULE, send_timeout, [Pid]}, _R) ->
+    ?EQ(is_process_alive(Pid), false);
 %% Catch all
 postcondition(_From, _To, _S , _C, _R) ->
     true.
@@ -209,12 +246,24 @@ test() ->
 test(Iterations) ->
     eqc:quickcheck(eqc:numtests(Iterations, prop_cluster_conn_state_transition())).
 
+start_link(_ProtocolVersion) ->
+    process_flag(trap_exit, true),
+    {ok, Pid} = ?TEST_MODULE:start_link(?CLUSTER_NAME, test),
+    Pid.
+
 current_fsm_state(Pid) ->
     {CurrentState, _} = ?TEST_MODULE:current_state(Pid),
     CurrentState.
 
+current_fsm_members(Pid) ->
+    {current_members, Members} = ?TEST_MODULE:current_members(Pid),
+    Members.
+
 send_timeout(Pid) ->
     gen_fsm:send_event(Pid, timeout).
+
+send_connection_failed(Pid, Error) ->
+    gen_fsm:send_event(Pid, {connect_failed, Error}).
 
 poll_cluster(Pid) ->
     gen_fsm:send_event(Pid, poll_cluster).
@@ -222,24 +271,78 @@ poll_cluster(Pid) ->
 garbage_event(Pid) ->
     gen_fsm:send_event(Pid, slartibartfast).
 
-connected_to_remote(Pid) ->
+connected_to_remote(Pid, ProtoVersion) ->
     Event = {connected_to_remote,
              fake_socket,
              ranch_tcp,
              "overtherainbow",
-             [{clustername, "FARFARAWAY"}],
-             {1,0}},
+             [{clustername, ?CLUSTER_NAME}],
+             ProtoVersion},
     gen_fsm:send_event(Pid, Event).
 
 cluster_name(Pid) ->
-    Event = {cluster_name, "FARFARAWAY"},
+    Event = {cluster_name, ?CLUSTER_NAME},
     gen_fsm:send_event(Pid, Event).
 
-cluster_members(Pid) ->
-    Event = {cluster_members,
-             [{"fake-address-1", 1},
-              {"fake-address-2", 2}
-             ]},
-    gen_fsm:send_event(Pid, Event).
+map_cluster_member_to_v10({_Node, {_IP, _Port}} = Member) ->
+    element(2, Member);
+map_cluster_member_to_v10(Member) ->
+    Member.
+
+map_cluster_members_to_v10([{_Node, {_IP, _Port}}|_T] = Members) ->
+    [map_cluster_member_to_v10(El) || El <- Members];
+map_cluster_members_to_v10([{_IP, _Port}|_T] = Members) ->
+    Members;
+map_cluster_members_to_v10(_) ->
+    [].
+
+create_cluster_members(Count, {1, 0}) ->
+    map_cluster_members_to_v10(create_cluster_members(Count, {1, 1}));
+create_cluster_members(Count, _ProtoVersion) ->
+    [{
+         list_to_binary(["fake-node-", integer_to_list(I)]),
+         { list_to_binary(["fake-address-", integer_to_list(I)]),
+           I }
+     } || I <- lists:seq(1, Count)].
+
+event_atom({1, 0} = _ProtoVersion) ->
+    cluster_members;
+event_atom(_) ->
+    all_cluster_members.
+
+send_cluster_members(Pid, Count, ProtoVersion, ExistingMembers) ->
+    send_cluster_members(Pid, Count, ProtoVersion, event_atom(ProtoVersion), ExistingMembers).
+
+send_cluster_members(Pid, Count, ProtoVersion, EventAtom, ExistingMembers) ->
+    Members = create_cluster_members(Count, ProtoVersion),
+    Event = {EventAtom, Members},
+    gen_fsm:send_event(Pid, Event),
+    SortedNew = ordsets:from_list(Members),
+    lists:filter(fun(Mem) ->
+                     not ordsets:is_element(Mem, SortedNew)
+                 end,
+                 ExistingMembers) ++ lists:reverse(Members).
+
+send_update_cluster_members(Pid, Count, {1, 0} = ProtoVersion, _ExistingMembers) ->
+    Members = create_cluster_members(Count, ProtoVersion),
+    gen_fsm:send_event(Pid, {event_atom(ProtoVersion), Members}),
+    Members;
+send_update_cluster_members(Pid, Count, ProtoVersion, ExistingMembers) ->
+    Members0 = create_cluster_members(Count, ProtoVersion),
+    Members = lists:map(fun({Node, {_IP, _Port}} = M) ->
+                            case lists:keyfind(Node, 1, ExistingMembers) of
+                                {_Node, {IP, _Port}} ->
+                                    {Node, {IP, undefined}};
+                                _ ->
+                                    M
+                            end
+                        end, Members0),
+    GarbageMember = {"garbage-node", { "garbage-ip", undefined }},
+    gen_fsm:send_event(Pid, {event_atom(ProtoVersion), [GarbageMember|Members]}),
+    Members.
+
+assert_existing_members_present(ExistingMembers, NewMembers) ->
+    NotCarriedMembers = ExistingMembers -- NewMembers,
+    ?EQ([], NotCarriedMembers).
 
 -endif.


### PR DESCRIPTION
This was undertaken due to lack of postcondition checking of cluster members. No defect was found :+1: , but coverage is increased.
- utilize test model state for wider test vector through generators.
- added testing variable for protocol versions.
- changed P macro to provide clearer output on assertion fails.
- added tracking of cluster members in test state for comparison to SuT state.
- ensured un-happy path coverage by sending connection fail and starting in a stop state.
- changed cluster members mock data to hit coverage areas of the SuT.
