### PR TITLE
Fix supervisor PID leak in do_repl_put function

### DIFF
--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -164,7 +164,7 @@ do_repl_put(Object, B, true) ->
             case riak_kv_util:is_x_deleted(Object) of
                 true ->
                     lager:debug("Incoming deleted obj ~p/~p", [B, K]),
-                    reap(ReqId, B, K),
+                    _ = reap(ReqId, B, K),
                     %% block waiting for response
                     wait_for_response(ReqId, "reap");
                 false ->

--- a/src/riak_repl_util.erl
+++ b/src/riak_repl_util.erl
@@ -175,9 +175,15 @@ do_repl_put(Object, B, true) ->
     end.
 
 reap(ReqId, B, K) ->
-    riak_kv_get_fsm_sup:start_get_fsm(node(),
-                                      [ReqId, B, K, 1, ?REPL_FSM_TIMEOUT,
-                                       self()]).
+    %% Note that this doesn't currently actually link with the new FSM proc
+    %% (unless sidejob is disabled for get FSMs, which nobody currently does).
+    %% Instead it just ends up calling sidejob_supervisor:start_child.
+    %% This is good, since REPL doesn't expect us to link with the FSM,
+    %% and we don't want a crashed FSM to take down whatever process is calling
+    %% reap.
+    %% The riak_kv API will be updated and improved in 2.2, but for 2.0.x
+    %% this should be fine.
+    riak_kv_get_fsm:start_link(ReqId, B, K, 1, ?REPL_FSM_TIMEOUT, self()).
 
 wait_for_response(ReqId, Verb) ->
     receive


### PR DESCRIPTION
There are some issues with the riak_kv API which will be fixed in a
future release, but long story short, riak_kv_get_fsm:start_link doesn't
always actually end up linking the caller to the new FSM process. This
would cause the supervisor to end up with an endlessly growing list of
workers, since it had no way of seeing when a child died.

To fix this resource leak, we can simply switch to starting the process
directly, instead of using the supervisor API call. There's really no
reason to run these processes under a supervisor anyway since they're
normally started up under sidejob.

Note that in 2.2 this fix may be reworked again to use whatever new
APIs we end up adding/changing in riak_kv.

For more info, see basho/riak_kv#1178 (RIAK-2157)
