### PR TITLE
Add bucket type support for AAE fullsync.

### DIFF
--- a/src/riak_repl2_fssink_pool.erl
+++ b/src/riak_repl2_fssink_pool.erl
@@ -2,7 +2,7 @@
 %% fullsyncs are running.
 
 -module(riak_repl2_fssink_pool).
--export([start_link/0, status/0, bin_put/1]).
+-export([start_link/0, status/0, put/1, bin_put/1]).
 
 start_link() ->
     MinPool = app_helper:get_env(riak_repl, fssink_min_workers, 5),
@@ -20,6 +20,12 @@ status() ->
      {worker_queue_len, WorkerQueueLen},
      {overflow, Overflow},
      {num_monitors, NumMonitors}].
+
+%% @doc Send an object or BT hash / object pair to the worker pool to
+%% run a put against. No guarantees of completion.
+put(Obj) ->
+    Pid = poolboy:checkout(?MODULE, true, infinity),
+    riak_repl_fullsync_worker:do_put(Pid, Obj, ?MODULE).
 
 %% @doc Send a replication wire-encoded binary to the worker pool
 %% for running a put against.  No guarantees of completion.

--- a/src/riak_repl_aae_sink.erl
+++ b/src/riak_repl_aae_sink.erl
@@ -83,7 +83,7 @@ handle_info({Proto, _Socket, Data}, State=#state{transport=Transport,
         [MsgType|<<>>] ->
             process_msg(MsgType, State);
         [MsgType|MsgData] ->
-            process_msg(MsgType, binary_to_term(MsgData), State)
+            process_msg(MsgType, riak_repl_util:decode_obj_msg(MsgData), State)
     end;
 
 handle_info({'DOWN', _, _, _, _}, State) ->
@@ -143,10 +143,10 @@ process_msg(?MSG_GET_AAE_SEGMENT, {SegmentNum,IndexN}, State=#state{tree_pid=Tre
     send_reply(ResponseMsg, State);
 
 %% no reply
-process_msg(?MSG_PUT_OBJ, {fs_diff_obj, BObj}, State) ->
+process_msg(?MSG_PUT_OBJ, {fs_diff_obj, Obj}, State) ->
     %% may block on worker pool, ok return means work was submitted
     %% to pool, not that put FSM completed successfully.
-    ok = riak_repl2_fssink_pool:bin_put(BObj),
+    ok = riak_repl2_fssink_pool:put(Obj),
     {noreply, State};
 
 %% replies: ok | not_responsible

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -56,6 +56,7 @@
          sockname/2,
          deduce_wire_version_from_proto/1,
          encode_obj_msg/2,
+         decode_obj_msg/1,
          make_pg_proxy_name/1,
          make_pg_name/1,
          mode_12_enabled/1,
@@ -875,13 +876,7 @@ encode_obj_msg(V, {Cmd, RObj}) ->
     encode_obj_msg(V, {Cmd, RObj}, riak_object:type(RObj)).
 
 encode_obj_msg(V, {Cmd, RObj}, undefined) ->
-    case V of
-        w0 ->
-            term_to_binary({Cmd, RObj});
-        _W ->
-            BObj = riak_repl_util:to_wire(w1,RObj),
-            term_to_binary({Cmd, BObj})
-    end;
+    term_to_binary({Cmd, encode_obj(V, RObj)});
 encode_obj_msg(V, {Cmd, RObj}, T) ->
     BTHash = case riak_repl_bucket_type_util:property_hash(T) of
                  undefined ->
@@ -889,13 +884,27 @@ encode_obj_msg(V, {Cmd, RObj}, T) ->
                  Hash ->
                      Hash
              end,
-    case V of
-        w0 ->
-            term_to_binary({Cmd, {BTHash, RObj}});
+    term_to_binary({Cmd, {BTHash, encode_obj(V, RObj)}}).
 
-        _W ->
-            BObj = riak_repl_util:to_wire(w1,RObj),
-            term_to_binary({Cmd, {BTHash, BObj}})
+%% A wrapper around to_wire which leaves the object unencoded when using the w0 wire protocol.
+encode_obj(w0, RObj) ->
+    RObj;
+encode_obj(W, RObj) ->
+    to_wire(W, RObj).
+
+decode_obj_msg(Data) ->
+    Msg = binary_to_term(Data),
+    case Msg of
+        {fs_diff_obj, BObj} when is_binary(BObj) ->
+            RObj = from_wire(BObj),
+            {fs_diff_obj, RObj};
+        {fs_diff_obj, {BTHash, BObj}} when is_binary(BObj) ->
+            RObj = from_wire(BObj),
+            {fs_diff_obj, {BTHash, RObj}};
+        {fs_diff_obj, _} ->
+            Msg;
+        Other ->
+            Other
     end.
 
 %% @doc Create binary wire formatted replication blob for riak 2.0+, complete with


### PR DESCRIPTION
Add bucket type support for AAE fullsync; ensure that the message is
properly decoded into the two tuple, and use this to ensure that the
bucket properties hash matches.

This reverts commit 078f16315c494ea06bd1c1b5f79aece43b09ff74.
