### PR TITLE
Catch exceptions thrown by the connected callback

### DIFF
--- a/src/riak_core_connection.erl
+++ b/src/riak_core_connection.erl
@@ -235,12 +235,12 @@ handle_info({_TransTag, Socket, Data}, wait_for_protocol, State = #state{socket 
             IpPort = {State#state.ip, State#state.port},
             NegotiatedProto = {ProtoName, {CommonMajor, LocalMinor}, {CommonMajor, RemoteMinor}},
             _ = Transport:setopts(Socket, State#state.socket_opts),
-            _ModStarted = Module:connected(Socket,
-                                           Transport,
-                                           IpPort,
-                                           NegotiatedProto,
-                                           ModArgs,
-                                           State#state.remote_capabilities),
+            _ModStarted = catch Module:connected(Socket,
+                                                 Transport,
+                                                 IpPort,
+                                                 NegotiatedProto,
+                                                 ModArgs,
+                                                 State#state.remote_capabilities),
             {stop, normal, State};
         Else ->
             lager:warning("Invalid version returned: ~p", [Else]),


### PR DESCRIPTION
A failure to call the connected callback should not be treated as a
failure to establish a connection. The 'riak_core_connection' process
should catch any exceptions thrown by this callback and exit normally.

Addresses issue #723 (RIAK-1671) (RIAK-2379).
