### PR TITLE
Ensure that we hash write_once bucket.

### DIFF
--- a/src/riak_repl_bucket_type_util.erl
+++ b/src/riak_repl_bucket_type_util.erl
@@ -14,7 +14,12 @@
 
 -define(DEFAULT_BUCKET_TYPE, <<"default">>).
 
--define(DEFAULT_HASH_BUCKET_PROPS, [consistent, datatype, n_val, allow_mult, last_write_wins]).
+-define(DEFAULT_HASH_BUCKET_PROPS, [consistent,
+                                    datatype,
+                                    n_val,
+                                    allow_mult,
+                                    last_write_wins,
+                                    write_once]).
 
 -spec bucket_props_match(proplists:proplist()) -> boolean().
 bucket_props_match(Props) ->


### PR DESCRIPTION
Ensure that when computing a hash for repl on the bucket type
properties, that we also consider write_once buckets as well.
