### PR TITLE
Replace useage of macro with factory function

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
         {lager, ".*", {git, "git://github.com/basho/lager.git", {tag, "3.2.2"}}},
         {ranch, "0.4.0-p1", {git, "git://github.com/basho/ranch.git", {tag, "0.4.0-p1"}}},
         {ebloom, ".*", {git, "git://github.com/basho/ebloom.git", {tag, "2.0.0"}}},
-        {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {tag, "2.1.3"}}},
+        {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {branch, "develop"}}},
         {riak_repl_pb_api, ".*", {git, "git@github.com:basho/riak_repl_pb_api.git", {tag, "2.4.0"}}}
        ]}.
 

--- a/src/riak_repl_fullsync_worker.erl
+++ b/src/riak_repl_fullsync_worker.erl
@@ -86,7 +86,7 @@ handle_call({get, B, K, Transport, Socket, Pool, Partition, Ver}, From, State) -
 
     ReqID = make_req_id(),
 
-    Req = ?KV_GET_REQ{bkey={B, K}, req_id=ReqID},
+    Req = riak_kv_requests:new_get_request({B, K}, ReqID),
     %% Assuming this function is called from a FSM process
     %% so self() == FSM pid
     riak_core_vnode_master:command(Preflist,


### PR DESCRIPTION
Depends on https://github.com/basho/riak_kv/pull/1506

This is part of the refactoring effort for `riak_kv_vnode` to encapsulate records. The usage of `?KV_GET_REQ` has been replaced by the new `riak_kv_requests:new_get_request/2` function.