### PR TITLE
Separate configs and defaults between fs/rt for Riak CS block tombstone filter [JIRA: RIAK-2215]

### DIFF
--- a/src/riak_repl_cs.erl
+++ b/src/riak_repl_cs.erl
@@ -32,7 +32,8 @@
 -define(BUCKETS_BUCKET, <<"moss.buckets">>).
 
 -define(CONFIG_REPL_BLOCKS, replicate_cs_blocks_realtime).
--define(CONFIG_REPL_BLOCK_TOMBSTONE, replicate_cs_block_tombstone).
+-define(CONFIG_REPL_BLOCK_TOMBSTONE_RT, replicate_cs_block_tombstone_realtime).
+-define(CONFIG_REPL_BLOCK_TOMBSTONE_FS, replicate_cs_block_tombstone_fullsync).
 -define(CONFIG_REPL_USERS, replicate_cs_user_objects).
 -define(CONFIG_REPL_BUCKETS, replicate_cs_bucket_objects).
 
@@ -69,8 +70,19 @@ replicate_object(<<?BLOCK_BUCKET_PREFIX, _Rest/binary>>, IsTombstone, FSorRT) ->
             true;
         {false, realtime} ->
             app_helper:get_env(riak_repl, ?CONFIG_REPL_BLOCKS, false);
-        {true, _} ->
-            app_helper:get_env(riak_repl, ?CONFIG_REPL_BLOCK_TOMBSTONE, true)
+        {true, fullsync} ->
+            %% Default for tombstoned blocks is *NO PROPAGATE*.
+            %% Tombstoned blocks at fullsync are probably lingering ones.
+            %% Propagating them to sink will trigger putting tombstones and
+            %% reaping them almost in vein. Coming fullsyncs will again propagate
+            %% them again and again.
+            app_helper:get_env(riak_repl, ?CONFIG_REPL_BLOCK_TOMBSTONE_FS, false);
+        {true, realtime} ->
+            %% Default for tombstoned blocks is GO AHEAD.
+            %% Tombstons put at sink side carry information about overwrite
+            %% by its vclock, it enables that sink avoid read phase of
+            %% read-before-delete and eases disk load caused by read.
+            app_helper:get_env(riak_repl, ?CONFIG_REPL_BLOCK_TOMBSTONE_RT, true)
     end;
 replicate_object(_, true, _) -> false;
 replicate_object(?STORAGE_BUCKET, _, _) -> false;
@@ -95,7 +107,8 @@ bool_to_ok_or_cancel(false) ->
 
 reset_app_env() ->
     ok = application:unset_env(riak_repl, ?CONFIG_REPL_BLOCKS),
-    ok = application:unset_env(riak_repl, ?CONFIG_REPL_BLOCK_TOMBSTONE),
+    ok = application:unset_env(riak_repl, ?CONFIG_REPL_BLOCK_TOMBSTONE_RT),
+    ok = application:unset_env(riak_repl, ?CONFIG_REPL_BLOCK_TOMBSTONE_FS),
     ok = application:unset_env(riak_repl, ?CONFIG_REPL_USERS),
     ok = application:unset_env(riak_repl, ?CONFIG_REPL_BUCKETS).
 
@@ -128,15 +141,40 @@ dont_repl_storage_objects_test() ->
 
 dont_repl_tombstoned_object_test() ->
     reset_app_env(),
-    ok = application:set_env(riak_repl, replicate_cs_block_tombstone, false),
     %% the riak client isn't even used
     Client = fake_client,
-    Bucket = <<"anything">>,
+    Bucket = <<"almost_anything">>,
     Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
     M = dict:from_list([{<<"X-Riak-Deleted">>, true}]),
     Object2 = riak_object:update_metadata(Object, M),
     Object3 = riak_object:apply_updates(Object2),
     ?assertNot(ok_or_cancel_to_bool(send(Object3, Client))),
+    ?assertNot(ok_or_cancel_to_bool(send_realtime(Object3, Client))).
+
+repl_block_tombstone_by_default_test() ->
+    reset_app_env(),
+    %% the riak client isn't even used
+    Client = fake_client,
+    Bucket = <<"0b:HASHEDUP">>,
+    Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
+    M = dict:from_list([{<<"X-Riak-Deleted">>, true}]),
+    Object2 = riak_object:update_metadata(Object, M),
+    Object3 = riak_object:apply_updates(Object2),
+    ?assertNot(ok_or_cancel_to_bool(send(Object3, Client))),
+    ?assert(ok_or_cancel_to_bool(send_realtime(Object3, Client))).
+
+repl_block_tombstone_customized_test() ->
+    reset_app_env(),
+    ok = application:set_env(riak_repl, ?CONFIG_REPL_BLOCK_TOMBSTONE_RT, false),
+    ok = application:set_env(riak_repl, ?CONFIG_REPL_BLOCK_TOMBSTONE_FS, true),
+    %% the riak client isn't even used
+    Client = fake_client,
+    Bucket = <<"0b:HASHEDUP">>,
+    Object = riak_object:new(Bucket, <<"key">>, <<"val">>),
+    M = dict:from_list([{<<"X-Riak-Deleted">>, true}]),
+    Object2 = riak_object:update_metadata(Object, M),
+    Object3 = riak_object:apply_updates(Object2),
+    ?assert(ok_or_cancel_to_bool(send(Object3, Client))),
     ?assertNot(ok_or_cancel_to_bool(send_realtime(Object3, Client))).
 
 repl_user_object_test() ->


### PR DESCRIPTION
This PR is a fix for https://github.com/basho/riak_repl/pull/678.
- Separate config keys into realtime and fullsync for block tombstone fileter and
- Set different default values for them, propagete in realtime and filter away
  in fullsync.

_NOTE_ If possible, it's nice to include this PR in coming Riak Enterprise 2.1.2
release, in which #678 will be included.

---

Copy-and-paste from code comments for why the change is necessary:

```
{true, fullsync} ->
    %% Default for tombstoned blocks is *NO PROPAGATE*.
    %% Tombstoned blocks at fullsync are probably lingering ones.
    %% Propagating them to sink will trigger putting tombstones and
    %% reaping them almost in vein. Coming fullsyncs will again propagate
    %% them again and again.
    app_helper:get_env(riak_repl, ?CONFIG_REPL_BLOCK_TOMBSTONE_FS, false);
{true, realtime} ->
    %% Default for tombstoned blocks is GO AHEAD.
    %% Tombstons put at sink side carry information about overwrite
    %% by its vclock, it enables that sink avoid read phase of
    %% read-before-delete and eases disk load caused by read.
    app_helper:get_env(riak_repl, ?CONFIG_REPL_BLOCK_TOMBSTONE_RT, true)
```
