### PR TITLE
Fix riak_repl2_rtq_eqc test cleanup

### DIFF
--- a/test/riak_repl2_rtq_eqc.erl
+++ b/test/riak_repl2_rtq_eqc.erl
@@ -67,6 +67,7 @@ setup() ->
 
 cleanup(_) ->
     kill_and_wait(riak_repl2_rtq),
+    application:unset_env(riak_repl, rtq_max_bytes),
     catch(meck:unload(riak_repl_stats)),
     meck:unload(),
     ok.


### PR DESCRIPTION
Leaving the rtq_max_bytes setting as-is could sometimes clobber other
tests that didn't expect random values to be present in that setting.
(Specifically the riak_repl2_rtsource_conn test, in the example we found
on the builder.)

Unsetting this value on cleanup fixes the problem.
