### PR TITLE
default strategy

### DIFF
--- a/src/riak_repl2_fssink.erl
+++ b/src/riak_repl2_fssink.erl
@@ -47,7 +47,7 @@
         cluster,
         fullsync_worker,
         work_dir = undefined,
-        strategy :: keylist | aae | undefined,
+        strategy = keylist :: keylist | aae,
         proto,
         ver              % highest common wire protocol in common with fs source
     }).


### PR DESCRIPTION
Instead of allowing an undefined strategy, we default to the keylist strategy