### PR TITLE
riak_repl2_pg: Fix invalid non-list status

### DIFF
--- a/src/riak_repl2_pg.erl
+++ b/src/riak_repl2_pg.erl
@@ -27,7 +27,7 @@ status() ->
     LeaderNode = riak_repl2_leader:leader_node(),
     case LeaderNode of
         undefined ->
-            {[], []};
+            [{proxy_get, []}];
         _ ->
             ReqStats = try riak_repl2_pg_block_requester_sup:started(LeaderNode) of
                 [] ->


### PR DESCRIPTION
status output is expected to be a list. This commit changes the status output
format when the repl leader is undefined to match the format of the
other case.