### PR TITLE
Add capability for default hash.

### DIFF
--- a/src/riak_repl_app.erl
+++ b/src/riak_repl_app.erl
@@ -47,6 +47,18 @@ start(_Type, _StartArgs) ->
     riak_core_capability:register({riak_repl, rtq_meta},
         [true, false], false),
 
+    %% Register capability for the default bucket properties hash.
+    riak_core_capability:register(
+        {riak_repl, default_bucket_props_hash},
+        [
+            %% 2.0.6, 2.1.2
+            [consistent, datatype, n_val, write_once],
+
+            %% 2.0.5, 2.1.1 and earlier
+            [consistent, datatype, n_val, allow_mult, last_write_wins]
+        ],
+        [consistent, datatype, n_val, allow_mult, last_write_wins]),
+
     %% skip Riak CS blocks
     case riak_repl_util:proxy_get_active() of
         true ->

--- a/src/riak_repl_bucket_type_util.erl
+++ b/src/riak_repl_bucket_type_util.erl
@@ -14,8 +14,6 @@
 
 -define(DEFAULT_BUCKET_TYPE, <<"default">>).
 
--define(DEFAULT_HASH_BUCKET_PROPS, [consistent, datatype, n_val, allow_mult, last_write_wins]).
-
 -spec bucket_props_match(proplists:proplist()) -> boolean().
 bucket_props_match(Props) ->
     case is_bucket_typed(Props) of
@@ -53,4 +51,7 @@ prop_get(Key, Default, Props) ->
 property_hash(undefined) ->
     undefined;
 property_hash(Type) ->
-    riak_core_bucket_type:property_hash(Type, ?DEFAULT_HASH_BUCKET_PROPS).
+    Defaults = riak_core_capability:get(
+            {riak_repl, default_bucket_props_hash},
+            [consistent, datatype, n_val, allow_mult, last_write_wins]),
+    riak_core_bucket_type:property_hash(Type, Defaults).


### PR DESCRIPTION
Use a capability to determine how to derive the bucket type hash so the
cluster can support mixed versions.
