### PR TITLE
Missed unregister_q deliver function.

### DIFF
--- a/src/riak_repl2_rtq.erl
+++ b/src/riak_repl2_rtq.erl
@@ -498,8 +498,8 @@ unregister_q(Name, State = #state{qtab = QTab, cs = Cs}) ->
             case C#c.deliver of
                 undefined ->
                     ok;
-                Deliver ->
-                    Deliver({error, unregistered})
+                DeliverFun ->
+                    deliver_error(DeliverFun, {error, unregistered})
             end,
             MinSeq = case Cs2 of
                          [] ->


### PR DESCRIPTION
Must have forgotten when manually reapplied from early testing to
now.  Should have listened to bors and eqc. Lesson on hubris and shame.
