### PR TITLE
Add bucket type support for AAE fullsync.

### DIFF
--- a/src/riak_repl2_fssink_pool.erl
+++ b/src/riak_repl2_fssink_pool.erl
@@ -2,7 +2,7 @@
 %% fullsyncs are running.
 
 -module(riak_repl2_fssink_pool).
--export([start_link/0, status/0, bin_put/1]).
+-export([start_link/0, status/0, put/1, bin_put/1]).
 
 start_link() ->
     MinPool = app_helper:get_env(riak_repl, fssink_min_workers, 5),
@@ -20,6 +20,12 @@ status() ->
      {worker_queue_len, WorkerQueueLen},
      {overflow, Overflow},
      {num_monitors, NumMonitors}].
+
+%% @doc Send an object or BT hash / object pair to the worker pool to
+%% run a put against. No guarantees of completion.
+put(Obj) ->
+    Pid = poolboy:checkout(?MODULE, true, infinity),
+    riak_repl_fullsync_worker:do_put(Pid, Obj, ?MODULE).
 
 %% @doc Send a replication wire-encoded binary to the worker pool
 %% for running a put against.  No guarantees of completion.

--- a/src/riak_repl_aae_sink.erl
+++ b/src/riak_repl_aae_sink.erl
@@ -83,7 +83,7 @@ handle_info({Proto, _Socket, Data}, State=#state{transport=Transport,
         [MsgType|<<>>] ->
             process_msg(MsgType, State);
         [MsgType|MsgData] ->
-            process_msg(MsgType, binary_to_term(MsgData), State)
+            process_msg(MsgType, riak_repl_util:decode_obj_msg(MsgData), State)
     end;
 
 handle_info({'DOWN', _, _, _, _}, State) ->
@@ -143,10 +143,10 @@ process_msg(?MSG_GET_AAE_SEGMENT, {SegmentNum,IndexN}, State=#state{tree_pid=Tre
     send_reply(ResponseMsg, State);
 
 %% no reply
-process_msg(?MSG_PUT_OBJ, {fs_diff_obj, BObj}, State) ->
+process_msg(?MSG_PUT_OBJ, {fs_diff_obj, Obj}, State) ->
     %% may block on worker pool, ok return means work was submitted
     %% to pool, not that put FSM completed successfully.
-    ok = riak_repl2_fssink_pool:bin_put(BObj),
+    ok = riak_repl2_fssink_pool:put(Obj),
     {noreply, State};
 
 %% replies: ok | not_responsible


### PR DESCRIPTION
Add bucket type support for AAE fullsync; ensure that the message is
properly decoded into the two tuple, and use this to ensure that the
bucket properties hash matches.

This reverts commit 078f16315c494ea06bd1c1b5f79aece43b09ff74.
