### PR TITLE
Improve RTQ visibility and/or add ability to remove blocked object

### DIFF
--- a/test/riak_repl2_rtq_tests.erl
+++ b/test/riak_repl2_rtq_tests.erl
@@ -2,12 +2,12 @@
 -compile(export_all).
 -include_lib("eunit/include/eunit.hrl").
 
--define(set_env, application:set_env(riak_repl, rtq_max_bytes, 10*1024*1024)).
--define(unset_env, application:unset_env(riak_repl, rtq_max_bytes)).
+-define(setup_env, application:set_env(riak_repl, rtq_max_bytes, 10*1024*1024)).
+-define(clean_env, application:unset_env(riak_repl, rtq_max_bytes)).
 
 rtq_trim_test() ->
     %% make sure the queue is 10mb
-    ?set_env,
+    ?setup_env,
     {ok, Pid} = riak_repl2_rtq:start_test(),
     try
         gen_server:call(Pid, {register, rtq_test}),
@@ -22,7 +22,7 @@ rtq_trim_test() ->
         %% the queue is now empty
         ?assert(gen_server:call(Pid, {is_empty, rtq_test}))
     after
-        ?unset_env,
+        ?clean_env,
         exit(Pid, kill)
     end.
 
@@ -48,12 +48,12 @@ accumulate(Pid, Acc, C) ->
 
 status_test_() ->
     {setup, fun() ->
-        ?set_env,
+        ?setup_env,
         {ok, QPid} = riak_repl2_rtq:start_link(),
         QPid
     end,
     fun(QPid) ->
-        ?unset_env,
+        ?clean_env,
         riak_repl_test_util:kill_and_wait(QPid)
     end,
     fun(_QPid) -> [
@@ -275,7 +275,7 @@ overload_test_() ->
     ]}.
 
 start_rtq() ->
-    ?set_env,
+    ?setup_env,
     %% application:start(lager),
     %% lager:set_loglevel(lager_console_backend, debug),
     {ok, Pid} = riak_repl2_rtq:start_link(),
@@ -283,7 +283,7 @@ start_rtq() ->
     Pid.
 
 kill_rtq(QPid) ->
-    ?unset_env,
+    ?clean_env,
     riak_repl_test_util:kill_and_wait(QPid).
 
 object_format() -> riak_core_capability:get({riak_kv, object_format}, v0).


### PR DESCRIPTION
For background info see [JIRA: RIAK-1818] and #681 (RIAK-1818) (RIAK-1818).

New functions added to riak_repl2_rtq module:
- summarize/0 returns a list of tuples of the form `{Seq, Key, Size}`, one for each object currently present in the rtq.
- evict/1 removes an object from the rtq by `Seq` number, if present.
- evict/2 removes an object from the rtq by `Seq` number iff it matches the provided `Key`.

Currently these functions are not exposed through any command-line interface and must be executed from within the console.
