### PR TITLE
Fix riak_repl_pb_get:get_cluster_id and :get, used in Repl communications with Riak CS

### DIFF
--- a/src/riak_repl2_pg_block_provider.erl
+++ b/src/riak_repl2_pg_block_provider.erl
@@ -146,7 +146,7 @@ handle_msg({proxy_get, Ref, Bucket, Key, Options},
                          proxy_gets_provided=PGCount}) ->
     lager:debug("Got proxy_get for ~p:~p", [Bucket, Key]),
     C = State#state.client,
-    Res = C:get(Bucket, Key, Options),
+    Res = riak_client:get(Bucket, Key, Options, C),
     Data = term_to_binary({proxy_get_resp, Ref, Res}),
     Transport:send(Socket, Data),
     {noreply, State#state{proxy_gets_provided=PGCount+1}}.

--- a/src/riak_repl_pb_get.erl
+++ b/src/riak_repl_pb_get.erl
@@ -99,7 +99,7 @@ process(#rpbreplgetreq{bucket=B, key=K, r=R0, pr=PR0, notfound_ok=NFOk,
         make_option(basic_quorum, BQ) ++
         make_option(n_val, N_val) ++
         make_option(sloppy_quorum, SloppyQuorum),
-    case C:get(B, K, GetOptions) of
+    case riak_client:get(B, K, GetOptions, C) of
         {ok, O} ->
             make_object_response(O, VClock, Head, State);
         {error, {deleted, TombstoneVClock}} ->

--- a/src/riak_repl_pb_get.erl
+++ b/src/riak_repl_pb_get.erl
@@ -81,9 +81,9 @@ process(#rpbreplgetreq{bucket=B, key=K, r=R0, pr=PR0, notfound_ok=NFOk,
 
     % check in ring metadata to see if there is a mapped cluser for this cluster_id
     % to use, in case the named one has been disabled
-    
+
     case riak_core_metadata:get({<<"replication">>, <<"cluster-mapping">>}, CName0) of
-        undefined -> 
+        undefined ->
             lager:info("Using non-mapped cluster_id: ~s", [CName0]),
             CName = CName0;
         MappedToClusterId ->
@@ -91,7 +91,7 @@ process(#rpbreplgetreq{bucket=B, key=K, r=R0, pr=PR0, notfound_ok=NFOk,
             CName = MappedToClusterId
     end,
     lager:info("doing replicated GET using cluster id ~p", [CName]),
-    
+
     GetOptions = make_option(deletedvclock, DeletedVClock) ++
         make_option(r, R) ++
         make_option(pr, PR) ++

--- a/src/riak_repl_pb_get.erl
+++ b/src/riak_repl_pb_get.erl
@@ -51,7 +51,7 @@ decode(_, Bin) ->
     {ok, Bin}.
 
 %% @doc encode/1 callback. Encodes an outgoing response message.
-encode(#rpbgetresp{} = Msg) ->
+encode(Msg) ->
     {ok, riak_pb_codec:encode(Msg)}.
 
 %% Process Protocol Buffer Requests

--- a/src/riak_repl_pb_get.erl
+++ b/src/riak_repl_pb_get.erl
@@ -62,7 +62,12 @@ process(<<Code:8, Data/binary>>, State) ->
     lager:debug("Got tunnelled message ~p", [Msg]),
     process(Msg, State);
 
-process(#rpbreplgetclusteridreq{}, State) ->
+process(rpbreplgetclusteridreq, State) ->
+    %% avoid having to change riak_pb_codec:decode to consistently
+    %% work for messages with and without args, for which it currently
+    %% returns just the record's tag as a bare atom (and not
+    %% #rpbreplgetclusteridreq{} as it probably should)
+
     %% get cluster id from local ring manager and format as string
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     ClusterId = lists:flatten(

--- a/src/riak_repl_pb_get.erl
+++ b/src/riak_repl_pb_get.erl
@@ -57,6 +57,11 @@ encode(#rpbgetresp{} = Msg) ->
 %% Process Protocol Buffer Requests
 %%
 %% @doc Return Cluster Id of the local cluster
+process(<<Code:8, Data/binary>>, State) ->
+    Msg = riak_pb_codec:decode(Code, Data),
+    lager:debug("Got tunnelled message ~p", [Msg]),
+    process(Msg, State);
+
 process(#rpbreplgetclusteridreq{}, State) ->
     %% get cluster id from local ring manager and format as string
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),


### PR DESCRIPTION
While doing renovation work on Riak CS, one test was found failing ([repl_v3_test](https://github.com/TI-Tokyo/riak_cs_test/blob/develop-3.0/tests/repl_v3_test.erl)). That test sets up two clusters and makes use of Repl proxy_get feature. Specifically, it makes two requests, `RpbReplCetClusterIdReq` and `RpbReplGetReq`, which are served by riak_repl_pb_get module. This PR clears up some bit rot to unbreak these requests.

There is an accompanying [PR in riak_pb](https://github.com/basho/riak_pb/pull/252).