### PR TITLE
Critical replication bug fix - table comparison

### DIFF
--- a/src/riak_repl2_ts.erl
+++ b/src/riak_repl2_ts.erl
@@ -72,7 +72,7 @@ set_bucket_meta({Type, _}) ->
     %% continuing, so we'll drop the batch elsewhere.
     IdentityHashes = get_identity_hashes(Type),
     case IdentityHashes of
-        fail ->
+        [] ->
             fail;
         _ ->
             %% By sending an invalid bucket type property hash we can
@@ -96,7 +96,7 @@ get_identity_hashes(Table) ->
             %% exist, etc
             lager:warning("DDL module for ~p does not exist or is not "
                           "compiled with identity hashes", [Table]),
-            fail;
+            [];
         HashList ->
             HashList
     end.


### PR DESCRIPTION
Previously, if a TS table did not exist in the sink cluster, the arrival of data via replication destined for that table would cause a recurring process failure until the node was restarted. All realtime replication through that node would stop working.

This was a careless mistake on my part involving returning an error atom from the code that retrieves metadata from the intended table.

`get_identity_hashes` is invoked in two places; once in the same module, once in `riak_repl_bucket_type_util`. The latter expects a list as a return value and blindly runs comparisons against it; those comparisons fail badly when an atom is returned.

With this fix, logging on the sink clearly indicates that the code is behaving properly.

```
2016-12-16 09:58:53.494 [warning] <0.4866.0>@riak_repl2_ts:get_identity_hashes:97 DDL module for <<"foo">> does not exist or is not compiled with identity hashes
2016-12-16 09:59:03.496 [error] <0.4866.0>@riak_repl2_rtsink_conn:handle_info:237 drops due to missing or mismatched type <<"foo">>: 1
2016-12-16 09:59:03.496 [error] <0.4866.0>@riak_repl2_rtsink_conn:handle_info:243 total bucket type drop count: 1
```

Easiest way to test this if desired:

1. Modify the `ts_cluster_replication` test in `riak_test` to throw a error after the clusters are established and realtime replication is enabled, but to keep things simpler without fullsync. (See below).
2. Create a new table on `dev1`.
3. Insert a row into that table.
4. Check server logs on `dev6` (probably) for either a recurring crash (with the old code) or the log lines above.


Here's a diff for `ts_cluster_replication` involving a useful test to interrupt for experimentation. It's a bit further into the test suite than I would like from a time perspective, but it does establish realtime sans fullsync.

```
@@ -323,6 +324,9 @@ prop_failure_replication_test([AFirst|_] = ANodes, [BFirst|_] = BNodes, LeaderA,

     log_to_nodes(ANodes++BNodes, "Write data to Cluster A, verify no replication to Cluster B via realtime because DDL comparison failed"),
     lager:info("Writing 100 keys to Cluster A-LeaderNode: ~p", [LeaderA]),
+
+    lager:info("~p~n", [[ANodes, BNodes, LeaderA, PortB, Table]]),
+    ?assertEqual(1, 2),
     ?assertEqual(ok, put_records(AFirst, Table, 202, 301)),

     lager:info("Pausing 2 seconds"),
```