### PR TITLE
Update bucket properties hash for write_once.

### DIFF
--- a/src/riak_repl_bucket_type_util.erl
+++ b/src/riak_repl_bucket_type_util.erl
@@ -14,7 +14,7 @@
 
 -define(DEFAULT_BUCKET_TYPE, <<"default">>).
 
--define(DEFAULT_HASH_BUCKET_PROPS, [consistent, datatype, n_val, allow_mult, last_write_wins]).
+-define(DEFAULT_HASH_BUCKET_PROPS, [consistent, datatype, n_val, write_once]).
 
 -spec bucket_props_match(proplists:proplist()) -> boolean().
 bucket_props_match(Props) ->


### PR DESCRIPTION
Update the bucket properties hash to take the write_once bucket property
into consideration; additionally, remove the allow_mult and
last_write_wins restrictions.
