### PR TITLE
Forward merge EQC test fix - 2.0 to 2.1

### DIFF
--- a/test/riak_repl2_rtq_eqc.erl
+++ b/test/riak_repl2_rtq_eqc.erl
@@ -67,6 +67,7 @@ setup() ->
 
 cleanup(_) ->
     kill_and_wait(riak_repl2_rtq),
+    application:unset_env(riak_repl, rtq_max_bytes),
     catch(meck:unload(riak_repl_stats)),
     meck:unload(),
     ok.


### PR DESCRIPTION
This merges the riak_repl2_rtq_eqc test cleanup fix from PR #728.
