### PR TITLE
Generate riak_repl_pb.hrl locally instead of depending on rial_repl_p…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ compile:
 	$(REBAR) compile
 
 clean:
+	rm -f include/*_pb.hrl
+	rm -f src/*_pb.erl
 	$(REBAR) clean
 
 cover: test

--- a/rebar.config
+++ b/rebar.config
@@ -2,6 +2,7 @@
 
 {cover_enabled, true}.
 {erl_opts, [debug_info, %warnings_as_errors,
+            {i, "./_build/default/plugins/gpb/include"},
             {parse_transform, lager_transform},
             {platform_define, "^[0-9]+", namespaced_types}]}.
 {erl_first_files, ["src/gen_leader.erl"]}.
@@ -14,8 +15,16 @@
         {ranch, {git, "git://github.com/ninenines/ranch.git", {tag, "1.6.0"}}},
         {ebloom,{git, "git://github.com/basho/ebloom.git", {branch, "develop-3.0"}}},
         {riak_kv, {git, "git://github.com/basho/riak_kv.git", {branch, "develop-3.0"}}},
-        {riak_repl_pb_api, {git, "git://github.com/basho/riak_repl_pb_api.git", {branch, "develop-3.0"}}}
+        {riak_pb, {git, "git://github.com/basho/riak_pb.git", {branch, "develop-3.0"}}}
        ]}.
+
+{plugins, [rebar3_gpb_plugin]}.
+
+{gpb_opts, [{module_name_suffix, "_pb"},
+            {msg_name_to_lower, true},
+            {i, "src"}]}.
+
+{provider_hooks, [{pre, [{compile, {protobuf, compile}}]}]}.
 
 {profiles,
        [{test, [{deps, [meck]}]}]

--- a/src/riak_repl_pb_get.erl
+++ b/src/riak_repl_pb_get.erl
@@ -2,7 +2,7 @@
 
 -include("riak_repl.hrl").
 
--include_lib("riak_repl_pb_api/include/riak_repl_pb.hrl").
+-include("riak_repl_pb.hrl").
 -include_lib("riak_pb/include/riak_kv_pb.hrl").
 -include_lib("riak_pb/include/riak_pb_kv_codec.hrl").
 
@@ -279,5 +279,3 @@ client_cluster_names_13() ->
         P /= undefined,
         {ClusterID, ClusterName} <- [client_cluster_name_13(P)]
     ].
-
-    


### PR DESCRIPTION
In riak_repl_pb_api.erl the function riak_repl_pb:encode is called. This is a function that does not exists. It also seems not used.

Most likely the only reason to have a dependency on riak_repl_pb_api is to get hold of the include file and generated file riak_repl_pb. We short-cut this by directly depending on riak_pb and generate the necessary files in riak_repl.