### PR TITLE
Change ETS queue table permissions to protected

### DIFF
--- a/src/riak_repl2_rtq.erl
+++ b/src/riak_repl2_rtq.erl
@@ -13,7 +13,7 @@
 %% with the sequence number.  If multiple deliveries have taken
 %% place an ack of the highest seq number acknowledge all previous.
 %%
-%% The queue is currently stored in a private ETS table.  Once
+%% The queue is currently stored in a protected ETS table.  Once
 %% all consumers are done with an item it is removed from the table.
 -module(riak_repl2_rtq).
 
@@ -53,7 +53,7 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
--record(state, {qtab = ets:new(?MODULE, [private, ordered_set]), % ETS table
+-record(state, {qtab = ets:new(?MODULE, [protected, ordered_set]), % ETS table
                 qseq = 0,  % Last sequence number handed out
                 max_bytes = undefined, % maximum ETS table memory usage in bytes
 
@@ -773,3 +773,4 @@ minseq(QTab, QSeq) ->
 summarize_object(Obj) ->
   ObjFmt = riak_core_capability:get({riak_kv, object_format}, v0),
   {riak_object:key(Obj), riak_object:approximate_size(ObjFmt, Obj)}.
+


### PR DESCRIPTION
NOTE: opened to replace #781 

Sometimes realtime replication stops working, the reason why it has stopped is unclear, diagnosis is further complicated by the fact that the ETS queue table (buffer of objects due to be replicated to the sink) is private (can only be seen by the `riak_repl2_rtq` `gen_server` instance).

If it were possible to examine the contents of that table the support engineer could examine the queued objects and perhaps discover that there is a large object causing head of line blocking. At the moment the only option is to kill the process and let the supervisor restart it, destroying all useful information in the process. The diagnostic information is opaque and needlessly so.

The table doesn't need to be changed to public as it's probably undesirable to modify state outside the public API for this gen_server.

I propose that the permissions be changed to 'protected' in order to improve visibility.